### PR TITLE
Don't generate C# for SystemWeb projects.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
@@ -66,6 +66,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                             () => new ProjectEngineFactory_2_1(),
                             new ExportCustomProjectEngineFactoryAttribute("MVC-2.1") { SupportsSerialization = true }),
+                        new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
+                            () => new ProjectEngineFactory_Unsupported(),
+                            new ExportCustomProjectEngineFactoryAttribute(UnsupportedRazorConfiguration.Instance.ConfigurationName) { SupportsSerialization = true }),
                     };
                     var services = AdhocServices.Create(
                         workspaceServices: new[]

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_Unsupported.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_Unsupported.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class ProjectEngineFactory_Unsupported : IProjectEngineFactory
+    {
+        public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            return RazorProjectEngine.Create(configuration, fileSystem, builder =>
+            {
+                var csharpLoweringIndex = builder.Phases.IndexOf(builder.Phases.OfType<IRazorCSharpLoweringPhase>().Single());
+                builder.Phases[csharpLoweringIndex] = new UnsupportedCSharpLoweringPhase();
+            });
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -240,6 +240,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                 return;
             }
 
+            var currentConfiguration = project.HostProject.Configuration;
+            if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName)
+            {
+                _logger.LogTrace($"Updating project '{filePath}' ignored. The project is already using configuration '{configuration.ConfigurationName}'.");
+                return;
+            }
+
             if (configuration == null)
             {
                 configuration = RazorDefaults.Configuration;

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorCodeDocumentExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorCodeDocumentExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class RazorCodeDocumentExtensions
+    {
+        private static readonly object UnsupportedKey = new object();
+
+        public static bool IsUnsupported(this RazorCodeDocument document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            var unsupportedObj = document.Items[UnsupportedKey];
+            if (unsupportedObj == null)
+            {
+                return false;
+            }
+
+            return (bool)unsupportedObj;
+        }
+
+        public static void SetUnsupported(this RazorCodeDocument document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            document.Items[UnsupportedKey] = true;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorCompletionEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorCompletionEndpoint.cs
@@ -73,6 +73,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }, CancellationToken.None, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
 
             var codeDocument = await document.GetGeneratedOutputAsync();
+
+            if (codeDocument.IsUnsupported())
+            {
+                return new CompletionList(isIncomplete: false);
+            }
+
             var syntaxTree = codeDocument.GetSyntaxTree();
 
             var sourceText = await document.GetTextAsync();

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -75,11 +75,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var sourceText = await documentSnapshot.GetTextAsync();
             var linePosition = new LinePosition((int)request.Position.Line, (int)request.Position.Character);
             var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
+            var responsePosition = request.Position;
+
+            if (codeDocument.IsUnsupported())
+            {
+                // All language queries on unsupported documents return Html. This is equivalent to what pre-VSCode Razor was capable of.
+                return new RazorLanguageQueryResponse()
+                {
+                    Kind = RazorLanguageKind.Html,
+                    Position = responsePosition,
+                    PositionIndex = hostDocumentIndex,
+                    HostDocumentVersion = documentVersion,
+                };
+            }
+
             var syntaxTree = codeDocument.GetSyntaxTree();
             var classifiedSpans = syntaxTree.GetClassifiedSpans();
             var languageKind = GetLanguageKind(classifiedSpans, hostDocumentIndex);
 
-            var responsePosition = request.Position;
             var responsePositionIndex = hostDocumentIndex;
 
             if (languageKind == RazorLanguageKind.CSharp)

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsupportedCSharpLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsupportedCSharpLoweringPhase.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class UnsupportedCSharpLoweringPhase : RazorEnginePhaseBase, IRazorCSharpLoweringPhase
+    {
+        internal const string UnsupportedDisclaimer = "// Razor CSharp output is not supported for this project's version of Razor.";
+
+        protected override void ExecuteCore(RazorCodeDocument codeDocument)
+        {
+            var documentNode = codeDocument.GetDocumentIntermediateNode();
+            ThrowForMissingDocumentDependency(documentNode);
+
+            var cSharpDocument = RazorCSharpDocument.Create(
+                UnsupportedDisclaimer,
+                documentNode.Options,
+                Enumerable.Empty<RazorDiagnostic>());
+            codeDocument.SetCSharpDocument(cSharpDocument);
+            codeDocument.SetUnsupported();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsupportedRazorConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsupportedRazorConfiguration.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class UnsupportedRazorConfiguration
+    {
+        public static readonly RazorConfiguration Instance = RazorConfiguration.Create(
+            RazorLanguageVersion.Version_1_0,
+            "UnsupportedRazor",
+            new[] { new UnsupportedRazorExtension("UnsupportedRazorExtension"), });
+
+        private class UnsupportedRazorExtension : RazorExtension
+        {
+            public UnsupportedRazorExtension(string extensionName)
+            {
+                if (extensionName == null)
+                {
+                    throw new ArgumentNullException(nameof(extensionName));
+                }
+
+                ExtensionName = extensionName;
+            }
+
+            public override string ExtensionName { get; }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net461</TargetFramework>
     <Description>Razor is a markup syntax for adding logic to pages. This package contains the Omnisharp Razor plugin that extracts Razor configuration information from projects.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    
+
     <!-- These pieces are required in order to reference OmniSharp.MSBuild -->
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
@@ -15,6 +15,7 @@
     <Compile Include="..\Microsoft.AspNetCore.Razor.LanguageServer\Serialization\*.cs">
       <Link>Serialization\%(FileName)%(Extension)</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNetCore.Razor.LanguageServer\UnsupportedRazorConfiguration.cs" Link="UnsupportedRazorConfiguration.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectLoadListener.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectLoadListener.cs
@@ -26,10 +26,11 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
         internal const string MSBuildProjectDirectoryPropertyName = "MSBuildProjectDirectory";
         internal const string RazorConfigurationFileName = "project.razor.json";
         internal const string ProjectCapabilityItemType = "ProjectCapability";
+        internal const string TargetFrameworkPropertyName = "TargetFramework";
+        internal const string TargetFrameworkVersionPropertyName = "TargetFrameworkVersion";
 
         private const string MSBuildProjectFullPathPropertyName = "MSBuildProjectFullPath";
         private const string DebugRazorOmnisharpPluginPropertyName = "_DebugRazorOmnisharpPlugin_";
-        private const string TargetFrameworkPropertyName = "TargetFramework";
         private readonly ILogger _logger;
         private readonly IEnumerable<RazorConfigurationProvider> _projectConfigurationProviders;
 
@@ -70,8 +71,8 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                     return;
                 }
 
-                var targetFramework = args.ProjectInstance.GetPropertyValue(TargetFrameworkPropertyName);
-                if (string.IsNullOrEmpty(projectFilePath))
+                var targetFramework = GetTargetFramework(args.ProjectInstance);
+                if (string.IsNullOrEmpty(targetFramework))
                 {
                     // This should never be true but we're being extra careful.
                     return;
@@ -165,6 +166,18 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
 
             path = Path.Combine(intermediateOutputPath, RazorConfigurationFileName);
             return true;
+        }
+
+        // Internal for testing
+        internal static string GetTargetFramework(ProjectInstance projectInstance)
+        {
+            var targetFramework = projectInstance.GetPropertyValue(TargetFrameworkPropertyName);
+            if (string.IsNullOrEmpty(targetFramework))
+            {
+                targetFramework = projectInstance.GetPropertyValue(TargetFrameworkVersionPropertyName);
+            }
+
+            return targetFramework;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/SystemWebConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/SystemWebConfigurationProvider.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    [Shared]
+    [Export(typeof(RazorConfigurationProvider))]
+    internal class SystemWebConfigurationProvider : CoreProjectConfigurationProvider
+    {
+        // Internal for testing
+        internal const string ReferencePathWithRefAssembliesItemType = "ReferencePathWithRefAssemblies";
+        internal const string SystemWebRazorAssemblyFileName = "System.Web.Razor.dll";
+
+        private const string LegacyRazorAssemblyName = "System.Web.Razor";
+
+        public override bool TryResolveConfiguration(RazorConfigurationProviderContext context, out RazorConfiguration configuration)
+        {
+            if (HasRazorCoreCapability(context))
+            {
+                configuration = null;
+                return false;
+            }
+
+            var compilationReferences = context.ProjectInstance.GetItems(ReferencePathWithRefAssembliesItemType);
+            string systemWebRazorReferenceFullPath = null;
+            foreach (var compilationReference in compilationReferences)
+            {
+                var assemblyFullPath = compilationReference.EvaluatedInclude;
+                if (assemblyFullPath.Length == SystemWebRazorAssemblyFileName.Length)
+                {
+                    continue;
+                }
+
+                var potentialPathSeparator = assemblyFullPath[assemblyFullPath.Length - SystemWebRazorAssemblyFileName.Length - 1];
+                if (potentialPathSeparator == '/' || potentialPathSeparator == '\\')
+                {
+                    systemWebRazorReferenceFullPath = assemblyFullPath;
+                    break;
+                }
+            }
+
+            if (systemWebRazorReferenceFullPath == null)
+            {
+                configuration = null;
+                return false;
+            }
+
+            configuration = UnsupportedRazorConfiguration.Instance;
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
@@ -5,7 +5,7 @@
 
 export interface UpdateProjectRequest {
     readonly projectFilePath: string;
-    readonly targetFramework: string;
-    readonly tagHelpers: any[];
-    readonly configuration: any;
+    readonly targetFramework?: string;
+    readonly tagHelpers?: any[];
+    readonly configuration?: any;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as vscode from 'vscode';
-import { IRazorProjectConfiguration } from './IRazorProjectConfiguration';
+import { IRazorProject } from './IRazorProject';
 import { RazorLanguageServerClient } from './RazorLanguageServerClient';
 import { AddDocumentRequest } from './RPC/AddDocumentRequest';
 import { AddProjectRequest } from './RPC/AddProjectRequest';
@@ -44,12 +44,12 @@ export class RazorLanguageServiceClient {
         await this.serverClient.sendRequest<RemoveProjectRequest>('projects/removeProject', request);
     }
 
-    public async updateProject(projectData: IRazorProjectConfiguration) {
+    public async updateProject(project: IRazorProject) {
         const request: UpdateProjectRequest = {
-            projectFilePath: projectData.projectPath,
-            tagHelpers: projectData.tagHelpers,
-            targetFramework: projectData.targetFramework,
-            configuration: projectData.configuration,
+            projectFilePath: project.uri.fsPath,
+            tagHelpers: project.configuration ? project.configuration.tagHelpers : [],
+            targetFramework: project.configuration ? project.configuration.targetFramework : undefined,
+            configuration: project.configuration ? project.configuration.configuration : undefined,
         };
         await this.serverClient.sendRequest<UpdateProjectRequest>('projects/updateProject', request);
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
@@ -87,7 +87,26 @@ export class RazorProjectManager {
     }
 
     private removeProjectConfiguration(uri: vscode.Uri) {
-        const newProject = this.createDefaultProject(uri);
+        const projectDataPath = getUriPath(uri);
+        const projects = Object.values(this.razorProjects);
+        let containingProject: IRazorProject | undefined;
+
+        for (const project of projects) {
+            if (project.configuration && project.configuration.path === projectDataPath) {
+                containingProject = project;
+                break;
+            }
+        }
+
+        if (!containingProject) {
+            // Deleted an untracked project.razor.json file, noop.
+            return;
+        }
+
+        const newProject: IRazorProject = {
+            uri: containingProject.uri,
+            path: containingProject.path,
+        };
         this.razorProjects[newProject.path] = newProject;
 
         this.notifyProjectChange(newProject, RazorProjectChangeKind.changed);

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectTracker.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectTracker.ts
@@ -26,13 +26,7 @@ export class RazorProjectTracker {
         } else if (event.kind === RazorProjectChangeKind.removed) {
             await this.languageServiceClient.removeProject(event.project.uri);
         } else if (event.kind === RazorProjectChangeKind.changed) {
-            const projectConfiguration = event.project.configuration;
-
-            if (!projectConfiguration) {
-                return;
-            }
-
-            await this.languageServiceClient.updateProject(projectConfiguration);
+            await this.languageServiceClient.updateProject(event.project);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -18,6 +18,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     public class DefaultRazorProjectServiceTest : TestBase
     {
         [Fact]
+        public void UpdateProject_SameConfigurationNoops()
+        {
+            // Arrange
+            var projectFilePath = "/C:/path/to/project.csproj";
+            var ownerProject = TestProjectSnapshot.Create(projectFilePath);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
+            projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
+                .Returns(ownerProject);
+            projectSnapshotManager.Setup(manager => manager.HostProjectChanged(It.IsAny<HostProject>()))
+                .Throws(new XunitException("Should not have been called."));
+            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
+
+            // Act & Assert
+            projectService.UpdateProject(projectFilePath, ownerProject.Configuration);
+        }
+
+        [Fact]
         public void UpdateProject_NullConfigurationUsesDefault()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectEngineFactory_UnsupportedTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectEngineFactory_UnsupportedTest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class ProjectEngineFactory_UnsupportedTest
+    {
+        [Fact]
+        public void Create_IgnoresConfigureParameter()
+        {
+            // Arrange
+            var factory = new ProjectEngineFactory_Unsupported();
+
+            // Act & Assert
+            factory.Create(UnsupportedRazorConfiguration.Instance, RazorProjectFileSystem.Empty, (builder) =>
+            {
+                throw new XunitException("There should not be an opportunity to configure the project engine in the unsupported scenario.");
+            });
+        }
+
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
+        public void Create_ProcessDesignTime_AlwaysGeneratesEmptyGeneratedCSharp()
+        {
+            // Arrange
+            var factory = new ProjectEngineFactory_Unsupported();
+            var engine = factory.Create(UnsupportedRazorConfiguration.Instance, RazorProjectFileSystem.Empty, (_) => { });
+            var sourceDocument = TestRazorSourceDocument.Create("<strong>Hello World!</strong>", RazorSourceDocumentProperties.Default);
+
+            // Act
+            var codeDocument = engine.ProcessDesignTime(sourceDocument, Array.Empty<RazorSourceDocument>(), Array.Empty<TagHelperDescriptor>());
+
+            // Assert
+            Assert.Equal(UnsupportedCSharpLoweringPhase.UnsupportedDisclaimer, codeDocument.GetCSharpDocument().GeneratedCode);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCodeDocumentExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCodeDocumentExtensionsTest.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorCodeDocumentExtensionsTest
+    {
+        [Fact]
+        public void IsUnsupported_Unset_ReturnsFalse()
+        {
+            // Arrange
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+
+            // Act
+            var result = codeDocument.IsUnsupported();
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsUnsupported_Set_ReturnsTrue()
+        {
+            // Arrange
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+            codeDocument.SetUnsupported();
+
+            // Act
+            var result = codeDocument.IsUnsupported();
+
+            // Assert
+            Assert.True(result);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
@@ -27,6 +27,29 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         // This is more of an integration test to validate that all the pieces work together
         [Fact]
+        public async Task Handle_Unsupported_NoCompletionItems()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var codeDocument = CreateCodeDocument("@");
+            codeDocument.SetUnsupported();
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, documentResolver, CompletionFactsService, LoggerFactory);
+            var request = new CompletionParams()
+            {
+                TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var completionList = await Task.Run(() => completionEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Empty(completionList);
+        }
+
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
         public async Task Handle_ResolvesDirectiveCompletionItems()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -107,6 +107,35 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
+        public async Task Handle_Unsupported_ResolvesLanguageRequest_Html()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var codeDocument = CreateCodeDocumentWithCSharpProjection(
+                "@",
+                "/* CSharp */",
+                new[] { new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12)) });
+            codeDocument.SetUnsupported();
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var request = new RazorLanguageQueryParams()
+            {
+                Uri = new Uri(documentPath),
+                Position = new Position(0, 1),
+            };
+
+            // Act
+            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.Html, response.Kind);
+            Assert.Equal(0, response.Position.Line);
+            Assert.Equal(1, response.Position.Character);
+            Assert.Equal(1337, response.HostDocumentVersion);
+        }
+
         [Fact]
         public void GetLanguageKind_CSharp()
         {
@@ -267,8 +296,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Act
             var result = RazorLanguageEndpoint.TryGetCSharpProjectedPosition(
-                codeDoc, 
-                28, 
+                codeDoc,
+                28,
                 out var projectedPosition,
                 out var projectedPositionIndex);
 
@@ -293,8 +322,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Act
             var result = RazorLanguageEndpoint.TryGetCSharpProjectedPosition(
-                codeDoc, 
-                35, 
+                codeDoc,
+                35,
                 out var projectedPosition,
                 out var projectedPositionIndex);
 

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ProjectLoadListenerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ProjectLoadListenerTest.cs
@@ -16,6 +16,65 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
     public class ProjectLoadListenerTest
     {
         [Fact]
+        public void GetTargetFramework_ReturnsTargetFramework()
+        {
+            // Arrange
+            var expectedTFM = "net461";
+            var projectInstance = new ProjectInstance(ProjectRootElement.Create());
+            projectInstance.SetProperty(ProjectLoadListener.TargetFrameworkPropertyName, expectedTFM);
+
+            // Act
+            var tfm = ProjectLoadListener.GetTargetFramework(projectInstance);
+
+            // Assert
+            Assert.Equal(expectedTFM, tfm);
+        }
+
+        [Fact]
+        public void GetTargetFramework_NoTFM_ReturnsTargetFrameworkVersion()
+        {
+            // Arrange
+            var expectedTFM = "v4.6.1";
+            var projectInstance = new ProjectInstance(ProjectRootElement.Create());
+            projectInstance.SetProperty(ProjectLoadListener.TargetFrameworkVersionPropertyName, expectedTFM);
+
+            // Act
+            var tfm = ProjectLoadListener.GetTargetFramework(projectInstance);
+
+            // Assert
+            Assert.Equal(expectedTFM, tfm);
+        }
+
+        [Fact]
+        public void GetTargetFramework_PrioritizesTargetFrameworkOverVersion()
+        {
+            // Arrange
+            var expectedTFM = "v4.6.1";
+            var projectInstance = new ProjectInstance(ProjectRootElement.Create());
+            projectInstance.SetProperty(ProjectLoadListener.TargetFrameworkPropertyName, expectedTFM);
+            projectInstance.SetProperty(ProjectLoadListener.TargetFrameworkVersionPropertyName, "Unexpected");
+
+            // Act
+            var tfm = ProjectLoadListener.GetTargetFramework(projectInstance);
+
+            // Assert
+            Assert.Equal(expectedTFM, tfm);
+        }
+
+        [Fact]
+        public void GetTargetFramework_NoTFM_ReturnsEmpty()
+        {
+            // Arrange
+            var projectInstance = new ProjectInstance(ProjectRootElement.Create());
+
+            // Act
+            var tfm = ProjectLoadListener.GetTargetFramework(projectInstance);
+
+            // Assert
+            Assert.Empty(tfm);
+        }
+
+        [Fact]
         public void GetRazorConfiguration_ProvidersReturnsTrue_ReturnsConfig()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/SystemWebConfigurationProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/SystemWebConfigurationProviderTest.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    public class SystemWebConfigurationProviderTest
+    {
+        [Fact]
+        public void TryResolveConfiguration_RazorCoreCapability_ReturnsFalse()
+        {
+            // Arrange
+            var projectCapabilities = new[]
+            {
+                CoreProjectConfigurationProvider.DotNetCoreRazorCapability,
+            };
+            var projectInstance = new ProjectInstance(ProjectRootElement.Create());
+            projectInstance.AddItem(SystemWebConfigurationProvider.ReferencePathWithRefAssembliesItemType, SystemWebConfigurationProvider.SystemWebRazorAssemblyFileName);
+            var context = new RazorConfigurationProviderContext(projectCapabilities, projectInstance);
+            var provider = new SystemWebConfigurationProvider();
+
+            // Act
+            var result = provider.TryResolveConfiguration(context, out var configuration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(configuration);
+        }
+
+        [Fact]
+        public void TryResolveConfiguration_NoSystemWebRazorReference_ReturnsFalse()
+        {
+            // Arrange
+            var context = BuildContext("/some/path/to/some.dll");
+            var provider = new SystemWebConfigurationProvider();
+
+            // Act
+            var result = provider.TryResolveConfiguration(context, out var configuration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(configuration);
+        }
+
+        [Fact]
+        public void TryResolveConfiguration_MvcWithVersion_ReturnsTrue()
+        {
+            // Arrange
+            var context = BuildContext("/some/path/to/some.dll", "/another/path/to/" + SystemWebConfigurationProvider.SystemWebRazorAssemblyFileName);
+            var provider = new SystemWebConfigurationProvider();
+
+            // Act
+            var result = provider.TryResolveConfiguration(context, out var configuration);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(UnsupportedRazorConfiguration.Instance, configuration);
+        }
+
+        private RazorConfigurationProviderContext BuildContext(params string[] referencePaths)
+        {
+            var projectInstance = new ProjectInstance(ProjectRootElement.Create());
+            foreach (var path in referencePaths)
+            {
+                projectInstance.AddItem(SystemWebConfigurationProvider.ReferencePathWithRefAssembliesItemType, path);
+            }
+            var context = new RazorConfigurationProviderContext(Array.Empty<string>(), projectInstance);
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
- This involved creating an Unsupported Razor configuration that adds a disclaimer to the generated Razor C# but refuses to do any other calculations.
- Added some extensions to allow us to understand when we're operating in an "unsupported" scenario. This means the server's API endpoints have some knowledge of being unsupported but the client code doesn't need to know anything. For instance, our language query endpoint forces Html always when working with unsupported documents; this is consistent with how VSCode used to operate.
- Added a SystemWeb plugin component that looks for `System.Web.Razor.dll` and uses that to determine if a project targets the old ASP.NET world. In the case that it does the SystemWeb plugin piece sets the project configuration to Unsupported.
- Added tests for all of the various components that were added.

#184