### PR TITLE
Disable script project system for repo.

### DIFF
--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,8 @@
+{
+    "script": {
+        "enabled": false
+     },
+     "cake": {
+         "enabled": false
+     }
+}


### PR DESCRIPTION
- The omnisharp-roslyn submodule has CSX files that end up causing errors when used in the Razor.VSCode repo. This change disabled the script project system because it has no function in Razor.VSCode.
- Also disabled the cake project system to aid in OmniSharp startup speed.

#134

Issue ended up being an OmniSharp issue: https://github.com/OmniSharp/omnisharp-roslyn/issues/1310

Worked around it for now by disabling the Script project system.

FYI @danroth27 