### PR TITLE
Disable omnisharp-vscode Razor in testapps.

### DIFF
--- a/test/testapps/.vscode/settings.json
+++ b/test/testapps/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "razor.disabled": true
+}


### PR DESCRIPTION
- There are 2 extensions that enable Razor, the omnisharp-vscode one and ours. In order for them not to conflict we need to disable one of them (in this case omnisharp-vscode). This disabling still results in our dev Razor using latest omnisharp-roslyn and omnisharp-vscode bits.

#175