### PR TITLE
Add non-component Blazor support.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20180911.2</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.6.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-alpha1-10495</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-alpha1-10495</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10495</MicrosoftAspNetCoreTestingPackageVersion>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
@@ -69,6 +69,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                             () => new ProjectEngineFactory_Unsupported(),
                             new ExportCustomProjectEngineFactoryAttribute(UnsupportedRazorConfiguration.Instance.ConfigurationName) { SupportsSerialization = true }),
+                        new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
+                            () => new ProjectEngineFactory_Blazor(),
+                            new ExportCustomProjectEngineFactoryAttribute("Blazor-0.1") { SupportsSerialization = false }),
                     };
                     var services = AdhocServices.Create(
                         workspaceServices: new[]

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="$(MicrosoftCodeAnalysisRazorWorkspacesPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Razor.Extensions" Version="$(MicrosoftAspNetCoreBlazorExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_Blazor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_Blazor.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Blazor.Razor;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    // This is a verbatim copy of Blazor's project engine implementation.
+
+    internal class ProjectEngineFactory_Blazor : IProjectEngineFactory
+    {
+        public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            return RazorProjectEngine.Create(configuration, fileSystem, b =>
+            {
+                configure?.Invoke(b);
+                new BlazorExtensionInitializer().Initialize(b);
+
+                var classifier = b.Features.OfType<ComponentDocumentClassifierPass>().Single();
+                classifier.MangleClassNames = true;
+            });
+        }
+    }
+}

--- a/test/testapps/Directory.Build.props
+++ b/test/testapps/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>


### PR DESCRIPTION
- One of the caveats with this approach is that you end up getting errors on components which are trying to bind event handlers. i.e. `<Counter onclick="@IncrementCount" />`. You get an error stating that you cannot convert a method delegate to object. This is because in non-component scenarios that line is understood as `__o = IncrementCount` where `IncrementCount` is a void returning method.
- Made the experimental language version round trippable once serialized.
- Added the Blazor ProjectEngine to the list of supported VSCode Razor project types.
- Noticed that our testapp projects were incorrectly inheriting our test package references (Xunit and the like).

IF you're viewing a file that uses a component that attaches an event handler via `@SomeMethodHandle` you get the following error:
![image](https://user-images.githubusercontent.com/2008729/47176934-bb74fb00-d2cb-11e8-8af5-de192fc12ada.png)

Otherwise, you get Blazor specific C#/directive completion throughout the document like normal i.e. 
![image](https://user-images.githubusercontent.com/2008729/47177010-0bec5880-d2cc-11e8-87a6-ffa75a7a4390.png)


@danroth27 / @SteveSandersonMS  / @rynowak  you guys need to decide if we should have this non-component Blazor support or force Blazor to have 0 C# completion like a Legacy app, i.e.
![image](https://user-images.githubusercontent.com/2008729/47177114-64235a80-d2cc-11e8-9ff4-5511bd09edb2.png)


#193