### PR TITLE
Normalize project.razor.json write-to file path.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectLoadListener.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectLoadListener.cs
@@ -164,6 +164,9 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 intermediateOutputPath = Path.Combine(projectDirectory, intermediateOutputPath);
             }
 
+            intermediateOutputPath = intermediateOutputPath
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
             path = Path.Combine(intermediateOutputPath, RazorConfigurationFileName);
             return true;
         }

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ProjectLoadListenerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ProjectLoadListenerTest.cs
@@ -134,6 +134,26 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
         }
 
         [Fact]
+        public void TryResolveConfigurationOutputPath_MSBuildIntermediateOutputPath_Normalizes()
+        {
+            // Arrange
+            var projectRootElement = ProjectRootElement.Create();
+
+            // Note the ending \ here that gets normalized away.
+            var intermediateOutputPath = "C:/project\\obj";
+            projectRootElement.AddProperty(ProjectLoadListener.IntermediateOutputPathPropertyName, intermediateOutputPath);
+            var projectInstance = new ProjectInstance(projectRootElement);
+            var expectedPath = string.Format("C:{0}project{0}obj{0}{1}", Path.DirectorySeparatorChar, ProjectLoadListener.RazorConfigurationFileName);
+
+            // Act
+            var result = ProjectLoadListener.TryResolveConfigurationOutputPath(projectInstance, out var path);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedPath, path);
+        }
+
+        [Fact]
         public void TryResolveConfigurationOutputPath_NoIntermediateOutputPath_ReturnsFalse()
         {
             // Arrange
@@ -153,7 +173,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
         {
             // Arrange
             var projectRootElement = ProjectRootElement.Create();
-            var intermediateOutputPath = "C:\\project\\obj";
+            var intermediateOutputPath = string.Format("C:{0}project{0}obj", Path.DirectorySeparatorChar);
             projectRootElement.AddProperty(ProjectLoadListener.IntermediateOutputPathPropertyName, intermediateOutputPath);
             var projectInstance = new ProjectInstance(projectRootElement);
             var expectedPath = Path.Combine(intermediateOutputPath, ProjectLoadListener.RazorConfigurationFileName);


### PR DESCRIPTION
- Prior to this, on OSX we wouldn't generate any project.razor.json files because the file names we'd determine would be invalid on OSX because MSBuild would return us a `\` based path.
- Added a test to verify normalization.