### PR TITLE
Add tests for RazorProjectService.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed/DefaultProjectSnapshotManagerShim.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed/DefaultProjectSnapshotManagerShim.cs
@@ -89,6 +89,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed
         {
             var loadedProject = InnerProjectSnapshotManager.GetLoadedProject(filePath);
 
+            if (loadedProject == null)
+            {
+                return null;
+            }
+
             return new DefaultProjectSnapshotShim(loadedProject);
         }
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultVSCodeLogger.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultVSCodeLogger.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultVSCodeLogger : VSCodeLogger
+    {
+        private readonly ILanguageServer _router;
+        private static string LastLogType = string.Empty;
+
+        public DefaultVSCodeLogger(ILanguageServer router)
+        {
+            if (router == null)
+            {
+                throw new ArgumentNullException(nameof(router));
+            }
+
+            _router = router;
+        }
+
+        public override void Log(string message)
+        {
+            var messageBuilder = new StringBuilder();
+            var typeName = GetType().Name;
+
+            lock (LastLogType)
+            {
+                if (LastLogType != typeName)
+                {
+                    LastLogType = typeName;
+
+                    messageBuilder
+                        .AppendLine()
+                        .AppendLine(typeName);
+                }
+            }
+
+            messageBuilder
+                .Append("  ")
+                .Append(DateTime.Now.ToString("HH:mm:ss"))
+                .Append("\t\t")
+                .Append(message);
+
+            _router.Window.LogMessage(new LogMessageParams()
+            {
+                Type = MessageType.Log,
+                Message = messageBuilder.ToString()
+            });
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorProjectEndpoint>()
                     .WithServices(services =>
                     {
-                        services.AddSingleton<VSCodeLogger>();
+                        services.AddSingleton<VSCodeLogger, DefaultVSCodeLogger>();
                         services.AddSingleton<ProjectResolver, DefaultProjectResolver>();
                         services.AddSingleton<DocumentResolver, DefaultDocumentResolver>();
                         services.AddSingleton<FilePathNormalizer>();

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -8,11 +8,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 {
     internal abstract class RazorProjectService
     {
-        public abstract void AddDocument(string text, Uri uri);
+        public abstract void AddDocument(string text, string filePath);
 
-        public abstract void RemoveDocument(Uri textDocumentUri);
+        public abstract void RemoveDocument(string filePath);
 
-        public abstract void UpdateDocument(string text, Uri uri);
+        public abstract void UpdateDocument(string text, string filePath);
 
         public abstract void AddProject(string filePath, RazorConfiguration configuration);
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             var newContent = notification.ContentChanges.Single().Text;
             await Task.Factory.StartNew(
-                () => _projectService.UpdateDocument(newContent, notification.TextDocument.Uri),
+                () => _projectService.UpdateDocument(newContent, notification.TextDocument.Uri.AbsolutePath),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken token)
         {
             await Task.Factory.StartNew(
-                () => _projectService.AddDocument(notification.TextDocument.Text, notification.TextDocument.Uri),
+                () => _projectService.AddDocument(notification.TextDocument.Text, notification.TextDocument.Uri.AbsolutePath),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task<Unit> Handle(DidCloseTextDocumentParams notification, CancellationToken token)
         {
             await Task.Factory.StartNew(
-                () => _projectService.RemoveDocument(notification.TextDocument.Uri),
+                () => _projectService.RemoveDocument(notification.TextDocument.Uri.AbsolutePath),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/VSCodeLogger.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/VSCodeLogger.cs
@@ -1,53 +1,10 @@
-﻿using System;
-using System.Text;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal class VSCodeLogger
+    public abstract class VSCodeLogger
     {
-        private readonly ILanguageServer _router;
-        private static string LastLogType = string.Empty;
-
-        public VSCodeLogger(ILanguageServer router)
-        {
-            if (router == null)
-            {
-                throw new ArgumentNullException(nameof(router));
-            }
-
-            _router = router;
-        }
-
-        public void Log(string message)
-        {
-            var messageBuilder = new StringBuilder();
-            var typeName = GetType().Name;
-
-            lock (LastLogType)
-            {
-                if (LastLogType != typeName)
-                {
-                    LastLogType = typeName;
-
-                    messageBuilder
-                        .AppendLine()
-                        .AppendLine(typeName);
-                }
-            }
-
-            messageBuilder
-                .Append("  ")
-                .Append(DateTime.Now.ToString("HH:mm:ss"))
-                .Append("\t\t")
-                .Append(message);
-
-            _router.Window.LogMessage(new LogMessageParams()
-            {
-                Type = MessageType.Log,
-                Message = messageBuilder.ToString()
-            });
-        }
+        public abstract void Log(string message);
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -1,0 +1,386 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.CodeAnalysis;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class DefaultRazorProjectServiceTest : TestBase
+    {
+        [Fact]
+        public void AddDocument_AddsDocumentToOwnerProject()
+        {
+            // Arrange
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = new TestProjectSnapshot("C:/path/to/project.sproj");
+            var projectResolver = new TestProjectResolver(
+                new Dictionary<string, ProjectSnapshotShim>
+                {
+                    [documentFilePath] = ownerProject
+                },
+                new TestProjectSnapshot("__MISC_PROJECT__"));
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>(), It.IsAny<TextLoader>()))
+                .Callback<HostProjectShim, HostDocumentShim, TextLoader>((hostProject, hostDocumentShim, textLoader) =>
+                {
+                    Assert.Same(ownerProject.HostProject, hostProject);
+                    Assert.Equal(documentFilePath, hostDocumentShim.FilePath);
+                    Assert.NotNull(textLoader);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.AddDocument("Hello World", documentFilePath);
+
+            // Assert
+            projectSnapshotManager.VerifyAll();
+        }
+
+        [Fact]
+        public void AddDocument_AddsDocumentToMiscellaneousProject()
+        {
+            // Arrange
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__");
+            var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshotShim>(), miscellaneousProject);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>(), It.IsAny<TextLoader>()))
+                .Callback<HostProjectShim, HostDocumentShim, TextLoader>((hostProject, hostDocumentShim, textLoader) =>
+                {
+                    Assert.Same(miscellaneousProject.HostProject, hostProject);
+                    Assert.Equal(documentFilePath, hostDocumentShim.FilePath);
+                    Assert.NotNull(textLoader);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.AddDocument("Hello World", documentFilePath);
+
+            // Assert
+            projectSnapshotManager.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveDocument_RemovesDocumentFromOwnerProject()
+        {
+            // Arrange
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = new TestProjectSnapshot("C:/path/to/project.sproj", new[] { documentFilePath });
+            var projectResolver = new TestProjectResolver(
+                new Dictionary<string, ProjectSnapshotShim>
+                {
+                    [documentFilePath] = ownerProject
+                },
+                new TestProjectSnapshot("__MISC_PROJECT__"));
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>()))
+                .Callback<HostProjectShim, HostDocumentShim>((hostProject, hostDocumentShim) =>
+                {
+                    Assert.Same(ownerProject.HostProject, hostProject);
+                    Assert.Equal(documentFilePath, hostDocumentShim.FilePath);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.RemoveDocument(documentFilePath);
+
+            // Assert
+            projectSnapshotManager.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveDocument_RemovesDocumentFromMiscellaneousProject()
+        {
+            // Arrange
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MIS_PROJECT__", new[] { documentFilePath });
+            var projectResolver = new TestProjectResolver(
+                new Dictionary<string, ProjectSnapshotShim>(),
+                miscellaneousProject);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>()))
+                .Callback<HostProjectShim, HostDocumentShim>((hostProject, hostDocumentShim) =>
+                {
+                    Assert.Same(miscellaneousProject.HostProject, hostProject);
+                    Assert.Equal(documentFilePath, hostDocumentShim.FilePath);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.RemoveDocument(documentFilePath);
+
+            // Assert
+            projectSnapshotManager.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveDocument_NoopsIfOwnerProjectDoesNotContainDocument()
+        {
+            // Arrange
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = new TestProjectSnapshot("C:/path/to/project.sproj", new string[0]);
+            var projectResolver = new TestProjectResolver(
+                new Dictionary<string, ProjectSnapshotShim>
+                {
+                    [documentFilePath] = ownerProject
+                },
+                new TestProjectSnapshot("__MISC_PROJECT__"));
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>();
+            projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>()))
+                .Throws(new InvalidOperationException("Should not have been called."));
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act & Assert
+            projectService.RemoveDocument(documentFilePath);
+        }
+
+        [Fact]
+        public void RemoveDocument_NoopsIfMiscellaneousProjectDoesNotContainDocument()
+        {
+            // Arrange
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MIS_PROJECT__", new string[0]);
+            var projectResolver = new TestProjectResolver(
+                new Dictionary<string, ProjectSnapshotShim>(),
+                miscellaneousProject);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>();
+            projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>()))
+                .Throws(new InvalidOperationException("Should not have been called."));
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act & Assert
+            projectService.RemoveDocument(documentFilePath);
+        }
+
+        // TODO: Add UpdateDocument tests. This API will change significantly when we start consuming incremental changes.
+
+        [Fact]
+        public void AddProject_AddsProjectWithProvidedConfiguration()
+        {
+            // Arrange
+            var projectConfiguration = RazorConfiguration.Create(RazorLanguageVersion.Version_1_0, "Test", Array.Empty<RazorExtension>());
+            var projectFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__");
+            var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshotShim>(), miscellaneousProject);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.HostProjectAdded(It.IsAny<HostProjectShim>()))
+                .Callback<HostProjectShim>((hostProject) =>
+                {
+                    Assert.Equal(projectFilePath, hostProject.FilePath);
+                    Assert.Same(projectConfiguration, hostProject.Configuration);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.AddProject(projectFilePath, projectConfiguration);
+
+            // Assert
+            projectSnapshotManager.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveProject_RemovesProject()
+        {
+            // Arrange
+            var projectFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = new TestProjectSnapshot(projectFilePath);
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__");
+            var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshotShim>(), miscellaneousProject);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
+                .Returns(ownerProject);
+            projectSnapshotManager.Setup(manager => manager.HostProjectRemoved(ownerProject.HostProject))
+                .Callback<HostProjectShim>((hostProject) =>
+                {
+                    Assert.Equal(projectFilePath, hostProject.FilePath);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.RemoveProject(projectFilePath);
+
+            // Assert
+            projectSnapshotManager.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveProject_NoopsIfProjectIsNotLoaded()
+        {
+            // Arrange
+            var projectFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__");
+            var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshotShim>(), miscellaneousProject);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>();
+            projectSnapshotManager.Setup(manager => manager.HostProjectRemoved(It.IsAny<HostProjectShim>()))
+                .Throws(new InvalidOperationException("Should not have been called."));
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act & Assert
+            projectService.RemoveProject(projectFilePath);
+        }
+
+        [Fact]
+        public void TryMigrateDocumentsFromRemovedProject_MigratesDocumentsToNonMiscProject()
+        {
+            // Arrange
+            var documentFilePath1 = "C:/path/to/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/document2.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__");
+            var removedProject = new TestProjectSnapshot("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
+            var projectToBeMigratedTo = new TestProjectSnapshot("C:/path/to/project.csproj");
+            var projectResolver = new TestProjectResolver(
+                new Dictionary<string, ProjectSnapshotShim>
+                {
+                    [documentFilePath1] = projectToBeMigratedTo,
+                    [documentFilePath2] = projectToBeMigratedTo,
+                },
+                miscellaneousProject);
+            var migratedDocuments = new List<HostDocumentShim>();
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>(), It.IsAny<TextLoader>()))
+                .Callback<HostProjectShim, HostDocumentShim, TextLoader>((hostProject, hostDocumentShim, textLoader) =>
+                {
+                    Assert.Same(projectToBeMigratedTo.HostProject, hostProject);
+                    Assert.NotNull(textLoader);
+
+                    migratedDocuments.Add(hostDocumentShim);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.TryMigrateDocumentsFromRemovedProject(removedProject);
+
+            // Assert
+            Assert.Collection(migratedDocuments,
+                document => Assert.Equal(documentFilePath1, document.FilePath),
+                document => Assert.Equal(documentFilePath2, document.FilePath));
+        }
+
+        [Fact]
+        public void TryMigrateDocumentsFromRemovedProject_MigratesDocumentsToMiscProject()
+        {
+            // Arrange
+            var documentFilePath1 = "C:/path/to/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/document2.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__");
+            var removedProject = new TestProjectSnapshot("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
+            var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshotShim>(), miscellaneousProject);
+            var migratedDocuments = new List<HostDocumentShim>();
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>(), It.IsAny<TextLoader>()))
+                .Callback<HostProjectShim, HostDocumentShim, TextLoader>((hostProject, hostDocumentShim, textLoader) =>
+                {
+                    Assert.Same(miscellaneousProject.HostProject, hostProject);
+                    Assert.NotNull(textLoader);
+
+                    migratedDocuments.Add(hostDocumentShim);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.TryMigrateDocumentsFromRemovedProject(removedProject);
+
+            // Assert
+            Assert.Collection(migratedDocuments,
+                document => Assert.Equal(documentFilePath1, document.FilePath),
+                document => Assert.Equal(documentFilePath2, document.FilePath));
+        }
+
+        [Fact]
+        public void TryMigrateMiscellaneousDocumentsToProject_DoesNotMigrateDocumentsIfNoOwnerProject()
+        {
+            // Arrange
+            var documentFilePath1 = "C:/path/to/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/document2.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshotShim>(), miscellaneousProject);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>();
+            projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>(), It.IsAny<TextLoader>()))
+                .Throws(new InvalidOperationException("Should not have been called."));
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act & Assert
+            projectService.TryMigrateMiscellaneousDocumentsToProject();
+        }
+
+        [Fact]
+        public void TryMigrateMiscellaneousDocumentsToProject_MigratesDocumentsToNewOwnerProject()
+        {
+            // Arrange
+            var documentFilePath1 = "C:/path/to/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/document2.cshtml";
+            var miscellaneousProject = new TestProjectSnapshot("__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var projectToBeMigratedTo = new TestProjectSnapshot("C:/path/to/project.csproj");
+            var projectResolver = new TestProjectResolver(
+                new Dictionary<string, ProjectSnapshotShim>
+                {
+                    [documentFilePath1] = projectToBeMigratedTo,
+                    [documentFilePath2] = projectToBeMigratedTo,
+                },
+                miscellaneousProject);
+            var migratedDocuments = new List<HostDocumentShim>();
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerShim>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>(), It.IsAny<TextLoader>()))
+                .Callback<HostProjectShim, HostDocumentShim, TextLoader>((hostProject, hostDocumentShim, textLoader) =>
+                {
+                    Assert.Same(projectToBeMigratedTo.HostProject, hostProject);
+                    Assert.NotNull(textLoader);
+
+                    migratedDocuments.Add(hostDocumentShim);
+                });
+            projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProjectShim>(), It.IsAny<HostDocumentShim>()))
+                .Callback<HostProjectShim, HostDocumentShim>((hostProject, hostDocumentShim) =>
+                {
+                    Assert.Same(miscellaneousProject.HostProject, hostProject);
+
+                    Assert.DoesNotContain(hostDocumentShim, migratedDocuments);
+                });
+            var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+
+            // Act
+            projectService.TryMigrateMiscellaneousDocumentsToProject();
+
+            // Assert
+            Assert.Collection(migratedDocuments,
+                document => Assert.Equal(documentFilePath1, document.FilePath),
+                document => Assert.Equal(documentFilePath2, document.FilePath));
+        }
+
+        private DefaultRazorProjectService CreateProjectService(ProjectResolver projectResolver, ProjectSnapshotManagerShim projectSnapshotManager)
+        {
+            var logger = Mock.Of<VSCodeLogger>();
+            var filePathNormalizer = new FilePathNormalizer();
+            var accessor = Mock.Of<ProjectSnapshotManagerShimAccessor>(a => a.Instance == projectSnapshotManager);
+            var projectService = new DefaultRazorProjectService(Dispatcher, projectResolver, filePathNormalizer, accessor, logger);
+
+            return projectService;
+        }
+
+        private class TestProjectResolver : ProjectResolver
+        {
+            private readonly IReadOnlyDictionary<string, ProjectSnapshotShim> _projectMappings;
+            private readonly ProjectSnapshotShim _miscellaneousProject;
+
+            public TestProjectResolver(IReadOnlyDictionary<string, ProjectSnapshotShim> projectMappings, ProjectSnapshotShim miscellaneousProject)
+            {
+                _projectMappings = projectMappings;
+                _miscellaneousProject = miscellaneousProject;
+            }
+
+            public override ProjectSnapshotShim GetMiscellaneousProject() => _miscellaneousProject;
+
+            public override bool TryResolveProject(string documentFilePath, out ProjectSnapshotShim projectSnapshot)
+            {
+                return _projectMappings.TryGetValue(documentFilePath, out projectSnapshot);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestDocumentSnapshot.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestDocumentSnapshot.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
+{
+    public class TestDocumentSnapshot : DocumentSnapshotShim
+    {
+        private readonly SourceText _sourceText;
+        private readonly TextAndVersion _textVersion;
+
+        public TestDocumentSnapshot(string filePath) : this(filePath, string.Empty)
+        {
+        }
+
+        public TestDocumentSnapshot(string filePath, string text)
+        {
+            HostDocument = HostDocumentShim.Create(filePath, filePath);
+
+            _sourceText = SourceText.From(text);
+            _textVersion = TextAndVersion.Create(_sourceText, VersionStamp.Default, FilePath);
+        }
+
+        public override HostDocumentShim HostDocument { get; }
+
+        public override string FilePath => HostDocument.FilePath;
+
+        public override string TargetPath => HostDocument.TargetPath;
+
+        public override Task<RazorCodeDocument> GetGeneratedOutputAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IReadOnlyList<DocumentSnapshotShim> GetImports()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<SourceText> GetTextAsync() => Task.FromResult(_sourceText);
+
+        public override Task<VersionStamp> GetTextVersionAsync() => Task.FromResult(_textVersion.Version);
+
+        public override bool TryGetGeneratedOutput(out RazorCodeDocument result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool TryGetText(out SourceText result)
+        {
+            result = _sourceText;
+            return true;
+        }
+
+        public override bool TryGetTextVersion(out VersionStamp result)
+        {
+            result = _textVersion.Version;
+            return true;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshot.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshot.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
+{
+    public class TestProjectSnapshot : ProjectSnapshotShim
+    {
+        private readonly Dictionary<string, DocumentSnapshotShim> _documents;
+
+        public TestProjectSnapshot(string filePath) : this(filePath, new string[0])
+        {
+        }
+
+        public TestProjectSnapshot(string filePath, string[] documentFilePaths)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (documentFilePaths == null)
+            {
+                throw new ArgumentNullException(nameof(documentFilePaths));
+            }
+
+            FilePath = filePath;
+            HostProject = HostProjectShim.Create(filePath, RazorConfiguration.Default);
+            DocumentFilePaths = documentFilePaths;
+            Configuration = RazorConfiguration.Default;
+            _documents = new Dictionary<string, DocumentSnapshotShim>();
+
+            foreach (var documentFilePath in documentFilePaths)
+            {
+                _documents[documentFilePath] = new TestDocumentSnapshot(documentFilePath);
+            }
+        }
+
+        public override HostProjectShim HostProject { get; }
+
+        public override RazorConfiguration Configuration { get; }
+
+        public override IEnumerable<string> DocumentFilePaths { get; }
+
+        public override string FilePath { get; }
+
+        public override bool IsInitialized => throw new NotImplementedException();
+
+        public override VersionStamp Version => throw new NotImplementedException();
+
+        public override Project WorkspaceProject => throw new NotImplementedException();
+
+        public override DocumentSnapshotShim GetDocument(string filePath)
+        {
+            if (!_documents.TryGetValue(filePath, out var documentSnapshot))
+            {
+                throw new InvalidOperationException("Test was not setup correctly. Could not locate document '" + filePath + "'.");
+            }
+
+            return documentSnapshot;
+        }
+
+        public override RazorProjectEngine GetProjectEngine()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<IReadOnlyList<TagHelperDescriptor>> GetTagHelpersAsync() => Task.FromResult<IReadOnlyList<TagHelperDescriptor>>(Array.Empty<TagHelperDescriptor>());
+
+        public override bool TryGetTagHelpers(out IReadOnlyList<TagHelperDescriptor> result)
+        {
+            result = Array.Empty<TagHelperDescriptor>();
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
- Abstracted the VSCode logger to make it easier to test.
- Updated some services API surfaces to be a little more reasonable and not depend on URIs.
- Added test helpers to abstract over document and project shims.
- Fixed issue in `DefaultProjectSnapshotManagerShim` where the `GetLoadedProject` was not behaving correctly.

#7