### PR TITLE
Report project info in telemetry.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -30,6 +30,10 @@ export async function activate(context: vscode.ExtensionContext) {
         post: (event: any) => {
             if (event.constructor.name === TelemetryEvent.name) {
                 console.log(`Telemetry Event: ${event.eventName}.`);
+                if (event.properties) {
+                    const propertiesString = JSON.stringify(event.properties, null, 2);
+                    console.log(propertiesString);
+                }
             } else {
                 console.log(`Unknown event: ${event.eventName}`);
             }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/ProjectTelemetryListener.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/ProjectTelemetryListener.ts
@@ -1,0 +1,20 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { RazorProjectChangeKind } from './RazorProjectChangeKind';
+import { RazorProjectManager } from './RazorProjectManager';
+import { TelemetryReporter } from './TelemetryReporter';
+
+export function reportTelemetryForProjects(
+    projectManager: RazorProjectManager,
+    telemetryReporter: TelemetryReporter) {
+    projectManager.onChange((event) => {
+        switch (event.kind) {
+            case RazorProjectChangeKind.changed:
+                telemetryReporter.reportProjectInfo(event.project);
+                break;
+        }
+    });
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -9,6 +9,7 @@ import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
 import { reportTelemetryForDocuments } from './DocumentTelemetryListener';
 import { HostEventStream } from './HostEventStream';
 import { RazorHtmlFeature } from './Html/RazorHtmlFeature';
+import { reportTelemetryForProjects } from './ProjectTelemetryListener';
 import { ProvisionalCompletionOrchestrator } from './ProvisionalCompletionOrchestrator';
 import { RazorCompletionItemProvider } from './RazorCompletionItemProvider';
 import { RazorDocumentManager } from './RazorDocumentManager';
@@ -35,8 +36,9 @@ export async function activate(context: ExtensionContext, languageServerDir: str
         const languageServerClient = new RazorLanguageServerClient(languageServerOptions, telemetryReporter, logger);
         const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
         const documentManager = new RazorDocumentManager(languageServerClient, logger);
-        const projectManager = new RazorProjectManager(logger);
         reportTelemetryForDocuments(documentManager, telemetryReporter);
+        const projectManager = new RazorProjectManager(logger);
+        reportTelemetryForProjects(projectManager, telemetryReporter);
         const languageConfiguration = new RazorLanguageConfiguration();
         const csharpFeature = new RazorCSharpFeature(documentManager);
         const htmlFeature = new RazorHtmlFeature(documentManager, languageServiceClient);


### PR DESCRIPTION
- Add a `ProjectTelemetryListener` which listens for `RazorProjectManager` changes and reports telemetry events.
- Reported telemetry is only reported for significant project changes that result in Razor's project configurations bieng significantly different.
- Update extension shim to log additional telemetry event data.

#194