### PR TITLE
Make the repo buildable.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   <Import Project="build\sources.props" />
 
   <PropertyGroup>
-    <Product>Microsoft ASP.NET Core</Product>
+    <Product>Microsoft ASP.NET Core VSCode</Product>
     <RepositoryUrl>https://github.com/aspnet/Razor.VSCode</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>

--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -4,6 +4,16 @@
       // Don't run any rules for packages the ADX team creates but doesn't ship.
     ],
     "packages": {
+      "Microsoft.AspNetCore.Razor.LanguageServer": {
+        "Exclusions": {
+          "SIGN_STRONGNAME": {
+            "lib/net461/Microsoft.AspNetCore.Razor.LanguageServer.exe": "Underlying omnisharp server is not strong-named."
+          },
+          "WRONG_PUBLICKEYTOKEN": {
+            "lib/net461/Microsoft.AspNetCore.Razor.LanguageServer.exe": "Underlying omnisharp server is not strong-named."
+          }
+        }
+      }
     }
   },
   "Default": { // Rules to run for packages not listed in any other set.

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,10 +1,8 @@
 ﻿<Project>
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
+  <Import Project="..\modules\Razor\build\dependencies.props" />
+
   <PropertyGroup Label="Package Versions">
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-17090</InternalAspNetCoreSdkPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />

--- a/build/repo.props
+++ b/build/repo.props
@@ -5,6 +5,9 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+    <DependencyVersionsFile>$(RepositoryRoot)modules\Razor\build\dependencies.props</DependencyVersionsFile>
+
     <!-- These properties are use by the automation that updates dependencies.props -->
     <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
     <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>

--- a/client/src/RazorLanguageServerClient.ts
+++ b/client/src/RazorLanguageServerClient.ts
@@ -30,16 +30,16 @@ export class RazorLanguageServerClient implements vscode.Disposable {
             outputChannel: options.outputChannel
         };
 
-        // TODO: Resolve dotnet path or self-host server executable
-        let args = [options.serverDllPath, '-lsp'];
+        const args = ['-lsp'];
+        let args = ['-lsp'];
 
         if (options.debug) {
             args[2] = "--debug";
         }
 
         this._serverOptions = {
-            run: { command: 'dotnet', args: args },
-            debug: { command: 'dotnet', args: args }
+            run: { command: options.serverDllPath, args },
+            debug: { command: options.serverDllPath, args },
         };
 
         this._client = new LanguageClient('razorLanguageServer', 'Razor Language Server', this._serverOptions, this._clientOptions);

--- a/modules/Directory.Build.props
+++ b/modules/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed/Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed.csproj
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed/Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <Description>Temporary assembly until the csharp language server is strong name signed.</Description>
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
     <SignAssembly>false</SignAssembly>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorCompletionEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorCompletionEndpoint.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             var line = lineBuilder.ToString();
             var trimmedLine = line.Trim();
-            if (!trimmedLine.StartsWith('@'))
+            if (!trimmedLine.StartsWith("@"))
             {
                 return false;
             }


### PR DESCRIPTION
- Made the server net461 to work with our underlying Razor dependencies.
- Updated the server start code to not depend on `dotnet` (it boots an .exe now).
- Harvest dependencies from underlying Razor clone to ensure no mismatch in korebuild and othe dependent versions.

#33

FYI @SteveSandersonMS this PR makes it so you need to update your `razor.languageServer.path` user setting:
```json
"razor.languageServer.path": "C:/Users/fooperson/GitHub/Razor.VSCode/src/Microsoft.AspNetCore.Razor.LanguageServer/bin/Debug/net461/Microsoft.AspNetCore.Razor.LanguageServer.exe",
```