### PR TITLE
Add ViewImportDependency tracking.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -188,8 +188,9 @@ export class RazorDocumentManager {
         const projectedDocument = document.csharpDocument;
 
         if (!projectedDocument.hostDocumentSyncVersion ||
-            projectedDocument.hostDocumentSyncVersion < updateBufferRequest.hostDocumentVersion) {
-
+            projectedDocument.hostDocumentSyncVersion <= updateBufferRequest.hostDocumentVersion) {
+            // We allow re-setting of the updated content from the same doc sync version in the case
+            // of project or _ViewImport.cshtml changes.
             const csharpProjectedDocument = projectedDocument as CSharpProjectedDocument;
             csharpProjectedDocument.update(updateBufferRequest.changes, updateBufferRequest.hostDocumentVersion);
 


### PR DESCRIPTION
- Prior to this whenever a ViewImport document was changed/added/removed there was a chance that documents wouldn't properly update due to ordering in network calls. This alleviates that because whenever an action occurs on a `_ViewImports.cshtml` we refresh all documents.
- Added tests to verify the new ViewImports dependency update behavior.

#174