### PR TITLE
Filter out duplicate text document change requests to RLS.

### DIFF
--- a/client/src/RazorLanguageServerClient.ts
+++ b/client/src/RazorLanguageServerClient.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/lib/main';
 import { RazorLanguage } from './RazorLanguage';
+import { RazorLanguageServerMiddleware } from './RazorLanguageServerMiddleware';
 import { RazorLanguageServerOptions } from './RazorLanguageServerOptions';
 
 const events = {
@@ -27,6 +28,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
         this.clientOptions = {
             documentSelector: RazorLanguage.documentSelector,
             outputChannel: options.outputChannel,
+            middleware: new RazorLanguageServerMiddleware(),
         };
 
         const args = ['-lsp'];

--- a/client/src/RazorLanguageServerMiddleware.ts
+++ b/client/src/RazorLanguageServerMiddleware.ts
@@ -1,0 +1,27 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { TextDocumentChangeEvent } from 'vscode';
+import { Middleware } from 'vscode-languageclient/lib/main';
+
+export class RazorLanguageServerMiddleware implements Middleware {
+    private lastSeenDocumentVersion: number;
+
+    constructor() {
+        this.lastSeenDocumentVersion = -1;
+    }
+
+    public didChange(data: TextDocumentChangeEvent, next: (data: TextDocumentChangeEvent) => void) {
+        if (data.document.version === this.lastSeenDocumentVersion) {
+            // We've already fired a change event for this text document version, noop so we don't flood the server
+            // with duplicate requests.
+            // Working around issue https://github.com/Microsoft/vscode-languageserver-node/issues/392
+            return;
+        }
+
+        this.lastSeenDocumentVersion = data.document.version;
+        next(data);
+    }
+}


### PR DESCRIPTION
- The core issue here is that the `LanguageClient` provided by vscode incorrectly registers the `textDocument/didChange` multiple times. It registers the event once for its built-in TextDocumentChange handling (it's just a polyfill, doesn't do anything) and then again when the server tries to register its own feature dynamically. The expected correct behavior here would be for the client to unregister its built-in feature once the dynamic registration of the RLS comes through. This is tracked by https://github.com/Microsoft/vscode-languageserver-node/issues/392 but we're working around it for the interim.
- Built a separate middleware class with the expectation that we'll be adding more middleware concepts as we add features to the Razor VSCode experience.

#52