### PR TITLE
Allow dll for server dll path.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -15,16 +15,11 @@ export const extensionActivated = new Promise(resolve => {
 });
 
 export async function activate(context: vscode.ExtensionContext) {
-    const ridDir = getPlatformRidDir();
-    if (!ridDir) {
-        throw new Error('Unsupported Razor platform.');
-    }
-
     // Because this extension is only used for local development and tests in CI,
     // we know the Razor Language Server is at a specific path within this repo
     const languageServerDir = path.join(
         __dirname, '..', '..', '..', 'src', 'Microsoft.AspNetCore.Razor.LanguageServer',
-        'bin', 'Debug', 'netcoreapp2.0', ridDir);
+        'bin', 'Debug', 'netcoreapp2.0');
 
     if (!fs.existsSync(languageServerDir)) {
         throw new Error('The Razor Language Server project has not yet been built - '
@@ -33,24 +28,4 @@ export async function activate(context: vscode.ExtensionContext) {
 
     await razorExtensionPackage.activate(context, languageServerDir);
     activationResolver();
-}
-
-function getPlatformRidDir() {
-    if (os.platform().match(/^win/)) {
-        if (process.env.PROCESSOR_ARCHITECTURE === 'x86' && process.env.PROCESSOR_ARCHITEW6432 === undefined) {
-            return 'win-x86';
-        } else {
-            return 'win-x64';
-        }
-    }
-
-    if (os.platform().match(/^linux/)) {
-        return 'linux-x64';
-    }
-
-    if (os.platform().match(/^darwin/)) {
-        return 'osx-x64';
-    }
-
-    return undefined;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -33,15 +33,21 @@ export class RazorLanguageServerClient implements vscode.Disposable {
             outputChannel: options.outputChannel,
         };
 
-        const args = ['-lsp'];
+        const args: string[] = [];
+        let command = options.serverPath;
+        if (options.serverPath.endsWith('.dll')) {
+            command = 'dotnet';
+            args.push(options.serverPath);
+        }
 
+        args.push('-lsp');
         if (options.debug) {
             args.push('--debug');
         }
 
         this.serverOptions = {
-            run: { command: options.serverDllPath, args },
-            debug: { command: options.serverDllPath, args },
+            run: { command, args },
+            debug: { command, args },
         };
 
         this.client = new LanguageClient(

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptions.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptions.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { Trace } from 'vscode-jsonrpc';
 
 export interface RazorLanguageServerOptions {
-    serverDllPath: string;
+    serverPath: string;
     outputChannel?: vscode.OutputChannel;
     debug?: boolean;
     trace?: Trace;

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
@@ -18,7 +18,7 @@ export function resolveRazorLanguageServerOptions(languageServerDir: string) {
     const traceString = RazorLanguage.serverConfig.get<string>('trace');
 
     return {
-        serverDllPath: languageServerExecutablePath,
+        serverPath: languageServerExecutablePath,
         debug: debugLanguageServer,
         outputChannel,
         trace: parseTraceString(traceString),
@@ -41,12 +41,24 @@ function parseTraceString(traceString: string | undefined) {
 
 function findLanguageServerExecutable(withinDir: string) {
     const extension = isWindows() ? '.exe' : '';
-    const fullPath = path.join(
+    const executablePath = path.join(
         withinDir,
         `Microsoft.AspNetCore.Razor.LanguageServer${extension}`);
+    let fullPath = '';
 
-    if (!fs.existsSync(fullPath)) {
-        throw new Error(`Could not find Razor Language Server executable at ${fullPath}`);
+    if (fs.existsSync(executablePath)) {
+        fullPath = executablePath;
+    } else {
+        // Exe doesn't exist.
+        const dllPath = path.join(
+            withinDir,
+            'Microsoft.AspNetCore.Razor.LanguageServer.dll');
+
+        if (!fs.existsSync(dllPath)) {
+            throw new Error(`Could not find Razor Language Server executable within directory '${withinDir}'`);
+        }
+
+        fullPath = dllPath;
     }
 
     return fullPath;


### PR DESCRIPTION
- At dev time we're not always publishing a Razor LanguageServer to the various RIDs; we're just building a dll. After playing around with our bootstrapper more I found that the requirement to publish repeatedly was a dev flow blocker so I reverted the changes I made to the bootstrapper extension.ts and allows it to understand a dll.
- To make this functionally work I also made changes to `RazorLanguageServerClient` to allow for a dll path and properly invoke dotnet on it. However, this approach assumes that `dotnet` is on the path. For dev time this should be fine.
- Renamed the `serverDllPath` to `serverPath` sine it can be an exe or a dll.