### PR TITLE
Add smart indent for Html and @{...}

### DIFF
--- a/client/src/RazorLanguageConfiguration.ts
+++ b/client/src/RazorLanguageConfiguration.ts
@@ -1,0 +1,49 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { RazorLanguage } from './RazorLanguage';
+
+const VOID_ELEMENTS: string[] = [
+    'area',
+    'base',
+    'br',
+    'col',
+    'embed',
+    'hr',
+    'img',
+    'input',
+    'keygen',
+    'link',
+    'menuitem',
+    'meta',
+    'param',
+    'source',
+    'track',
+    'wbr',
+];
+
+export class RazorLanguageConfiguration {
+    public register() {
+        const configurationRegistration = vscode.languages.setLanguageConfiguration(RazorLanguage.id, {
+            wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
+            onEnterRules: [
+                {
+                    beforeText: new RegExp(
+                        `<(?!(?:${VOID_ELEMENTS.join('|')}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+                    afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>/i,
+                    action: { indentAction: vscode.IndentAction.IndentOutdent },
+                },
+                {
+                    beforeText: new RegExp(
+                        `<(?!(?:${VOID_ELEMENTS.join('|')}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+                    action: { indentAction: vscode.IndentAction.Indent },
+                },
+            ],
+        });
+
+        return configurationRegistration;
+    }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -11,6 +11,7 @@ import { ProvisionalCompletionOrchestrator } from './ProvisionalCompletionOrches
 import { RazorCompletionItemProvider } from './RazorCompletionItemProvider';
 import { RazorDocumentTracker } from './RazorDocumentTracker';
 import { RazorLanguage } from './RazorLanguage';
+import { RazorLanguageConfiguration } from './RazorLanguageConfiguration';
 import { RazorLanguageServerClient } from './RazorLanguageServerClient';
 import { resolveRazorLanguageServerOptions } from './RazorLanguageServerOptionsResolver';
 import { RazorLanguageServiceClient } from './RazorLanguageServiceClient';
@@ -23,6 +24,7 @@ export const extensionActivated = new Promise(resolve => {
 
 export async function activate(context: ExtensionContext) {
     const languageServerOptions = resolveRazorLanguageServerOptions();
+    const languageConfiguration = new RazorLanguageConfiguration();
     const languageServerClient = new RazorLanguageServerClient(languageServerOptions);
     const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
     const csharpFeature = new RazorCSharpFeature(languageServerClient);
@@ -42,6 +44,7 @@ export async function activate(context: ExtensionContext) {
             provisionalCompletionOrchestrator);
 
         localRegistrations.push(
+            languageConfiguration.register(),
             provisionalCompletionOrchestrator.register(),
             vscode.languages.registerCompletionItemProvider(
                 RazorLanguage.id,


### PR DESCRIPTION
- This is entirely based off of the in-box Razor editor support. It adds indents when typing enter inbetween `@{...}` and after Html tags.
- Could not test this feature since the functionality is based off of the act of typing (not making edits via the editor APIs).

![image](https://i.imgur.com/AycZKRX.gif)


#87 