### PR TITLE
Track all Razor documents and their open/close status.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,10 +21,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ansi-cyan": {
@@ -65,8 +65,8 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -94,7 +94,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -117,7 +117,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
@@ -146,9 +146,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -157,11 +157,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -183,7 +183,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "block-stream": {
@@ -191,7 +191,7 @@
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "brace-expansion": {
@@ -199,7 +199,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -208,9 +208,9 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -245,9 +245,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -256,7 +256,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.2"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "has-flag": {
@@ -271,7 +271,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -296,9 +296,9 @@
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "co": {
@@ -326,7 +326,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -355,8 +355,8 @@
             "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
             "dev": true,
             "requires": {
-                "cross-spawn": "6.0.5",
-                "is-windows": "1.0.2"
+                "cross-spawn": "^6.0.5",
+                "is-windows": "^1.0.0"
             }
         },
         "cross-spawn": {
@@ -365,11 +365,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "1.0.4",
-                "path-key": "2.0.1",
-                "semver": "5.5.0",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "dashdash": {
@@ -377,7 +377,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "debug": {
@@ -393,7 +393,7 @@
             "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "delayed-stream": {
@@ -416,10 +416,10 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -428,8 +428,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "end-of-stream": {
@@ -437,7 +437,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -456,13 +456,13 @@
             "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -470,7 +470,7 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -478,7 +478,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "extend": {
@@ -491,7 +491,7 @@
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             }
         },
         "extglob": {
@@ -499,7 +499,7 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -529,7 +529,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -542,11 +542,11 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "first-chunk-stream": {
@@ -564,7 +564,7 @@
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -577,9 +577,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.19"
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -597,10 +597,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "getpass": {
@@ -608,7 +608,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -616,12 +616,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -629,8 +629,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -638,7 +638,7 @@
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -651,7 +651,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -661,8 +661,8 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -670,14 +670,14 @@
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "requires": {
-                "extend": "3.0.2",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -685,11 +685,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -702,10 +702,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -718,8 +718,8 @@
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -739,9 +739,9 @@
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -749,9 +749,9 @@
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -759,8 +759,8 @@
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -773,10 +773,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -789,8 +789,8 @@
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -800,11 +800,11 @@
             "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.87.0",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0"
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -822,12 +822,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -837,11 +837,11 @@
             "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -859,8 +859,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -871,10 +871,10 @@
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-untar": {
@@ -882,11 +882,11 @@
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "requires": {
-                "event-stream": "3.3.4",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -904,8 +904,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -916,13 +916,13 @@
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.10.0",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -940,7 +940,7 @@
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "vinyl": {
@@ -948,12 +948,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -964,12 +964,12 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.3.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -978,7 +978,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -996,9 +996,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1006,8 +1006,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1035,7 +1035,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -1053,7 +1053,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-number": {
@@ -1061,7 +1061,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1069,7 +1069,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1166,7 +1166,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1200,7 +1200,7 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lodash.isequal": {
@@ -1229,7 +1229,7 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -1237,19 +1237,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1257,7 +1257,7 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -1270,7 +1270,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -1278,7 +1278,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1293,7 +1293,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
             "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
             "requires": {
-                "mime-db": "1.35.0"
+                "mime-db": "~1.35.0"
             }
         },
         "minimatch": {
@@ -1301,7 +1301,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -1344,10 +1344,10 @@
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "nice-try": {
@@ -1361,7 +1361,7 @@
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-path": {
@@ -1369,13 +1369,13 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -1387,8 +1387,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "once": {
@@ -1396,7 +1396,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "ordered-read-streams": {
@@ -1404,8 +1404,8 @@
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.6"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "parse-glob": {
@@ -1413,10 +1413,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1429,7 +1429,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1461,7 +1461,7 @@
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -1479,11 +1479,11 @@
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "preserve": {
@@ -1495,6 +1495,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "psl": {
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
         },
         "punycode": {
             "version": "1.4.1",
@@ -1516,17 +1521,17 @@
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-            "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -1546,13 +1551,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regex-cache": {
@@ -1560,7 +1565,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -1584,30 +1589,30 @@
             "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
         },
         "request": {
-            "version": "2.87.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.19",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             }
         },
         "requires-port": {
@@ -1621,7 +1626,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.5"
             }
         },
         "rimraf": {
@@ -1629,7 +1634,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -1653,7 +1658,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -1672,8 +1677,8 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "split": {
@@ -1681,7 +1686,7 @@
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sshpk": {
@@ -1689,15 +1694,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -1710,7 +1715,7 @@
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -1723,7 +1728,7 @@
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -1736,7 +1741,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -1745,7 +1750,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -1753,7 +1758,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -1761,8 +1766,8 @@
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "supports-color": {
@@ -1770,7 +1775,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
             "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
             "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
             }
         },
         "tar": {
@@ -1778,9 +1783,9 @@
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -1793,8 +1798,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -1802,8 +1807,8 @@
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "to-absolute-glob": {
@@ -1811,7 +1816,7 @@
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1819,17 +1824,18 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
         },
         "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "requires": {
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             }
         },
         "ts-node": {
@@ -1838,14 +1844,14 @@
             "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "buffer-from": "1.1.1",
-                "diff": "3.3.1",
-                "make-error": "1.3.4",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.5.6",
-                "yn": "2.0.0"
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
             },
             "dependencies": {
                 "minimist": {
@@ -1868,17 +1874,17 @@
             "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.11.0",
-                "diff": "3.3.1",
-                "glob": "7.1.2",
-                "minimatch": "3.0.4",
-                "resolve": "1.8.1",
-                "semver": "5.5.0",
-                "tslib": "1.9.3",
-                "tsutils": "2.29.0"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.1.0",
+                "commander": "^2.9.0",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.7.1",
+                "tsutils": "^2.12.1"
             }
         },
         "tsutils": {
@@ -1887,7 +1893,7 @@
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.8.1"
             }
         },
         "tunnel-agent": {
@@ -1895,7 +1901,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -1915,8 +1921,8 @@
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "url-parse": {
@@ -1924,8 +1930,8 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
             "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -1948,9 +1954,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -1958,8 +1964,8 @@
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
@@ -1967,23 +1973,23 @@
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "requires": {
-                "duplexify": "3.6.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -2001,8 +2007,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2013,29 +2019,29 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
         "vscode": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.18.tgz",
-            "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.21.tgz",
+            "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.87.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.6",
-                "url-parse": "1.4.3",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "vscode-jsonrpc": {
@@ -2048,7 +2054,7 @@
             "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.0.tgz",
             "integrity": "sha512-sXBwIcwG4W5MjnDAfXf0hM5ErOcXxEBlix6QJb5ijf0gtecYygrMAqv8hag7sEg/jCCOKQdXJ4K1iZL3GZcJZg==",
             "requires": {
-                "vscode-languageserver-protocol": "3.10.0"
+                "vscode-languageserver-protocol": "^3.10.0"
             }
         },
         "vscode-languageserver-protocol": {
@@ -2056,8 +2062,8 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.10.0.tgz",
             "integrity": "sha512-PNNmKM0IcQPRiY1oUIxfwseBvxS5Sa5aZUpTcq/qsXWclnl8FFNs8oCCoAtyLhBXnuJvybWUNafiA78y0unJDA==",
             "requires": {
-                "vscode-jsonrpc": "3.6.2",
-                "vscode-languageserver-types": "3.10.0"
+                "vscode-jsonrpc": "^3.6.2",
+                "vscode-languageserver-types": "^3.10.0"
             }
         },
         "vscode-languageserver-types": {
@@ -2071,7 +2077,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "wrappy": {
@@ -2089,8 +2095,8 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.1.0"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
@@ -2098,7 +2104,7 @@
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         },
         "yn": {

--- a/client/package.json
+++ b/client/package.json
@@ -82,7 +82,7 @@
         "typescript": "2.6.1"
     },
     "dependencies": {
-        "vscode": "^1.1.18",
+        "vscode": "^1.1.21",
         "vscode-languageclient": "^4.1.4"
     }
 }

--- a/client/src/RPC/AddDocumentRequest.ts
+++ b/client/src/RPC/AddDocumentRequest.ts
@@ -1,0 +1,9 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export class AddDocumentRequest {
+    constructor(public readonly filePath: string) {
+    }
+}

--- a/client/src/RPC/RemoveDocumentRequest.ts
+++ b/client/src/RPC/RemoveDocumentRequest.ts
@@ -1,0 +1,9 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export class RemoveDocumentRequest {
+    constructor(public readonly filePath: string) {
+    }
+}

--- a/client/src/RazorDocumentTracker.ts
+++ b/client/src/RazorDocumentTracker.ts
@@ -1,0 +1,40 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+
+import { RazorLanguage } from './RazorLanguage';
+import { RazorLanguageServiceClient } from './RazorLanguageServiceClient';
+
+const globbingPath = `**/*.${RazorLanguage.fileExtension}`;
+
+export class RazorDocumentTracker {
+
+    constructor(private readonly languageServiceClient: RazorLanguageServiceClient) {
+    }
+
+    public async initialize() {
+        // Track current documents
+        const documentUris = await vscode.workspace.findFiles(globbingPath);
+
+        for (const uri of documentUris) {
+            await this.languageServiceClient.addDocument(uri);
+        }
+    }
+
+    public register() {
+        // Track future documents
+        const watcher = vscode.workspace.createFileSystemWatcher(globbingPath);
+        const createRegistration = watcher.onDidCreate(async (uri: vscode.Uri) => {
+            await this.languageServiceClient.addDocument(uri);
+        });
+
+        const deleteRegistration = watcher.onDidDelete(async (uri: vscode.Uri) => {
+            await this.languageServiceClient.removeDocument(uri);
+        });
+
+        return vscode.Disposable.from(watcher, createRegistration, deleteRegistration);
+    }
+}

--- a/client/src/RazorLanguage.ts
+++ b/client/src/RazorLanguage.ts
@@ -8,7 +8,8 @@ import { DocumentSelector } from 'vscode-languageclient/lib/main';
 
 export class RazorLanguage {
     public static id = 'razor';
-    public static documentSelector: DocumentSelector =  [ { pattern: '**/*.cshtml' } ];
+    public static fileExtension = 'cshtml';
+    public static documentSelector: DocumentSelector =  [ { pattern: `**/*.${RazorLanguage.fileExtension}` } ];
     public static languageConfig = vscode.workspace.getConfiguration('razor');
     public static serverConfig = vscode.workspace.getConfiguration('razor.languageServer');
 }

--- a/client/src/RazorLanguageServerClient.ts
+++ b/client/src/RazorLanguageServerClient.ts
@@ -5,7 +5,13 @@
 
 import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/lib/main';
+import {
+    GenericRequestHandler,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    State,
+} from 'vscode-languageclient/lib/main';
 import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageServerMiddleware } from './RazorLanguageServerMiddleware';
 import { RazorLanguageServerOptions } from './RazorLanguageServerOptions';
@@ -82,6 +88,14 @@ export class RazorLanguageServerClient implements vscode.Disposable {
         }
 
         return this.client.sendRequest<TResponseType>(method, param);
+    }
+
+    public async onRequest<TRequest, TReturn>(method: string, handler: GenericRequestHandler<TRequest, TReturn>) {
+        if (!this.isStarted) {
+            throw new Error('Tried to bind on request logic while server is not started.');
+        }
+
+        this.client.onRequest(method, handler);
     }
 
     public dispose() {

--- a/client/src/RazorLanguageServiceClient.ts
+++ b/client/src/RazorLanguageServiceClient.ts
@@ -5,13 +5,31 @@
 
 import * as vscode from 'vscode';
 import { RazorLanguageServerClient } from './RazorLanguageServerClient';
+import { AddDocumentRequest } from './RPC/AddDocumentRequest';
 import { AddProjectRequest } from './RPC/AddProjectRequest';
 import { LanguageQueryRequest } from './RPC/LanguageQueryRequest';
 import { LanguageQueryResponse } from './RPC/LanguageQueryResponse';
+import { RazorTextDocumentItem } from './RPC/RazorTextDocumentItem';
+import { RemoveDocumentRequest } from './RPC/RemoveDocumentRequest';
 import { RemoveProjectRequest } from './RPC/RemoveProjectRequest';
 
 export class RazorLanguageServiceClient {
     constructor(private readonly serverClient: RazorLanguageServerClient) {
+        serverClient.onStart(() => {
+            // Once the server starts we need to attach to all of the request handlers
+
+            serverClient.onRequest('getTextDocument', filePath => this.getTextDocument(filePath));
+        });
+    }
+
+    public async addDocument(documentUri: vscode.Uri) {
+        const request = new AddDocumentRequest(documentUri.fsPath);
+        await this.serverClient.sendRequest<AddDocumentRequest>('projects/addDocument', request);
+    }
+
+    public async removeDocument(documentUri: vscode.Uri) {
+        const request = new RemoveDocumentRequest(documentUri.fsPath);
+        await this.serverClient.sendRequest<RemoveDocumentRequest>('projects/removeDocument', request);
     }
 
     public async addProject(projectFileUri: vscode.Uri, configurationName?: string) {
@@ -29,5 +47,12 @@ export class RazorLanguageServiceClient {
         const response = await this.serverClient.sendRequest<LanguageQueryResponse>('razor/languageQuery', request);
         response.position = new vscode.Position(response.position.line, response.position.character);
         return response;
+    }
+
+    private async getTextDocument(filePath: string) {
+        const clientUri = vscode.Uri.file(filePath);
+        const document = await vscode.workspace.openTextDocument(clientUri);
+
+        return new RazorTextDocumentItem(document);
     }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { ExtensionContext } from 'vscode';
 import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
 import { RazorCompletionItemProvider } from './RazorCompletionItemProvider';
+import { RazorDocumentTracker } from './RazorDocumentTracker';
 import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageServerClient } from './RazorLanguageServerClient';
 import { resolveRazorLanguageServerOptions } from './RazorLanguageServerOptionsResolver';
@@ -24,6 +25,7 @@ export async function activate(context: ExtensionContext) {
     const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
     const csharpFeature = new RazorCSharpFeature();
     const projectTracker = new RazorProjectTracker(languageServiceClient);
+    const documentTracker = new RazorDocumentTracker(languageServiceClient);
     const localRegistrations: vscode.Disposable[] = [];
 
     const onStartRegistration = languageServerClient.onStart(() => {
@@ -32,6 +34,7 @@ export async function activate(context: ExtensionContext) {
                 RazorLanguage.id,
                 new RazorCompletionItemProvider(csharpFeature, languageServiceClient)),
             projectTracker.register(),
+            documentTracker.register(),
             csharpFeature.register(),
             vscode.workspace.onDidChangeTextDocument(args => {
                 const activeTextEditor = vscode.window.activeTextEditor;
@@ -48,6 +51,7 @@ export async function activate(context: ExtensionContext) {
 
     await languageServerClient.start();
     await projectTracker.initialize();
+    await documentTracker.initialize();
     await csharpFeature.initialize();
 
     context.subscriptions.push(languageServerClient, onStartRegistration, onStopRegistration);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRemoteTextLoaderFactory.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultRemoteTextLoaderFactory : RemoteTextLoaderFactory
+    {
+        private const string GetTextDocumentMethod = "getTextDocument";
+        private readonly ILanguageServer _router;
+
+        public DefaultRemoteTextLoaderFactory(ILanguageServer router)
+        {
+            if (router == null)
+            {
+                throw new ArgumentNullException(nameof(router));
+            }
+
+            _router = router;
+        }
+
+        public override TextLoader Create(string filePath)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            return new RemoteTextLoader(filePath, _router);
+        }
+
+        private class RemoteTextLoader : TextLoader
+        {
+            private readonly string _filePath;
+            private readonly ILanguageServer _router;
+
+            public RemoteTextLoader(string filePath, ILanguageServer router)
+            {
+                if (filePath == null)
+                {
+                    throw new ArgumentNullException(nameof(filePath));
+                }
+
+                if (router == null)
+                {
+                    throw new ArgumentNullException(nameof(router));
+                }
+
+                _filePath = filePath;
+                _router = router;
+            }
+
+            public override async Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+            {
+                var document = await _router.Client.SendRequest<string, TextDocumentItem>(GetTextDocumentMethod, _filePath);
+                var sourceText = SourceText.From(document.Text);
+                var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
+                return textAndVersion;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -47,6 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorProjectEndpoint>()
                     .WithServices(services =>
                     {
+                        services.AddSingleton<RemoteTextLoaderFactory, DefaultRemoteTextLoaderFactory>();
                         services.AddSingleton<VSCodeLogger, DefaultVSCodeLogger>();
                         services.AddSingleton<ProjectResolver, DefaultProjectResolver>();
                         services.AddSingleton<DocumentResolver, DefaultDocumentResolver>();

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/AddDocumentParams.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/AddDocumentParams.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using MediatR;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
+{
+    public class AddDocumentParams : IRequest
+    {
+        public string FilePath { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultDocumentResolver.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultDocumentResolver.cs
@@ -46,12 +46,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             if (!_projectResolver.TryResolveProject(normalizedPath, out var project))
             {
                 project = _projectResolver.GetMiscellaneousProject();
-                if (!project.DocumentFilePaths.Contains(normalizedPath, FilePathComparerShim.Instance))
-                {
-                    // Miscellaneous project and other tracked projects do not contain document.
-                    document = null;
-                    return false;
-                }
+            }
+
+            if (!project.DocumentFilePaths.Contains(normalizedPath, FilePathComparerShim.Instance))
+            {
+                // Miscellaneous project and other tracked projects do not contain document.
+                document = null;
+                return false;
             }
 
             document = project.GetDocument(normalizedPath);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorAddDocumentHandler.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorAddDocumentHandler.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
+{
+    [Parallel, Method("projects/addDocument")]
+    public interface IRazorAddDocumentHandler : IJsonRpcRequestHandler<AddDocumentParams>
+    {
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorRemoveDocumentHandler.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorRemoveDocumentHandler.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
+{
+    [Parallel, Method("projects/removeDocument")]
+    public interface IRazorRemoveDocumentHandler : IJsonRpcRequestHandler<RemoveDocumentParams>
+    {
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -11,6 +11,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
     {
         public abstract void AddDocument(string filePath, TextLoader textLoader);
 
+        public abstract void OpenDocument(string filePath, SourceText sourceText);
+
+        public abstract void CloseDocument(string filePath, TextLoader textLoader);
+
         public abstract void RemoveDocument(string filePath);
 
         public abstract void UpdateDocument(string filePath, SourceText sourceText);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RemoveDocumentParams.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RemoveDocumentParams.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using MediatR;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
+{
+    public class RemoveDocumentParams : IRequest
+    {
+        public string FilePath { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -24,11 +24,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly VSCodeLogger _logger;
         private readonly ForegroundDispatcherShim _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
+        private readonly RemoteTextLoaderFactory _remoteTextLoaderFactory;
         private readonly RazorProjectService _projectService;
 
         public RazorDocumentSynchronizationEndpoint(
             ForegroundDispatcherShim foregroundDispatcher,
             DocumentResolver documentResolver,
+            RemoteTextLoaderFactory remoteTextLoaderFactory,
             RazorProjectService projectService,
             VSCodeLogger logger)
         {
@@ -40,6 +42,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (documentResolver == null)
             {
                 throw new ArgumentNullException(nameof(documentResolver));
+            }
+
+            if (remoteTextLoaderFactory == null)
+            {
+                throw new ArgumentNullException(nameof(remoteTextLoaderFactory));
             }
 
             if (projectService == null)
@@ -54,6 +61,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _foregroundDispatcher = foregroundDispatcher;
             _documentResolver = documentResolver;
+            _remoteTextLoaderFactory = remoteTextLoaderFactory;
             _projectService = projectService;
             _logger = logger;
         }
@@ -116,11 +124,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _foregroundDispatcher.AssertBackgroundThread();
 
             var sourceText = SourceText.From(notification.TextDocument.Text);
-            var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
-            var textLoader = TextLoader.From(textAndVersion);
 
             await Task.Factory.StartNew(
-                () => _projectService.AddDocument(notification.TextDocument.Uri.AbsolutePath, textLoader),
+                () => _projectService.OpenDocument(notification.TextDocument.Uri.AbsolutePath, sourceText),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);
@@ -132,8 +138,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             _foregroundDispatcher.AssertBackgroundThread();
 
+            var textLoader = _remoteTextLoaderFactory.Create(notification.TextDocument.Uri.AbsolutePath);
             await Task.Factory.StartNew(
-                () => _projectService.RemoveDocument(notification.TextDocument.Uri.AbsolutePath),
+                () => _projectService.CloseDocument(notification.TextDocument.Uri.AbsolutePath, textLoader),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteTextLoaderFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteTextLoaderFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public abstract class RemoteTextLoaderFactory
+    {
+        public abstract TextLoader Create(string filePath);
+    }
+}


### PR DESCRIPTION
- This is required to make scenarios like Blazor possible. On startup we capture all Razor files in the workspace (`DocumentTracker.ts`) and add them to our Razor project system. As files get opened or closed we update their status internally. The largest conceptual bit in this changeset is that when we receive `textDocument/didOpen` / `textDocument/didClose`we no longer add those Razor documents to the system; and start parsing them: They're already known to the system because we initialized them when the language server started. Therefore, the `didOpen` / `didClose` calls result in open/close flaggings.
- Updated `DocumentResolver` to be more strict in when it returns possible documents. It now cross-checks potential projects with the documents they're currently aware of. This means if a document is not part of a project but the project is a "potential" project then we'll fail to resolve the document.
- Added a new client side API to help the language server lazily resolve text content of documents. This will be especially valuable when we start pre-emptively parsing all of our Razor files in the project system and then need to get their content without the requirement to push every Razor files content in the world over the wire. This work was also paired with the creation of the `RemoteTextLoaderFactory`which is our wiring to the Roslyn abstraction that retrieves content behind the scenes.
- Updated and added tests for all the new comer APIs

#62