### PR TITLE
Add ability to consume incremental changes.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             _logger = logger;
         }
 
-        public override void AddDocument(string text, string filePath)
+        public override void AddDocument(SourceText sourceText, string filePath)
         {
             _foregroundDispatcher.AssertForegroundThread();
 
@@ -68,7 +68,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             }
 
             var hostDocument = HostDocumentShim.Create(textDocumentPath, textDocumentPath);
-            var sourceText = SourceText.From(text);
             var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
             var textLoader = TextLoader.From(textAndVersion);
             _projectSnapshotManagerAccessor.Instance.DocumentAdded(projectSnapshot.HostProject, hostDocument, textLoader);
@@ -98,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             _logger.Log($"Removed document '{textDocumentPath}' from project '{projectSnapshot.FilePath}'.");
         }
 
-        public override void UpdateDocument(string text, string filePath)
+        public override void UpdateDocument(SourceText sourceText, string filePath)
         {
             _foregroundDispatcher.AssertForegroundThread();
 
@@ -107,7 +106,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             {
                 projectSnapshot = _projectResolver.GetMiscellaneousProject();
             }
-            var sourceText = SourceText.From(text);
             _projectSnapshotManagerAccessor.Instance.DocumentChanged(projectSnapshot.HostProject.FilePath, textDocumentPath, sourceText);
 
             _logger.Log($"Updated document '{textDocumentPath}'.");

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -3,16 +3,17 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 {
     internal abstract class RazorProjectService
     {
-        public abstract void AddDocument(string text, string filePath);
+        public abstract void AddDocument(SourceText sourceText, string filePath);
 
         public abstract void RemoveDocument(string filePath);
 
-        public abstract void UpdateDocument(string text, string filePath);
+        public abstract void UpdateDocument(SourceText sourceText, string filePath);
 
         public abstract void AddProject(string filePath, RazorConfiguration configuration);
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Properties/AssemblyInfo.cs
@@ -3,4 +3,5 @@
 
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Razor.LanguageServer.Test")]

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed;
 using Microsoft.CodeAnalysis.Text;
@@ -24,16 +22,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private SynchronizationCapability _capability;
         private readonly VSCodeLogger _logger;
         private readonly ForegroundDispatcherShim _foregroundDispatcher;
+        private readonly DocumentResolver _documentResolver;
         private readonly RazorProjectService _projectService;
 
         public RazorDocumentSynchronizationEndpoint(
             ForegroundDispatcherShim foregroundDispatcher,
+            DocumentResolver documentResolver,
             RazorProjectService projectService,
             VSCodeLogger logger)
         {
             if (foregroundDispatcher == null)
             {
                 throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (documentResolver == null)
+            {
+                throw new ArgumentNullException(nameof(documentResolver));
             }
 
             if (projectService == null)
@@ -47,12 +52,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             _foregroundDispatcher = foregroundDispatcher;
+            _documentResolver = documentResolver;
             _projectService = projectService;
             _logger = logger;
         }
 
-        // TODO: GO INCREMENTAL
-        public TextDocumentSyncKind Change { get; } = TextDocumentSyncKind.Full;
+        public TextDocumentSyncKind Change { get; } = TextDocumentSyncKind.Incremental;
 
         public void SetCapability(SynchronizationCapability capability)
         {
@@ -63,9 +68,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public async Task<Unit> Handle(DidChangeTextDocumentParams notification, CancellationToken token)
         {
-            var newContent = notification.ContentChanges.Single().Text;
+            _foregroundDispatcher.AssertBackgroundThread();
+
+            var document = await Task.Factory.StartNew(() =>
+            {
+                _documentResolver.TryResolveDocument(notification.TextDocument.Uri.AbsolutePath, out var documentSnapshot);
+
+                return documentSnapshot;
+            }, CancellationToken.None, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
+
+            var sourceText = await document.GetTextAsync();
+            sourceText = ApplyContentChanges(notification.ContentChanges, sourceText);
+
             await Task.Factory.StartNew(
-                () => _projectService.UpdateDocument(newContent, notification.TextDocument.Uri.AbsolutePath),
+                () => _projectService.UpdateDocument(sourceText, document.FilePath),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);
@@ -73,10 +89,34 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return Unit.Value;
         }
 
+        // Internal for testing
+        internal SourceText ApplyContentChanges(IEnumerable<TextDocumentContentChangeEvent> contentChanges, SourceText sourceText)
+        {
+            foreach (var change in contentChanges)
+            {
+                var linePosition = new LinePosition((int)change.Range.Start.Line, (int)change.Range.Start.Character);
+                var position = sourceText.Lines.GetPosition(linePosition);
+                var textSpan = new TextSpan(position, change.RangeLength);
+                var textChange = new TextChange(textSpan, change.Text);
+
+                _logger.Log("Applying " + textChange);
+
+                // If there happens to be multiple text changes we generate a new source text for each one. Due to the
+                // differences in VSCode and Roslyn's representation we can't pass in all changes simultaneously because
+                // ordering may differ.
+                sourceText = sourceText.WithChanges(textChange);
+            }
+
+            return sourceText;
+        }
+
         public async Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken token)
         {
+            _foregroundDispatcher.AssertBackgroundThread();
+
+            var sourceText = SourceText.From(notification.TextDocument.Text);
             await Task.Factory.StartNew(
-                () => _projectService.AddDocument(notification.TextDocument.Text, notification.TextDocument.Uri.AbsolutePath),
+                () => _projectService.AddDocument(sourceText, notification.TextDocument.Uri.AbsolutePath),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);
@@ -86,6 +126,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public async Task<Unit> Handle(DidCloseTextDocumentParams notification, CancellationToken token)
         {
+            _foregroundDispatcher.AssertBackgroundThread();
+
             await Task.Factory.StartNew(
                 () => _projectService.RemoveDocument(notification.TextDocument.Uri.AbsolutePath),
                 CancellationToken.None,
@@ -104,8 +146,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public TextDocumentAttributes GetTextDocumentAttributes(Uri uri)
         {
-            _logger.Log("Asked for attributes");
-
             return new TextDocumentAttributes(uri, "razor");
         }
 

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using Moq;
 using Xunit;
 
@@ -36,9 +37,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Assert.NotNull(textLoader);
                 });
             var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+            var sourceText = SourceText.From("Hello World");
 
             // Act
-            projectService.AddDocument("Hello World", documentFilePath);
+            projectService.AddDocument(sourceText, documentFilePath);
 
             // Assert
             projectSnapshotManager.VerifyAll();
@@ -60,9 +62,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Assert.NotNull(textLoader);
                 });
             var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
+            var sourceText = SourceText.From("Hello World");
 
             // Act
-            projectService.AddDocument("Hello World", documentFilePath);
+            projectService.AddDocument(sourceText, documentFilePath);
 
             // Assert
             projectSnapshotManager.VerifyAll();

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentSynchronizationEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentSynchronizationEndpointTest.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.LanguageServer.StrongNamed;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorDocumentSynchronizationEndpointTest : TestBase
+    {
+        [Fact]
+        public void ApplyContentChanges_SingleChange()
+        {
+            // Arrange
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, Mock.Of<DocumentResolver>(), Mock.Of<RazorProjectService>(), Logger);
+            var sourceText = SourceText.From("Hello World");
+            var change = new TextDocumentContentChangeEvent()
+            {
+                Range = new Range(new Position(0, 5), new Position(0, 5)),
+                RangeLength = 0,
+                Text = "!"
+            };
+
+            // Act
+            var result = endpoint.ApplyContentChanges(new[] { change }, sourceText);
+
+            // Assert
+            var resultString = GetString(result);
+            Assert.Equal("Hello! World", resultString);
+        }
+
+        [Fact]
+        public void ApplyContentChanges_MultipleChanges()
+        {
+            // Arrange
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, Mock.Of<DocumentResolver>(), Mock.Of<RazorProjectService>(), Logger);
+            var sourceText = SourceText.From("Hello World");
+            var changes = new[] {
+                new TextDocumentContentChangeEvent()
+                {
+                    Range = new Range(new Position(0, 5), new Position(0, 5)),
+                    RangeLength = 0,
+                    Text = Environment.NewLine
+                },
+                // Hello
+                //  World
+
+                new TextDocumentContentChangeEvent()
+                {
+                    Range = new Range(new Position(1, 0), new Position(1, 0)),
+                    RangeLength = 0,
+                    Text = "!"
+                },
+                // Hello
+                // ! World
+
+                new TextDocumentContentChangeEvent()
+                {
+                    Range = new Range(new Position(0, 1), new Position(0, 1)),
+                    RangeLength = 4,
+                    Text = "i!" + Environment.NewLine
+                },
+                // Hi!
+                //
+                // ! World
+            };
+
+            // Act
+            var result = endpoint.ApplyContentChanges(changes, sourceText);
+
+            // Assert
+            var resultString = GetString(result);
+            Assert.Equal(@"Hi!
+
+! World", resultString);
+        }
+
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
+        public async Task Handle_DidChangeTextDocument_UpdatesDocument()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var sourceText = SourceText.From("<p>");
+            var documentResolver = CreateDocumentResolver(documentPath, sourceText);
+            var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
+            projectService.Setup(service => service.UpdateDocument(It.IsAny<SourceText>(), It.IsAny<string>()))
+                .Callback<SourceText, string>((text, path) =>
+                {
+                    var resultString = GetString(text);
+                    Assert.Equal("<p></p>", resultString);
+                    Assert.Equal(documentPath, path);
+                });
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, documentResolver, projectService.Object, Logger);
+            var change = new TextDocumentContentChangeEvent()
+            {
+                Range = new Range(new Position(0, 3), new Position(0, 3)),
+                RangeLength = 0,
+                Text = "</p>"
+            };
+            var request = new DidChangeTextDocumentParams()
+            {
+                ContentChanges = new Container<TextDocumentContentChangeEvent>(change),
+                TextDocument = new VersionedTextDocumentIdentifier()
+                {
+                    Uri = new Uri(documentPath)
+                }
+            };
+
+            // Act
+            await Task.Run(() => endpoint.Handle(request, default));
+
+            // Assert
+            projectService.VerifyAll();
+        }
+
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
+        public async Task Handle_DidOpenTextDocument_AddsDocument()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
+            projectService.Setup(service => service.AddDocument(It.IsAny<SourceText>(), It.IsAny<string>()))
+                .Callback<SourceText, string>((sourceText, path) =>
+                {
+                    var resultString = GetString(sourceText);
+                    Assert.Equal("hello", resultString);
+                    Assert.Equal(documentPath, path);
+                });
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, Mock.Of<DocumentResolver>(), projectService.Object, Logger);
+            var request = new DidOpenTextDocumentParams()
+            {
+                TextDocument = new TextDocumentItem()
+                {
+                    Text = "hello",
+                    Uri = new Uri(documentPath)
+                }
+            };
+
+            // Act
+            await Task.Run(() => endpoint.Handle(request, default));
+
+            // Assert
+            projectService.VerifyAll();
+        }
+
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
+        public async Task Handle_DidCloseTextDocument_RemovesDocument()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
+            projectService.Setup(service => service.RemoveDocument(It.IsAny<string>()))
+                .Callback<string>((path) =>
+                {
+                    Assert.Equal(documentPath, path);
+                });
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, Mock.Of<DocumentResolver>(), projectService.Object, Logger);
+            var request = new DidCloseTextDocumentParams()
+            {
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = new Uri(documentPath)
+                }
+            };
+
+            // Act
+            await Task.Run(() => endpoint.Handle(request, default));
+
+            // Assert
+            projectService.VerifyAll();
+        }
+
+        private string GetString(SourceText sourceText)
+        {
+            var sourceChars = new char[sourceText.Length];
+            sourceText.CopyTo(0, sourceChars, 0, sourceText.Length);
+            var sourceString = new string(sourceChars);
+
+            return sourceString;
+        }
+
+        private static DocumentResolver CreateDocumentResolver(string documentPath, SourceText sourceText)
+        {
+            var documentSnapshot = Mock.Of<DocumentSnapshotShim>(document => document.GetTextAsync() == Task.FromResult(sourceText) && document.FilePath == documentPath);
+            var documentResolver = new Mock<DocumentResolver>();
+            documentResolver.Setup(resolver => resolver.TryResolveDocument(documentPath, out documentSnapshot))
+                .Returns(true);
+            return documentResolver.Object;
+        }
+    }
+}


### PR DESCRIPTION
- Updated `RazorProjectService`s `AddDocument` API to take a `SourceText` instead of `string` text for consistency with other APIs.
- Updated `RazorProjectService`s `UpdateDocument` API to take a `SourceText` instead of `string` text for consistency with other APIs.
- Changed the `TextDocumentSyncKind` from `Full` to `Incremental`. The big difference here is that the VS Code IDE will pump character changes to the language server at a higher rate allowing us to have a more consistent experience when dealing with user actions (completion).
- Found that the VS Code & Roslyn APIs were slightly incompatible when changes occurred in bulk edits. Roslyn's `SourceText` implementation would complain that the VS Code changes weren't in a chronological order; to address this we apply each change individually relying on the expectation that the changes don't impact each other negatively.
- Added unit tests for the newly added `ApplyContentChanges`
- Added 3 integration tests to verify the end-to-end for each of the primary text document sycnhronization points.

#10