### PR TITLE
Fix typing `@{` auto-completing into `@DateTime{}`

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCompletionItemProvider.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCompletionItemProvider.ts
@@ -52,6 +52,14 @@ export class RazorCompletionItemProvider
 
                 // textEdit is deprecated in favor of .range. Clear out its value to avoid any unexpected behavior.
                 completionItem.textEdit = undefined;
+
+                if (triggerCharacter === '@' &&
+                    completionItem.commitCharacters) {
+                    // We remove `{` from the commit characters to prevent auto-completing the first completion item
+                    // with a curly brace when a user intended to type `@{}`.
+                    completionItem.commitCharacters = completionItem.commitCharacters.filter(
+                        commitChar => commitChar !== '{');
+                }
             }
 
             const isIncomplete = completions instanceof Array ? false


### PR DESCRIPTION
- When we detect that a a completion is invoked via a Razor transition `@` we now remove the `{` commit character from all of the completion items to prevent committing an item incorrectly.

#240