### PR TITLE
Re-design document synchronization.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocument.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocument.ts
@@ -15,6 +15,7 @@ export class CSharpProjectedDocument implements IProjectedDocument {
     private preProvisionalContent: string | undefined;
     private provisionalEditAt: number | undefined;
     private hostDocumentVersion: number | null = null;
+    private projectedDocumentVersion = 0;
 
     public constructor(public readonly uri: vscode.Uri) {
         this.path = getUriPath(uri);
@@ -22,6 +23,10 @@ export class CSharpProjectedDocument implements IProjectedDocument {
 
     public get hostDocumentSyncVersion(): number | null {
         return this.hostDocumentVersion;
+    }
+
+    public get projectedDocumentSyncVersion(): number {
+        return this.projectedDocumentVersion;
     }
 
     public update(edits: ServerTextChange[], hostDocumentVersion: number | null) {
@@ -85,6 +90,7 @@ export class CSharpProjectedDocument implements IProjectedDocument {
     }
 
     private setContent(content: string) {
+        this.projectedDocumentVersion++;
         this.content = content;
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocumentContentProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocumentContentProvider.ts
@@ -27,7 +27,8 @@ export class CSharpProjectedDocumentContentProvider implements vscode.TextDocume
             return;
         }
 
-        const content = razorDocument.csharpDocument.getContent();
+        const content = `${razorDocument.csharpDocument.getContent()}
+// ${razorDocument.csharpDocument.projectedDocumentSyncVersion}`;
 
         return content;
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
@@ -11,6 +11,7 @@ export class HtmlProjectedDocument implements IProjectedDocument {
     public readonly path: string;
     private content = '';
     private hostDocumentVersion: number | null = null;
+    private projectedDocumentVersion = 0;
 
     public constructor(public readonly uri: vscode.Uri) {
         this.path = getUriPath(uri);
@@ -20,12 +21,17 @@ export class HtmlProjectedDocument implements IProjectedDocument {
         return this.hostDocumentVersion;
     }
 
+    public get projectedDocumentSyncVersion(): number {
+        return this.projectedDocumentVersion;
+    }
+
     public getContent() {
         return this.content;
     }
 
     public setContent(content: string, hostDocumentVersion: number | null) {
-        this.content = content;
+        this.projectedDocumentVersion++;
         this.hostDocumentVersion = hostDocumentVersion;
+        this.content = content;
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocumentContentProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocumentContentProvider.ts
@@ -27,7 +27,9 @@ export class HtmlProjectedDocumentContentProvider implements vscode.TextDocument
             return;
         }
 
-        const content = razorDocument.htmlDocument.getContent();
+        const content = `${razorDocument.htmlDocument.getContent()}
+// ${razorDocument.htmlDocument.projectedDocumentSyncVersion}`;
+
         return content;
     }
 

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/IProjectedDocument.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/IProjectedDocument.ts
@@ -9,5 +9,6 @@ export interface IProjectedDocument {
     readonly path: string;
     readonly uri: vscode.Uri;
     readonly hostDocumentSyncVersion: number | null;
+    readonly projectedDocumentSyncVersion: number;
     getContent(): string;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCompletionItemProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCompletionItemProvider.ts
@@ -73,7 +73,7 @@ export class RazorCompletionItemProvider
     public async provideCompletionItems(
         document: vscode.TextDocument, position: vscode.Position,
         token: vscode.CancellationToken, context: vscode.CompletionContext) {
-        const projection = await this.getProjection(document, position);
+        const projection = await this.getProjection(document, position, token);
 
         if (this.logger.verboseEnabled) {
             this.logger.logVerbose(`Providing completions for document ${getUriPath(document.uri)} ` +

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentFactory.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentFactory.ts
@@ -27,8 +27,8 @@ export function createDocument(uri: vscode.Uri) {
 }
 
 function createProjectedHtmlDocument(hostDocumentUri: vscode.Uri) {
-    // Index.cshtml => __Index.cshtml.html
-    const projectedPath = `__${hostDocumentUri.path}.html`;
+    // Index.cshtml => Index.cshtml__virtual.html
+    const projectedPath = `${hostDocumentUri.path}__virtual.html`;
     const projectedUri = vscode.Uri.parse(`${HtmlProjectedDocumentContentProvider.scheme}://${projectedPath}`);
     const projectedDocument = new HtmlProjectedDocument(projectedUri);
 
@@ -36,8 +36,8 @@ function createProjectedHtmlDocument(hostDocumentUri: vscode.Uri) {
 }
 
 function createProjectedCSharpDocument(hostDocumentUri: vscode.Uri) {
-    // Index.cshtml => __Index.cshtml__virtual.cs
-    const projectedPath = `__${hostDocumentUri.path}__virtual.cs`;
+    // Index.cshtml => Index.cshtml__virtual.cs
+    const projectedPath = `${hostDocumentUri.path}__virtual.cs`;
     const projectedUri = vscode.Uri.parse(`${CSharpProjectedDocumentContentProvider.scheme}://${projectedPath}`);
     const projectedDocument = new CSharpProjectedDocument(projectedUri);
 

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentSynchronizer.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentSynchronizer.ts
@@ -5,183 +5,271 @@
 
 import * as vscode from 'vscode';
 
+import { CSharpProjectedDocumentContentProvider } from './CSharp/CSharpProjectedDocumentContentProvider';
+import { HtmlProjectedDocumentContentProvider } from './Html/HtmlProjectedDocumentContentProvider';
 import { IProjectedDocument } from './IProjectedDocument';
 import { IRazorDocumentChangeEvent } from './IRazorDocumentChangeEvent';
 import { RazorDocumentChangeKind } from './RazorDocumentChangeKind';
 import { RazorDocumentManager } from './RazorDocumentManager';
-import { RazorLanguage } from './RazorLanguage';
 import { RazorLogger } from './RazorLogger';
 import { getUriPath } from './UriPaths';
 
 export class RazorDocumentSynchronizer {
-    private readonly synchronizations: { [uri: string]: SynchronizationContext } = {};
+    private readonly synchronizations: { [uri: string]: SynchronizationContext[] } = {};
     private synchronizationIdentifier = 0;
 
     constructor(
-        documentManager: RazorDocumentManager,
+        private readonly documentManager: RazorDocumentManager,
         private readonly logger: RazorLogger) {
-        documentManager.onChange((event) => this.documentChanged(event));
     }
 
     public register() {
-        const changeRegistration = vscode.workspace.onDidChangeTextDocument((args) => {
-            if (args.document.languageId !== RazorLanguage.id) {
-                return;
-            }
+        const documentManagerRegistration = this.documentManager.onChange(
+            event => this.documentChanged(event));
+        const textDocumentChangeRegistration = vscode.workspace.onDidChangeTextDocument(
+            event => this.textDocumentChanged(event));
 
-            const uriPath = getUriPath(args.document.uri);
-            const context = this.synchronizations[uriPath];
-
-            if (context && args.document.version >= context.documentVersion) {
-                if (this.logger.verboseEnabled) {
-                    this.logger.logVerbose(
-                        `${context.logIdentifier} - Notify Success: Host document updated to equivalent version.`);
-                }
-                context.synchronized(true);
-            }
-        });
-
-        return changeRegistration;
+        return vscode.Disposable.from(documentManagerRegistration, textDocumentChangeRegistration);
     }
 
-    public async trySynchronize(
+    public async trySynchronizeProjectedDocument(
         hostDocument: vscode.TextDocument,
         projectedDocument: IProjectedDocument,
-        toVersion: number) {
-        const logIdentifier = this.synchronizationIdentifier++;
+        expectedHostDocumentVersion: number,
+        token: vscode.CancellationToken) {
+
+        const logId = ++this.synchronizationIdentifier;
+
+        const documentKey = getUriPath(projectedDocument.uri);
+        if (this.logger.verboseEnabled) {
+            const ehdv = expectedHostDocumentVersion;
+            this.logger.logVerbose(
+                `${logId} - Synchronizing '${documentKey}':
+    Currently at ${projectedDocument.hostDocumentSyncVersion}, synchronizing to version '${ehdv}'.
+    Current host document version: '${hostDocument.version}'
+    Current projected document version: '${projectedDocument.projectedDocumentSyncVersion}'`);
+        }
+
+        if (hostDocument.version !== expectedHostDocumentVersion) {
+            if (this.logger.verboseEnabled) {
+                this.logger.logVerbose(
+                    `${logId} - toHostDocumentVersion and hostDocument.version already out of date.`);
+            }
+
+            // Already out-of-date. Allowing synchronizations for now to see if this actually causes any issues.
+        }
+
+        const context: SynchronizationContext = this.createSynchronizationContext(
+            documentKey,
+            projectedDocument,
+            expectedHostDocumentVersion,
+            hostDocument,
+            token);
+
+        try {
+            if (projectedDocument.hostDocumentSyncVersion !== expectedHostDocumentVersion) {
+                if (this.logger.verboseEnabled) {
+                    this.logger.logVerbose(
+                        `${logId} - Projected document not in sync with host document, waiting for update...
+    Current host document sync version: ${projectedDocument.hostDocumentSyncVersion}`);
+                }
+                await context.onProjectedDocumentSynchronized;
+            }
+
+            if (this.logger.verboseEnabled) {
+                this.logger.logVerbose(
+                    `${logId} - Projected document in sync with host document`);
+            }
+
+            // Projected document is the one we expect.
+
+            const projectedTextDocument = await vscode.workspace.openTextDocument(projectedDocument.uri);
+            const projectedTextDocumentVersion = this.getProjectedTextDocumentVersion(projectedTextDocument);
+            if (projectedDocument.projectedDocumentSyncVersion !== projectedTextDocumentVersion) {
+                if (this.logger.verboseEnabled) {
+                    this.logger.logVerbose(
+                        `${logId} - Projected text document not in sync with data type, waiting for update...
+    Current projected text document sync version: ${projectedTextDocumentVersion}`);
+                }
+                await context.onProjectedTextDocumentSynchronized;
+            }
+
+            if (this.logger.verboseEnabled) {
+                this.logger.logVerbose(
+                    `${logId} - Projected text document in sync with data type`);
+            }
+
+            // Projected text document is the one we expect
+        } catch (cancellationReason) {
+            this.removeSynchronization(context);
+
+            if (this.logger.verboseEnabled) {
+                this.logger.logVerbose(
+                    `${logId} - Synchronization failed: ${cancellationReason}`);
+            }
+
+            return false;
+        }
+
+        this.removeSynchronization(context);
 
         if (this.logger.verboseEnabled) {
-            this.logger.logVerbose(`${logIdentifier} - Synchronizing '${getUriPath(projectedDocument.uri)}' ` +
-                `currently at ${projectedDocument.hostDocumentSyncVersion} to version '${toVersion}'. ` +
-                `Current host document version: '${hostDocument.version}'`);
+            this.logger.logVerbose(
+                `${logId} - Synchronization successful!`);
         }
 
-        if (projectedDocument.hostDocumentSyncVersion === hostDocument.version) {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(
-                    `${logIdentifier} - Success: Projected document and host document already synchronized.`);
-            }
+        return true;
+    }
 
-            // Already synchronized
-            return true;
+    private removeSynchronization(context: SynchronizationContext) {
+        const documentKey = getUriPath(context.projectedDocument.uri);
+        const synchronizations = this.synchronizations[documentKey];
+        clearTimeout(context.timeoutId);
+
+        if (synchronizations.length === 1) {
+            delete this.synchronizations[documentKey];
+            return;
         }
 
-        if (toVersion !== hostDocument.version) {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(
-                    `${logIdentifier} - Failed: toVersion and host document version already out of date.`);
-            }
+        this.synchronizations[documentKey] = synchronizations.filter(item => item !== context);
+    }
 
-            // Already out-of-date. Failed to synchronize.
-            return false;
-        }
+    private createSynchronizationContext(
+        documentKey: string,
+        projectedDocument: IProjectedDocument,
+        toHostDocumentVersion: number,
+        hostDocument: vscode.TextDocument,
+        token: vscode.CancellationToken) {
 
-        let synchronized: (success: boolean) => void;
-        const uriPath = getUriPath(hostDocument.uri);
-
-        let synchronizationContext = this.synchronizations[uriPath];
-        if (synchronizationContext) {
-            // Already a synchronization for this document.
-
-            if (synchronizationContext.toVersion < toVersion) {
-                // Currently tracked synchronization is older than the requeseted.
-                // Mark old one as failed.
-                if (this.logger.verboseEnabled) {
-                    this.logger.logVerbose(`${logIdentifier} - Notify Failed: Newer synchronization request came in.`);
-                }
-                synchronizationContext.synchronized(false);
-            } else {
-                // The already tracked synchronization is sufficient.
-                return synchronizationContext.onSynchronized;
-            }
-        }
-
-        const onSynchronized = new Promise<boolean>((resolve) => {
-            synchronized = resolve;
+        const rejectionsForCancel: Array<(reason: string) => void> = [];
+        let projectedDocumentSynchronized: () => void = Function;
+        const onProjectedDocumentSynchronized = new Promise<void>((resolve, reject) => {
+            projectedDocumentSynchronized = resolve;
+            rejectionsForCancel.push(reject);
         });
-        const timeout = setTimeout(() => {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(`${logIdentifier} - Notify Failed: Synchronization timed out.`);
-            }
-            synchronizationContext.synchronized(false);
-        }, 500);
-        synchronizationContext = {
-            logIdentifier,
-            toVersion,
-            documentVersion: hostDocument.version,
-            synchronized: (s) => {
-                delete this.synchronizations[uriPath];
-                clearTimeout(timeout);
-                synchronized(s);
+        let projectedTextDocumentSynchronized: () => void = Function;
+        const onProjectedTextDocumentSynchronized = new Promise<void>((resolve, reject) => {
+            projectedTextDocumentSynchronized = resolve;
+            rejectionsForCancel.push(reject);
+        });
+
+        token.onCancellationRequested((reason) => {
+            context.cancel(`Token cancellation requested: ${reason}`);
+        });
+        const timeoutId = setTimeout(() => {
+            context.cancel('Synchronization timed out');
+        }, 2000);
+        const context: SynchronizationContext = {
+            projectedDocument,
+            logIdentifier: this.synchronizationIdentifier,
+            timeoutId,
+            toHostDocumentVersion,
+            hostDocumentVersion: hostDocument.version,
+            cancel: (reason) => {
+                for (const reject of rejectionsForCancel) {
+                    reject(reason);
+                }
             },
-            onSynchronized,
+            projectedDocumentSynchronized,
+            onProjectedDocumentSynchronized,
+            projectedTextDocumentSynchronized,
+            onProjectedTextDocumentSynchronized,
         };
-        this.synchronizations[uriPath] = synchronizationContext;
 
-        const success = await onSynchronized;
-
-        if (success && projectedDocument.hostDocumentSyncVersion !== hostDocument.version) {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(`${logIdentifier} - Failed: User moved on.`);
-            }
-
-            // Already out-of-date, failed to synchronize.
-            return false;
+        let synchronizations = this.synchronizations[documentKey];
+        if (!synchronizations) {
+            synchronizations = [];
+            this.synchronizations[documentKey] = synchronizations;
         }
 
-        if (success) {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(`${logIdentifier} - Success: Documents synchronized to version ${toVersion}.`);
-            }
+        synchronizations.push(context);
 
-            return true;
-        } else {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(`${logIdentifier} - Failed: Documents not synchronized ${toVersion}.`);
-            }
+        return context;
+    }
 
-            return false;
+    private textDocumentChanged(event: vscode.TextDocumentChangeEvent) {
+        if (event.document.uri.scheme !== CSharpProjectedDocumentContentProvider.scheme &&
+            event.document.uri.scheme !== HtmlProjectedDocumentContentProvider.scheme) {
+            return;
+        }
+
+        const projectedTextDocumentVersion = this.getProjectedTextDocumentVersion(event.document);
+        if (projectedTextDocumentVersion === null) {
+            return;
+        }
+
+        const documentKey = getUriPath(event.document.uri);
+        const synchronizationContexts = this.synchronizations[documentKey];
+
+        if (!synchronizationContexts) {
+            return;
+        }
+
+        for (const context of synchronizationContexts) {
+            if (context.projectedDocument.projectedDocumentSyncVersion === projectedTextDocumentVersion) {
+                if (this.logger.verboseEnabled) {
+                    const li = context.logIdentifier;
+                    const ptdv = projectedTextDocumentVersion;
+                    this.logger.logVerbose(`${li} - Projected text document synchronized to ${ptdv}.`);
+                }
+                context.projectedTextDocumentSynchronized();
+            }
         }
     }
 
     private documentChanged(event: IRazorDocumentChangeEvent) {
+        let projectedDocument: IProjectedDocument;
         if (event.kind === RazorDocumentChangeKind.csharpChanged) {
-            const uriPath = getUriPath(event.document.uri);
-            const context = this.synchronizations[uriPath];
-            const csharpDocument = event.document.csharpDocument;
-
-            if (csharpDocument.hostDocumentSyncVersion === null) {
-                return;
-            }
-
-            if (context && csharpDocument.hostDocumentSyncVersion >= context.documentVersion) {
-                if (this.logger.verboseEnabled) {
-                    this.logger.logVerbose(
-                        `${context.logIdentifier} - Notify Success: CSharp updated to ${context.documentVersion}.`);
-                }
-                context.synchronized(true);
-            }
-        } else if (event.kind === RazorDocumentChangeKind.closed) {
-            const uriPath = getUriPath(event.document.uri);
-            const context = this.synchronizations[uriPath];
-
-            if (context) {
-                if (this.logger.verboseEnabled) {
-                    this.logger.logVerbose(
-                        `${context.logIdentifier} - Notify Failed: Document closed.`);
-                }
-
-                context.synchronized(false);
-            }
-
+            projectedDocument = event.document.csharpDocument;
+        } else if (event.kind === RazorDocumentChangeKind.htmlChanged) {
+            projectedDocument = event.document.htmlDocument;
+        } else {
+            return;
         }
+
+        const hostDocumentSyncVersion = projectedDocument.hostDocumentSyncVersion;
+        if (hostDocumentSyncVersion === null) {
+            return;
+        }
+
+        const documentKey = getUriPath(projectedDocument.uri);
+        const synchronizationContexts = this.synchronizations[documentKey];
+        if (!synchronizationContexts) {
+            return;
+        }
+
+        for (const context of synchronizationContexts) {
+            if (context.toHostDocumentVersion === projectedDocument.hostDocumentSyncVersion) {
+                context.projectedDocumentSynchronized();
+            }
+        }
+    }
+
+    private getProjectedTextDocumentVersion(textDocument: vscode.TextDocument) {
+        // Logic defined in this method is heavily dependent on the functionality in the projected
+        // document content providers to append versions to the end of text documents.
+
+        if (textDocument.lineCount <= 0) {
+            return null;
+        }
+
+        const lastLine = textDocument.lineAt(textDocument.lineCount - 1);
+        const versionString = lastLine.text.substring(3 /* //_ */);
+        const textDocumentProjectedVersion = parseInt(versionString, 10);
+
+        return textDocumentProjectedVersion;
     }
 }
 
 interface SynchronizationContext {
+    readonly projectedDocument: IProjectedDocument;
     readonly logIdentifier: number;
-    readonly toVersion: number;
-    readonly documentVersion: number;
-    readonly synchronized: (success: boolean) => void;
-    readonly onSynchronized: Promise<boolean>;
+    readonly toHostDocumentVersion: number;
+    readonly hostDocumentVersion: number;
+    readonly timeoutId: NodeJS.Timer;
+    readonly projectedDocumentSynchronized: () => void;
+    readonly onProjectedDocumentSynchronized: Promise<void>;
+    readonly projectedTextDocumentSynchronized: () => void;
+    readonly onProjectedTextDocumentSynchronized: Promise<void>;
+    readonly cancel: (reason: string) => void;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageFeatureBase.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageFeatureBase.ts
@@ -17,7 +17,10 @@ export class RazorLanguageFeatureBase {
         protected readonly serviceClient: RazorLanguageServiceClient) {
     }
 
-    protected async getProjection(document: vscode.TextDocument, position: vscode.Position) {
+    protected async getProjection(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken) {
         const languageResponse = await this.serviceClient.languageQuery(position, document.uri);
 
         switch (languageResponse.kind) {
@@ -28,10 +31,11 @@ export class RazorLanguageFeatureBase {
                     ? razorDocument.csharpDocument
                     : razorDocument.htmlDocument;
 
-                const synchronized = await this.documentSynchronizer.trySynchronize(
+                const synchronized = await this.documentSynchronizer.trySynchronizeProjectedDocument(
                     document,
                     projectedDocument,
-                    languageResponse.hostDocumentVersion);
+                    languageResponse.hostDocumentVersion,
+                    token);
                 if (!synchronized) {
                     // Could not synchronize
                     return null;

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorSignatureHelpProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorSignatureHelpProvider.ts
@@ -14,7 +14,7 @@ export class RazorSignatureHelpProvider
         document: vscode.TextDocument, position: vscode.Position,
         token: vscode.CancellationToken) {
 
-        const projection = await this.getProjection(document, position);
+        const projection = await this.getProjection(document, position, token);
         if (projection) {
             const result = await vscode.commands.executeCommand<vscode.SignatureHelp>(
                     'vscode.executeSignatureHelpProvider',


### PR DESCRIPTION
- The purpose of this redesign is to make completion more reliable. We now have a great understanding of how VSCode's object model mutates and therefore can make better assumptiosn on how to synchronize it.
- In this changeset we primarily do 2 things to synchronize a document:
  1. Make sure our `IProjectedDocument` has been updated by our language server.
  2. Make sure VSCode's TextDocument reflects the appropriate content detailed by the `IProjectedDocument`
If these two assertions are true then every other extension sees updated C#/Html and can respond accordingly.
- To properly accomplish 2 I had to persist information into the `vscode.TextDocument` to identify when the content properly matches our DTO. We do this by adding a `// SomeNumber` to the end of projected text documents.
- Updated RazorDocumentFactory to generate virtual C# files without a `__` prefix to prevent URIs from being placed as "authoritative" sources labeled by `__`. This caused issues in VSCode when working with copmletion.
- Flowed cancellation tokens into synchronization APIs so that when VSCode cancels an action we can also cancel synchronization.

#210