### PR TITLE
Upload published Language Server binaries to blob store

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/PublishAll.targets
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/PublishAll.targets
@@ -40,14 +40,19 @@
              BuildInParallel="true" />
 
     <!-- Now build a .zip file from each platform's directory and write it to 'artifacts' -->
+    <PropertyGroup>
+      <ZipOutputDir>$(RepositoryRoot)artifacts\build\languageserver\</ZipOutputDir>
+    </PropertyGroup>
+
     <ItemGroup>
       <LanguageServiceBinaryDir Include="$([System.IO.Directory]::GetDirectories(&quot;$(RidsPublishDir)&quot;))" />
       <LanguageServiceBinary Include="@(LanguageServiceBinaryDir)">
         <SourceDir>%(LanguageServiceBinaryDir.Identity)</SourceDir>
-        <ZipFile>$(RepositoryRoot)artifacts\build\%(LanguageServiceBinaryDir.Filename)-$(PackageVersion).zip</ZipFile>
+        <ZipFile>$(ZipOutputDir)RazorLanguageServer-%(LanguageServiceBinaryDir.Filename)-$(PackageVersion).zip</ZipFile>
       </LanguageServiceBinary>
     </ItemGroup>
 
+    <MakeDir Directories="$(ZipOutputDir)" />
     <Delete Files="%(LanguageServiceBinary.ZipFile)" />
     <Exec Command="powershell.exe -NonInteractive -command &quot;&amp;{ Write-Host &quot;Writing %(LanguageServiceBinary.ZipFile)...&quot; ; Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::CreateFromDirectory('%(LanguageServiceBinary.SourceDir)', '%(LanguageServiceBinary.ZipFile)') }&quot;" />
   </Target>


### PR DESCRIPTION
The code inside this PR just creates the `.zip` files in the `artifacts` dir as part of the build.

The job of actually uploading to blob storage is handled by a VSTS Release Pipeline: https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_releases2?definitionId=1055&view=mine&_a=releases

It's currently configured to push them into a publicly-readable blob store (subscription "ASP.NET Core Test", storage account: "razorvscodetest", blob store "languageserver"). Example file: https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win10-x64-2.2.0-preview1-20180913.5.zip