### PR TITLE
Add support for provisional completions.

### DIFF
--- a/client/src/CSharp/CSharpPreviewDocumentContentProvider.ts
+++ b/client/src/CSharp/CSharpPreviewDocumentContentProvider.ts
@@ -60,7 +60,7 @@ export class CSharpPreviewDocumentContentProvider implements vscode.TextDocument
     private async tryUpdate(uri: vscode.Uri) {
         const activeDocument = await this.csharpProjectionProvider.getActiveDocument();
 
-        if (activeDocument.projectedUri === uri) {
+        if (activeDocument && activeDocument.projectedUri === uri) {
             this.onDidChangeEmitter.fire(CSharpPreviewDocumentContentProvider.previewUri);
         }
     }

--- a/client/src/CSharp/CSharpProjectedDocument.ts
+++ b/client/src/CSharp/CSharpProjectedDocument.ts
@@ -8,6 +8,8 @@ import { ServerTextChange } from '../RPC/ServerTextChange';
 
 export class CSharpProjectedDocument {
     private content = '';
+    private preProvisionalContent: string | undefined;
+    private provisionalEditAt: number | undefined;
 
     public constructor(
         readonly projectedUri: vscode.Uri,
@@ -16,6 +18,8 @@ export class CSharpProjectedDocument {
     }
 
     public applyEdits(edits: ServerTextChange[]) {
+        this.removeProvisionalDot();
+
         for (const edit of edits) {
             // TODO: Use a better data structure to represent the content, string concats
             // are slow.
@@ -27,6 +31,37 @@ export class CSharpProjectedDocument {
 
     public getContent() {
         return this.content;
+    }
+
+    // A provisional dot represents a '.' that's inserted into the projected document but will be
+    // removed prior to any edits that get applied. In Razor's case a provisional dot is used to
+    // show completions after an expression for a dot that's usually interpreted as Html.
+    public addProvisionalDotAt(index: number) {
+        if (this.provisionalEditAt === index) {
+            // Edits already applied.
+            return;
+        }
+
+        const preEditContent = this.content;
+        this.applyEdits([{
+            newText: '.',
+            span: {
+                start: index,
+                end: index,
+                length: 0,
+            },
+        }]);
+        this.preProvisionalContent = preEditContent;
+        this.provisionalEditAt = index;
+    }
+
+    public removeProvisionalDot() {
+        if (this.provisionalEditAt && this.preProvisionalContent) {
+            // Undo provisional edit if one was applied.
+            this.setContent(this.preProvisionalContent);
+            this.provisionalEditAt = undefined;
+            this.preProvisionalContent = undefined;
+        }
     }
 
     private setContent(content: string) {

--- a/client/src/CSharp/CSharpProjectedDocumentContentProvider.ts
+++ b/client/src/CSharp/CSharpProjectedDocumentContentProvider.ts
@@ -33,7 +33,7 @@ export class CSharpProjectedDocumentContentProvider implements vscode.TextDocume
 
     public getActiveDocument() {
         if (!vscode.window.activeTextEditor) {
-            throw new Error('No active text document');
+            return null;
         }
 
         return this.ensureProjectedDocument(vscode.window.activeTextEditor.document.uri);
@@ -60,7 +60,7 @@ export class CSharpProjectedDocumentContentProvider implements vscode.TextDocume
     private createProjectedDocument(hostDocumentUri: vscode.Uri) {
         const extensionlessPath = hostDocumentUri.path.substring(
             0, hostDocumentUri.path.length - RazorLanguage.fileExtension.length - 1);
-        const transformedPath =  `${extensionlessPath}.cs`;
+        const transformedPath = `${extensionlessPath}.cs`;
         const projectedUri = vscode.Uri.parse(`${CSharpProjectedDocumentContentProvider.scheme}://${transformedPath}`);
         const onChange = () => this.onDidChangeEmitter.fire(projectedUri);
 

--- a/client/src/ProjectionResult.ts
+++ b/client/src/ProjectionResult.ts
@@ -1,0 +1,13 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { LanguageKind } from './RPC/LanguageKind';
+
+export interface ProjectionResult {
+    uri: vscode.Uri;
+    position: vscode.Position;
+    languageKind: LanguageKind;
+}

--- a/client/src/ProvisionalCompletionOrchestrator.ts
+++ b/client/src/ProvisionalCompletionOrchestrator.ts
@@ -1,0 +1,142 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
+import { ProjectionResult } from './ProjectionResult';
+import { RazorCompletionItemProvider } from './RazorCompletionItemProvider';
+import { RazorLanguage } from './RazorLanguage';
+import { RazorLanguageServiceClient } from './RazorLanguageServiceClient';
+import { LanguageKind } from './RPC/LanguageKind';
+
+export class ProvisionalCompletionOrchestrator {
+    private provisionalDotsMayBeActive = false;
+    private currentActiveDocument: vscode.TextDocument | undefined;
+
+    constructor(
+        private readonly csharpFeature: RazorCSharpFeature,
+        private readonly serviceClient: RazorLanguageServiceClient) {
+    }
+
+    public register() {
+        if (vscode.window.activeTextEditor) {
+            this.currentActiveDocument = vscode.window.activeTextEditor.document;
+        }
+
+        // There's no event in VSCode to let us know when the completion window has been dismissed.
+        // Because of this restriction we do a best effort to understand when the user has gone onto
+        // different actions (other than viewing completion).
+
+        const onDidChangeSelectionRegistration = vscode.window.onDidChangeTextEditorSelection(
+            args => this.tryRemoveProvisionalDot(args.textEditor.document));
+        const onDidChangeRegistration = vscode.workspace.onDidChangeTextDocument(async args => {
+            if (args.contentChanges.length === 1 && args.contentChanges[0].text === '.') {
+                // Don't want to remove a provisional dot that we just added.
+                return;
+            }
+
+            await this.tryRemoveProvisionalDot(args.document);
+        });
+        const onDidChangeActiveEditorRegistration = vscode.window.onDidChangeActiveTextEditor(args => {
+            if (this.currentActiveDocument) {
+                this.tryRemoveProvisionalDot(this.currentActiveDocument);
+            }
+
+            if (args) {
+                this.currentActiveDocument = args.document;
+            } else {
+                this.currentActiveDocument = undefined;
+            }
+        });
+
+        return vscode.Disposable.from(
+            onDidChangeRegistration,
+            onDidChangeSelectionRegistration,
+            onDidChangeActiveEditorRegistration);
+    }
+
+    public async tryGetProvisionalCompletions(
+        hostDocumentUri: vscode.Uri,
+        projection: ProjectionResult,
+        completionContext: vscode.CompletionContext) {
+        // We expect to be called in scenarios where the user has just typed a dot after
+        // some identifier.
+        // Such as (cursor is pipe): "DateTime.| "
+        // In this case Razor interprets after the dot as Html and before it as C#. We
+        // use this criteria to provide a better completion experience for what we call
+        // provisional changes.
+
+        if (projection.languageKind !== LanguageKind.Html) {
+            return null;
+        }
+
+        if (completionContext.triggerCharacter !== '.') {
+            return null;
+        }
+
+        const htmlPosition = projection.position;
+        if (htmlPosition.character === 0) {
+            return null;
+        }
+
+        const previousCharacterPosition = new vscode.Position(
+            htmlPosition.line,
+            htmlPosition.character - 1,
+        );
+        const previousCharacterQuery = await this.serviceClient.languageQuery(
+            previousCharacterPosition,
+            hostDocumentUri);
+
+        if (previousCharacterQuery.kind !== LanguageKind.CSharp) {
+            return null;
+        }
+
+        const projectedDocument = await this.csharpFeature.projectionProvider.getDocument(hostDocumentUri);
+        const projectedEditorDocument = await vscode.workspace.openTextDocument(projectedDocument.projectedUri);
+        const absoluteIndex = projectedEditorDocument.offsetAt(previousCharacterQuery.position);
+
+        // Edit the projected document to contain a '.'. This allows C# completion to provide valid completion items
+        // for moments when a user has typed a '.' that's typically interpreted as Html.
+        // This provisional dot is removed when one of the following is true:
+        //  1. The user starts typing
+        //  2. The user swaps active documents
+        //  3. The user selects different content
+        //  4. The projected document gets an update request
+        projectedDocument.addProvisionalDotAt(absoluteIndex);
+
+        const provisionalPosition = new vscode.Position(
+            previousCharacterQuery.position.line,
+            previousCharacterQuery.position.character + 1);
+        const completionList = await RazorCompletionItemProvider.getCompletions(
+            projectedDocument.projectedUri,
+            htmlPosition,
+            provisionalPosition,
+            completionContext.triggerCharacter);
+
+        // We track when we add provisional dots to avoid doing unnecessary work on commonly invoked events.
+        this.provisionalDotsMayBeActive = true;
+
+        return completionList;
+    }
+
+    private async tryRemoveProvisionalDot(document: vscode.TextDocument) {
+        if (!this.provisionalDotsMayBeActive) {
+            return;
+        }
+
+        if (document.languageId !== RazorLanguage.id) {
+            return;
+        }
+
+        const projectedDocument = await this.csharpFeature.projectionProvider.getActiveDocument();
+
+        if (!projectedDocument) {
+            return;
+        }
+
+        projectedDocument.removeProvisionalDot();
+        this.provisionalDotsMayBeActive = false;
+    }
+}

--- a/client/src/RPC/ServerTextSpan.ts
+++ b/client/src/RPC/ServerTextSpan.ts
@@ -7,5 +7,4 @@ export interface ServerTextSpan {
     readonly start: number;
     readonly end: number;
     readonly length: number;
-    readonly isEmpty: boolean;
 }

--- a/client/src/RazorCompletionItemProvider.ts
+++ b/client/src/RazorCompletionItemProvider.ts
@@ -4,25 +4,28 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as vscode from 'vscode';
+import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
+import { RazorHtmlFeature } from './Html/RazorHtmlFeature';
+import { ProvisionalCompletionOrchestrator } from './ProvisionalCompletionOrchestrator';
 import { RazorLanguageFeatureBase } from './RazorLanguageFeatureBase';
+import { RazorLanguageServiceClient } from './RazorLanguageServiceClient';
 
 export class RazorCompletionItemProvider
     extends RazorLanguageFeatureBase
     implements vscode.CompletionItemProvider {
 
-    public async provideCompletionItems(
-        document: vscode.TextDocument, position: vscode.Position,
-        token: vscode.CancellationToken, context: vscode.CompletionContext) {
-        const projection = await this.getProjection(document, position);
+    public static async getCompletions(
+        projectedUri: vscode.Uri, hostDocumentPosition: vscode.Position,
+        projectedPosition: vscode.Position, triggerCharacter: string | undefined) {
 
-        if (projection) {
+        if (projectedUri) {
             const completions = await vscode
                 .commands
                 .executeCommand<vscode.CompletionList | vscode.CompletionItem[]>(
                     'vscode.executeCompletionItemProvider',
-                    projection.uri,
-                    projection.position,
-                    context.triggerCharacter);
+                    projectedUri,
+                    projectedPosition,
+                    triggerCharacter);
 
             const completionItems =
                 completions instanceof Array ? completions  // was vscode.CompletionItem[]
@@ -33,14 +36,14 @@ export class RazorCompletionItemProvider
             // Therefore, we need to offset all completion items charactesr by a certain amount in order
             // to have proper completion. An example of this is typing @DateTime at the beginning of a line.
             // In the code behind it's represented as __o = DateTime.
-            const completionCharacterOffset = projection.position.character - position.character;
+            const completionCharacterOffset = projectedPosition.character - hostDocumentPosition.character;
             for (const completionItem of completionItems) {
                 if (completionItem.range) {
                     const rangeStart = new vscode.Position(
-                        position.line,
+                        hostDocumentPosition.line,
                         completionItem.range.start.character - completionCharacterOffset);
                     const rangeEnd = new vscode.Position(
-                        position.line,
+                        hostDocumentPosition.line,
                         completionItem.range.end.character - completionCharacterOffset);
                     completionItem.range = new vscode.Range(rangeStart, rangeEnd);
                 }
@@ -54,7 +57,40 @@ export class RazorCompletionItemProvider
                     : false;
             return new vscode.CompletionList(completionItems, isIncomplete);
         }
+    }
 
-        return { isIncomplete: true, items: [] } as vscode.CompletionList;
+    constructor(
+        csharpFeature: RazorCSharpFeature,
+        htmlFeature: RazorHtmlFeature,
+        serviceClient: RazorLanguageServiceClient,
+        private readonly provisionalCompletionOrchestrator: ProvisionalCompletionOrchestrator) {
+        super(csharpFeature, htmlFeature, serviceClient);
+    }
+
+    public async provideCompletionItems(
+        document: vscode.TextDocument, position: vscode.Position,
+        token: vscode.CancellationToken, context: vscode.CompletionContext) {
+        const projection = await this.getProjection(document, position);
+
+        if (!projection) {
+            return { isIncomplete: true, items: [] } as vscode.CompletionList;
+        }
+
+        const provisionalCompletions = await this.provisionalCompletionOrchestrator.tryGetProvisionalCompletions(
+            document.uri,
+            projection,
+            context);
+        if (provisionalCompletions) {
+            return provisionalCompletions;
+        }
+
+        // Not a provisional completion
+
+        const completionList = RazorCompletionItemProvider.getCompletions(
+            projection.uri,
+            position,
+            projection.position,
+            context.triggerCharacter);
+        return completionList;
     }
 }

--- a/client/src/RazorLanguageFeatureBase.ts
+++ b/client/src/RazorLanguageFeatureBase.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
 import { RazorHtmlFeature } from './Html/RazorHtmlFeature';
+import { ProjectionResult } from './ProjectionResult';
 import { RazorLanguageServiceClient } from './RazorLanguageServiceClient';
 import { LanguageKind } from './RPC/LanguageKind';
 
@@ -28,15 +29,14 @@ export class RazorLanguageFeatureBase {
                 const projectedDocument = await projectionProvider.getDocument(document.uri);
                 const projectedUri = projectedDocument.projectedUri;
 
-                return { uri: projectedUri, position: languageResponse.position } as ProjectionResult;
+                return {
+                    uri: projectedUri,
+                    position: languageResponse.position,
+                    languageKind: languageResponse.kind,
+                } as ProjectionResult;
 
             default:
                 return null;
         }
     }
-}
-
-interface ProjectionResult {
-    uri: vscode.Uri;
-    position: vscode.Position;
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { ExtensionContext } from 'vscode';
 import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
 import { RazorHtmlFeature } from './Html/RazorHtmlFeature';
+import { ProvisionalCompletionOrchestrator } from './ProvisionalCompletionOrchestrator';
 import { RazorCompletionItemProvider } from './RazorCompletionItemProvider';
 import { RazorDocumentTracker } from './RazorDocumentTracker';
 import { RazorLanguage } from './RazorLanguage';
@@ -31,10 +32,20 @@ export async function activate(context: ExtensionContext) {
     const localRegistrations: vscode.Disposable[] = [];
 
     const onStartRegistration = languageServerClient.onStart(() => {
+        const provisionalCompletionOrchestrator = new ProvisionalCompletionOrchestrator(
+            csharpFeature,
+            languageServiceClient);
+        const completionItemProvider = new RazorCompletionItemProvider(
+            csharpFeature,
+            htmlFeature,
+            languageServiceClient,
+            provisionalCompletionOrchestrator);
+
         localRegistrations.push(
+            provisionalCompletionOrchestrator.register(),
             vscode.languages.registerCompletionItemProvider(
                 RazorLanguage.id,
-                new RazorCompletionItemProvider(csharpFeature, htmlFeature, languageServiceClient),
+                completionItemProvider,
                 '.', '<'),
             projectTracker.register(),
             documentTracker.register(),


### PR DESCRIPTION
- A provisional completion is a scenario such as (cursor is pipe): "DateTime.|". In this case Razor interprets after the dot as Html and before it as C#. This causes issues in practice because if completion is triggered when a user is typing they will see Html completion for the `.`. To work around this, in this PR, we insert a temporary dot into the projected buffer and then invoke completion to provide an accurate experience.
- Provisional completions are and always have been a special case in Razor. I've special cased them in the `CSharpProjectedDocument` to keep things as simple as possible. Along these lines I've also tried to contain as much provisional completion understanding into a single class (the orchestrator) to prevent special case concepts from further leaking into new code.
- Could not test the provisional completion bits because our completion code relies on the user indirectly invoking completion through triggers by typing a dot. When using `executeCommand` the completion event is always fired as an invoked completion event and therefore our provisional completion bits don't execute properly.
- Refactored the `RazorCompletionItemProvider` to have a static `getCompletions` method that enables the provisional completion orchestrator to get customized completions.
- Added a language kind to `ProjectionResult` and lifted it into its own class.
- Updated the `getActiveDocument` call paths in C# to allow `null` because I found that when reseting provisional completions active documents weren't garunteed. After playing around with it a bit I also noticed that in general active documents can be `null`; wil do a follow up PR with the changes for the Html side of the world.

#68