### PR TITLE
Add telemetry.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs';
 import * as razorExtensionPackage from 'microsoft.aspnetcore.razor.vscode';
+import { TelemetryEvent } from 'Microsoft.AspNetCore.Razor.VSCode/dist/HostEventStream';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
@@ -25,6 +26,20 @@ export async function activate(context: vscode.ExtensionContext) {
             + `could not find ${languageServerDir}`);
     }
 
-    await razorExtensionPackage.activate(context, languageServerDir);
+    const hostEventStream = {
+        post: (event: any) => {
+            if (event.constructor.name === TelemetryEvent.name) {
+                console.log(`Telemetry Event: ${event.eventName}.`);
+            } else {
+                console.log(`Unknown event: ${event.eventName}`);
+            }
+        },
+    };
+
+    await razorExtensionPackage.activate(
+        context,
+        languageServerDir,
+        hostEventStream);
+
     activationResolver();
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/DocumentTelemetryListener.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/DocumentTelemetryListener.ts
@@ -1,0 +1,30 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { RazorDocumentChangeKind } from './RazorDocumentChangeKind';
+import { RazorDocumentManager } from './RazorDocumentManager';
+import { TelemetryReporter } from './TelemetryReporter';
+
+export function reportTelemetryForDocuments(
+    documentManager: RazorDocumentManager,
+    telemetryReporter: TelemetryReporter) {
+    documentManager.onChange((event) => {
+        switch (event.kind) {
+            case RazorDocumentChangeKind.added:
+                telemetryReporter.reportWorkspaceContainsRazor();
+                break;
+            case RazorDocumentChangeKind.opened:
+                telemetryReporter.reportDocumentOpened(event.document.path);
+                break;
+            case RazorDocumentChangeKind.closed:
+                telemetryReporter.reportDocumentClosed(event.document.path);
+                break;
+            case RazorDocumentChangeKind.htmlChanged:
+                // Right now whenever the document changes the Html changes.
+                telemetryReporter.reportDocumentEdited(event.document.path);
+                break;
+        }
+    });
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/HostEventStream.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/HostEventStream.ts
@@ -1,0 +1,22 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+// Bits in this file are contracts defined in https://github.com/omnisharp/omnisharp-vscode
+
+export interface HostEventStream {
+    post(event: BaseEvent): void;
+}
+
+export class TelemetryEvent implements BaseEvent {
+    constructor(
+        public eventName: string,
+        public properties?: { [key: string]: string },
+        public measures?: { [key: string]: number }) {
+    }
+}
+
+// tslint:disable-next-line:no-empty-interface
+interface BaseEvent {
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
@@ -1,0 +1,82 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { Trace } from 'vscode-jsonrpc';
+import { HostEventStream, TelemetryEvent } from './HostEventStream';
+
+export class TelemetryReporter {
+    private readonly razorDocuments: { [hostDocumentPath: string]: boolean } = {};
+    private readonly documentOpenedEvent = new TelemetryEvent('VSCode.Razor.DocumentOpened');
+    private readonly documentClosedEvent = new TelemetryEvent('VSCode.Razor.DocumentClosed');
+    private readonly documentEditedAfterOpenEvent = new TelemetryEvent('VSCode.Razor.DocumentEditedAfterOpen');
+    private readonly razorExtensionActivated = new TelemetryEvent('VSCode.Razor.RazorExtensionActivated');
+    private readonly debugLanguageServerEvent = new TelemetryEvent('VSCode.Razor.DebugLanguageServer');
+    private readonly workspaceContainsRazorEvent = new TelemetryEvent('VSCode.Razor.WorkspaceContainsRazor');
+    private reportedWorkspaceContainsRazor = false;
+
+    constructor(
+        private readonly eventStream: HostEventStream) {
+        // If this telemetry reporter is created it means the rest of the Razor extension world was created.
+        this.eventStream.post(this.razorExtensionActivated);
+    }
+
+    public reportTraceLevel(trace: Trace) {
+        const traceLevelEvent = new TelemetryEvent(
+            'VSCode.Razor.TraceLevel',
+            {
+                trace: Trace[trace],
+            });
+        this.eventStream.post(traceLevelEvent);
+    }
+
+    public reportErrorOnServerStart(error: Error) {
+        this.reportError('VSCode.Razor.ErrorOnServerStart', error);
+    }
+
+    public reportErrorOnActivation(error: Error) {
+        this.reportError('VSCode.Razor.ErrorOnActivation', error);
+    }
+
+    public reportDebugLanguageServer() {
+        this.eventStream.post(this.debugLanguageServerEvent);
+    }
+
+    public reportWorkspaceContainsRazor() {
+        if (this.reportedWorkspaceContainsRazor) {
+            return;
+        }
+
+        this.reportedWorkspaceContainsRazor = true;
+        this.eventStream.post(this.workspaceContainsRazorEvent);
+    }
+
+    public reportDocumentOpened(path: string) {
+        this.eventStream.post(this.documentOpenedEvent);
+    }
+
+    public reportDocumentClosed(path: string) {
+        delete this.razorDocuments[path];
+        this.eventStream.post(this.documentClosedEvent);
+    }
+
+    public reportDocumentEdited(path: string) {
+        if (this.razorDocuments[path] === undefined) {
+            this.razorDocuments[path] = true;
+
+            // Only report the first edit to a document when its opened.
+            this.eventStream.post(this.documentEditedAfterOpenEvent);
+        }
+    }
+
+    private reportError(eventName: string, error: Error) {
+        const errorOnActivationEvent = new TelemetryEvent(
+            eventName,
+            {
+                error: JSON.stringify(error),
+            });
+
+        this.eventStream.post(errorOnActivationEvent);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import { ExtensionContext } from 'vscode';
 import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
+import { reportTelemetryForDocuments } from './DocumentTelemetryListener';
+import { HostEventStream } from './HostEventStream';
 import { RazorHtmlFeature } from './Html/RazorHtmlFeature';
 import { ProvisionalCompletionOrchestrator } from './ProvisionalCompletionOrchestrator';
 import { RazorCompletionItemProvider } from './RazorCompletionItemProvider';
@@ -21,66 +23,73 @@ import { RazorLanguageServiceClient } from './RazorLanguageServiceClient';
 import { RazorLogger } from './RazorLogger';
 import { RazorProjectTracker } from './RazorProjectTracker';
 import { RazorSignatureHelpProvider } from './RazorSignatureHelpProvider';
+import { TelemetryReporter } from './TelemetryReporter';
 
-export async function activate(context: ExtensionContext, languageServerDir: string) {
-    const languageServerTrace = resolveRazorLanguageServerTrace();
-    const logger = new RazorLogger(languageServerTrace);
-    const languageServerOptions = resolveRazorLanguageServerOptions(languageServerDir, languageServerTrace, logger);
-    const languageConfiguration = new RazorLanguageConfiguration();
-    const languageServerClient = new RazorLanguageServerClient(languageServerOptions, logger);
-    const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
-    const documentManager = new RazorDocumentManager(languageServerClient, logger);
-    const csharpFeature = new RazorCSharpFeature(documentManager);
-    const htmlFeature = new RazorHtmlFeature(documentManager, languageServiceClient);
-    const projectTracker = new RazorProjectTracker(languageServiceClient);
-    const documentTracker = new RazorDocumentTracker(documentManager, languageServiceClient);
-    const localRegistrations: vscode.Disposable[] = [];
+export async function activate(context: ExtensionContext, languageServerDir: string, eventStream: HostEventStream) {
+    const telemetryReporter = new TelemetryReporter(eventStream);
+    try {
+        const languageServerTrace = resolveRazorLanguageServerTrace();
+        const logger = new RazorLogger(languageServerTrace);
+        const languageServerOptions = resolveRazorLanguageServerOptions(languageServerDir, languageServerTrace, logger);
+        const languageServerClient = new RazorLanguageServerClient(languageServerOptions, telemetryReporter, logger);
+        const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
+        const documentManager = new RazorDocumentManager(languageServerClient, logger);
+        reportTelemetryForDocuments(documentManager, telemetryReporter);
+        const languageConfiguration = new RazorLanguageConfiguration();
+        const csharpFeature = new RazorCSharpFeature(documentManager);
+        const htmlFeature = new RazorHtmlFeature(documentManager, languageServiceClient);
+        const projectTracker = new RazorProjectTracker(languageServiceClient);
+        const documentTracker = new RazorDocumentTracker(documentManager, languageServiceClient);
+        const localRegistrations: vscode.Disposable[] = [];
 
-    const onStartRegistration = languageServerClient.onStart(() => {
-        const documentSynchronizer = new RazorDocumentSynchronizer(logger);
-        const provisionalCompletionOrchestrator = new ProvisionalCompletionOrchestrator(
-            documentManager,
-            csharpFeature.projectionProvider,
-            languageServiceClient,
-            logger);
-        const completionItemProvider = new RazorCompletionItemProvider(
-            documentSynchronizer,
-            documentManager,
-            languageServiceClient,
-            provisionalCompletionOrchestrator,
-            logger);
-        const signatureHelpProvider = new RazorSignatureHelpProvider(
-            documentSynchronizer,
-            documentManager,
-            languageServiceClient);
+        const onStartRegistration = languageServerClient.onStart(() => {
+            const documentSynchronizer = new RazorDocumentSynchronizer(logger);
+            const provisionalCompletionOrchestrator = new ProvisionalCompletionOrchestrator(
+                documentManager,
+                csharpFeature.projectionProvider,
+                languageServiceClient,
+                logger);
+            const completionItemProvider = new RazorCompletionItemProvider(
+                documentSynchronizer,
+                documentManager,
+                languageServiceClient,
+                provisionalCompletionOrchestrator,
+                logger);
+            const signatureHelpProvider = new RazorSignatureHelpProvider(
+                documentSynchronizer,
+                documentManager,
+                languageServiceClient);
 
-        localRegistrations.push(
-            languageConfiguration.register(),
-            provisionalCompletionOrchestrator.register(),
-            vscode.languages.registerCompletionItemProvider(
-                RazorLanguage.id,
-                completionItemProvider,
-                '.', '<', '@'),
-            vscode.languages.registerSignatureHelpProvider(
-                RazorLanguage.id,
-                signatureHelpProvider,
-                '(', ','),
-            projectTracker.register(),
-            documentManager.register(),
-            documentTracker.register(),
-            csharpFeature.register(),
-            htmlFeature.register(),
-            documentSynchronizer.register());
-    });
+            localRegistrations.push(
+                languageConfiguration.register(),
+                provisionalCompletionOrchestrator.register(),
+                vscode.languages.registerCompletionItemProvider(
+                    RazorLanguage.id,
+                    completionItemProvider,
+                    '.', '<', '@'),
+                vscode.languages.registerSignatureHelpProvider(
+                    RazorLanguage.id,
+                    signatureHelpProvider,
+                    '(', ','),
+                projectTracker.register(),
+                documentManager.register(),
+                documentTracker.register(),
+                csharpFeature.register(),
+                htmlFeature.register(),
+                documentSynchronizer.register());
+        });
 
-    const onStopRegistration = languageServerClient.onStop(() => {
-        localRegistrations.forEach(r => r.dispose());
-        localRegistrations.length = 0;
-    });
+        const onStopRegistration = languageServerClient.onStop(() => {
+            localRegistrations.forEach(r => r.dispose());
+            localRegistrations.length = 0;
+        });
 
-    await languageServerClient.start();
-    await projectTracker.initialize();
-    await documentManager.initialize();
+        await languageServerClient.start();
+        await projectTracker.initialize();
+        await documentManager.initialize();
 
-    context.subscriptions.push(languageServerClient, onStartRegistration, onStopRegistration, logger);
+        context.subscriptions.push(languageServerClient, onStartRegistration, onStopRegistration, logger);
+    } catch (error) {
+        telemetryReporter.reportErrorOnActivation(error);
+    }
 }


### PR DESCRIPTION
- Added a `TelemetryReporter` that's responsible for reporting specific types of events. Spread those reports across multiple classes.
- Added event stream abstractions to the extension to allow for telemetry posting.
- Added a host event stream for local dev

#108 

Best to review this PR with `?w=1` in the url to make it so GitHub doesn't show the whitespace diffs.

This will also require changes in omnishar-vscode's side which I have ready locally but need an official pakage to actually make a PR.