### PR TITLE
Track open/closed/deleted state of Razor documents and its impact on projected documents.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal abstract class DocumentVersionCache
+    internal abstract class DocumentVersionCache : ProjectSnapshotChangeTrigger
     {
         public abstract bool TryGetDocumentVersion(DocumentSnapshot documentSnapshot, out long version);
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -61,10 +61,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<HostDocumentFactory, DefaultHostDocumentFactory>();
                         services.AddSingleton<ProjectSnapshotManagerAccessor, DefaultProjectSnapshotManagerAccessor>();
                         services.AddSingleton<RazorConfigurationResolver, DefaultRazorConfigurationResolver>();
-                        services.AddSingleton<ForegroundDispatcher, VSCodeForegroundDispatcher>();
+
+                        var foregroundDispatcher = new VSCodeForegroundDispatcher();
+                        services.AddSingleton<ForegroundDispatcher>(foregroundDispatcher);
                         services.AddSingleton<RazorSyntaxFactsService, DefaultRazorSyntaxFactsService>();
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
-                        services.AddSingleton<DocumentVersionCache, DefaultDocumentVersionCache>();
+                        var documentVersionCache = new DefaultDocumentVersionCache(foregroundDispatcher);
+                        services.AddSingleton<DocumentVersionCache>(documentVersionCache);
+                        services.AddSingleton<ProjectSnapshotChangeTrigger>(documentVersionCache);
                     }));
 
             await server.WaitForExit;

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpPreviewDocumentContentProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpPreviewDocumentContentProvider.ts
@@ -66,6 +66,11 @@ export class CSharpPreviewDocumentContentProvider implements vscode.TextDocument
             if (document === event.document) {
                 this.onDidChangeEmitter.fire(CSharpPreviewDocumentContentProvider.previewUri);
             }
+        } else if (
+            event.kind === RazorDocumentChangeKind.opened ||
+            event.kind === RazorDocumentChangeKind.closed) {
+            // Force refresh on the preview when a Razor document opens/closes.
+            this.onDidChangeEmitter.fire(CSharpPreviewDocumentContentProvider.previewUri);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocument.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocument.ts
@@ -24,7 +24,7 @@ export class CSharpProjectedDocument implements IProjectedDocument {
         return this.hostDocumentVersion;
     }
 
-    public update(edits: ServerTextChange[], hostDocumentVersion: number) {
+    public update(edits: ServerTextChange[], hostDocumentVersion: number | null) {
         this.removeProvisionalDot();
 
         this.hostDocumentVersion = hostDocumentVersion;

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocumentContentProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocumentContentProvider.ts
@@ -37,7 +37,8 @@ export class CSharpProjectedDocumentContentProvider implements vscode.TextDocume
     }
 
     private documentChanged(event: IRazorDocumentChangeEvent) {
-        if (event.kind === RazorDocumentChangeKind.csharpChanged) {
+        if (event.kind === RazorDocumentChangeKind.csharpChanged ||
+            event.kind === RazorDocumentChangeKind.opened) {
             this.onDidChangeEmitter.fire(event.document.csharpDocument.uri);
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlPreviewDocumentContentProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlPreviewDocumentContentProvider.ts
@@ -66,6 +66,11 @@ export class HtmlPreviewDocumentContentProvider implements vscode.TextDocumentCo
             if (document === event.document) {
                 this.onDidChangeEmitter.fire(HtmlPreviewDocumentContentProvider.previewUri);
             }
+        } else if (
+            event.kind === RazorDocumentChangeKind.opened ||
+            event.kind === RazorDocumentChangeKind.closed) {
+            // Force refresh on the preview when a Razor document opens/closes.
+            this.onDidChangeEmitter.fire(HtmlPreviewDocumentContentProvider.previewUri);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
@@ -24,7 +24,7 @@ export class HtmlProjectedDocument implements IProjectedDocument {
         return this.content;
     }
 
-    public setContent(content: string, hostDocumentVersion: number) {
+    public setContent(content: string, hostDocumentVersion: number | null) {
         this.content = content;
         this.hostDocumentVersion = hostDocumentVersion;
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocumentContentProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocumentContentProvider.ts
@@ -32,7 +32,8 @@ export class HtmlProjectedDocumentContentProvider implements vscode.TextDocument
     }
 
     private documentChanged(event: IRazorDocumentChangeEvent) {
-        if (event.kind === RazorDocumentChangeKind.htmlChanged) {
+        if (event.kind === RazorDocumentChangeKind.htmlChanged ||
+            event.kind === RazorDocumentChangeKind.opened) {
             this.onDidChangeEmitter.fire(event.document.htmlDocument.uri);
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentChangeKind.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentChangeKind.ts
@@ -6,6 +6,8 @@
 export enum RazorDocumentChangeKind {
     added,
     removed,
+    opened,
+    closed,
     csharpChanged,
     htmlChanged,
 }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
@@ -299,6 +299,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             public override void TrackDocumentVersion(DocumentSnapshot documentSnapshot, long version) => throw new NotImplementedException();
+
+            public override void Initialize(ProjectSnapshotManagerBase projectManager)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private class TestRouter : ILanguageServer

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshotManager.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshotManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
 
         }
 
-        public static ProjectSnapshotManagerBase Create(ForegroundDispatcher dispatcher)
+        public static TestProjectSnapshotManager Create(ForegroundDispatcher dispatcher)
         {
             if (dispatcher == null)
             {


### PR DESCRIPTION
- This enables us to close/re-open Razor files by resetting a projected documents sync version.
- Made `DocumentVersionCache` on the server project aware. It now listens to document removed/closed equivalent events and evicts cache entries.
- Added opened/closed `RazorDocumentChangeKind` and corresponding implementation.
- Updated C# and Html previews to understand opened/closed.

#114