### PR TITLE
Fix _ViewImport.cshtml lookup.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class RemoteProjectItem : RazorProjectItem
+    {
+        private readonly RazorProjectItem _from;
+
+        public RemoteProjectItem(RazorProjectItem from, string physicalPath)
+        {
+            _from = from;
+            PhysicalPath = physicalPath;
+        }
+
+        public override string BasePath => _from.BasePath;
+
+        public override string FilePath => _from.FilePath;
+
+        public override string PhysicalPath { get; }
+
+        public override bool Exists => _from.Exists;
+
+        public override Stream Read() => _from.Read();
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class RemoteProjectSnapshotProjectEngineFactory : DefaultProjectSnapshotProjectEngineFactory
+    {
+        private readonly FilePathNormalizer _filePathNormalizer;
+
+        public RemoteProjectSnapshotProjectEngineFactory(
+            IFallbackProjectEngineFactory fallback,
+            Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>[] factories,
+            FilePathNormalizer filePathNormalizer) : base(fallback, factories)
+        {
+            if (fallback == null)
+            {
+                throw new ArgumentNullException(nameof(fallback));
+            }
+
+            if (factories == null)
+            {
+                throw new ArgumentNullException(nameof(factories));
+            }
+
+            if (filePathNormalizer == null)
+            {
+                throw new ArgumentNullException(nameof(filePathNormalizer));
+            }
+
+            _filePathNormalizer = filePathNormalizer;
+        }
+
+        public override RazorProjectEngine Create(
+            ProjectSnapshot project,
+            RazorProjectFileSystem fileSystem,
+            Action<RazorProjectEngineBuilder> configure)
+        {
+            var remoteFileSystem = new RemoteRazorProjectFileSystem(fileSystem, _filePathNormalizer);
+
+            return base.Create(project, remoteFileSystem, configure);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class RemoteRazorProjectFileSystem : RazorProjectFileSystem
+    {
+        private readonly RazorProjectFileSystem _inner;
+        private readonly FilePathNormalizer _filePathNormalizer;
+
+        public RemoteRazorProjectFileSystem(RazorProjectFileSystem inner, FilePathNormalizer filePathNormalizer)
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException(nameof(inner));
+            }
+
+            if (filePathNormalizer == null)
+            {
+                throw new ArgumentNullException(nameof(filePathNormalizer));
+            }
+
+            _inner = inner;
+            _filePathNormalizer = filePathNormalizer;
+        }
+
+        public override IEnumerable<RazorProjectItem> EnumerateItems(string basePath)
+        {
+            var innerItems = _inner.EnumerateItems(basePath);
+            var normalizedItems = innerItems.Select(NormalizeItem);
+
+            return normalizedItems;
+        }
+
+        public override RazorProjectItem GetItem(string path)
+        {
+            var innerItem = _inner.GetItem(path);
+            var normalizedItem = NormalizeItem(innerItem);
+
+            return normalizedItem;
+        }
+
+        private RazorProjectItem NormalizeItem(RazorProjectItem item)
+        {
+            var normalizedPhysicalPath = _filePathNormalizer.Normalize(item.PhysicalPath);
+            return new RemoteProjectItem(item, normalizedPhysicalPath);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentFactory.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentFactory.ts
@@ -36,8 +36,8 @@ function createProjectedHtmlDocument(hostDocumentUri: vscode.Uri) {
 }
 
 function createProjectedCSharpDocument(hostDocumentUri: vscode.Uri) {
-    // Index.cshtml => __Index.cshtml.cs
-    const projectedPath = `__${hostDocumentUri.path}.cs`;
+    // Index.cshtml => __Index.cshtml__virtual.cs
+    const projectedPath = `__${hostDocumentUri.path}__virtual.cs`;
     const projectedUri = vscode.Uri.parse(`${CSharpProjectedDocumentContentProvider.scheme}://${projectedPath}`);
     const projectedDocument = new CSharpProjectedDocument(projectedUri);
 

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshotManager.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshotManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -24,7 +25,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
                 throw new ArgumentNullException(nameof(dispatcher));
             }
 
-            var defaultAccessor = new DefaultProjectSnapshotManagerAccessor(dispatcher, Enumerable.Empty<ProjectSnapshotChangeTrigger>());
+            var defaultAccessor = new DefaultProjectSnapshotManagerAccessor(
+                dispatcher,
+                Enumerable.Empty<ProjectSnapshotChangeTrigger>(),
+                new FilePathNormalizer());
             var workspace = defaultAccessor.Instance.Workspace;
             var testProjectManager = new TestProjectSnapshotManager(dispatcher, workspace);
 


### PR DESCRIPTION
- Prior to this the Razor system would attempt to lookup _ViewImports.cshtml with a local file path. That local file path would be different from the normalized path we registered the remote file with. Therefore, we now override the Razor project system to normalize all file paths that are determined.
- Updated the path of the generated C# to include more than just underscores. It seems that the underscores were ignored by OmniSharp and resulted in compilation conflicts.

#145 

Mostly Razor ceremony here @SteveSandersonMS  so FYI.