### PR TITLE
Don't start language server if there are no Razor files in the workspace.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,29 @@
         "Other"
     ],
     "activationEvents": [
-        "onLanguage:aspnetcorerazor"
+        "onDebugInitialConfigurations",
+        "onDebugResolve:coreclr",
+        "onDebugResolve:clr",
+        "onLanguage:csharp",
+        "onLanguage:aspnetcorerazor",
+        "onCommand:o.restart",
+        "onCommand:o.pickProjectAndStart",
+        "onCommand:o.showOutput",
+        "onCommand:dotnet.restore.project",
+        "onCommand:dotnet.restore.all",
+        "onCommand:dotnet.generateAssets",
+        "onCommand:csharp.downloadDebugger",
+        "onCommand:csharp.listProcess",
+        "onCommand:csharp.listRemoteProcess",
+        "workspaceContains:project.json",
+        "workspaceContains:*.csproj",
+        "workspaceContains:*.sln",
+        "workspaceContains:*.csx",
+        "workspaceContains:*.cake",
+        "workspaceContains:**/*.csproj",
+        "workspaceContains:**/*.sln",
+        "workspaceContains:**/*.csx",
+        "workspaceContains:**/*.cake"
     ],
     "main": "./out/src/extension",
     "contributes": {

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -16,8 +16,6 @@ import { RazorLogger } from './RazorLogger';
 import { UpdateCSharpBufferRequest } from './RPC/UpdateCSharpBufferRequest';
 import { getUriPath } from './UriPaths';
 
-const globbingPath = `**/*.${RazorLanguage.fileExtension}`;
-
 export class RazorDocumentManager {
     private readonly razorDocuments: { [hostDocumentPath: string]: IRazorDocument } = {};
     private onChangeEmitter = new vscode.EventEmitter<IRazorDocumentChangeEvent>();
@@ -56,7 +54,7 @@ export class RazorDocumentManager {
 
     public async initialize() {
         // Track current documents
-        const documentUris = await vscode.workspace.findFiles(globbingPath);
+        const documentUris = await vscode.workspace.findFiles(RazorLanguage.globbingPattern);
 
         for (const uri of documentUris) {
             this.addDocument(uri);
@@ -79,7 +77,7 @@ export class RazorDocumentManager {
 
     public register() {
         // Track future documents
-        const watcher = vscode.workspace.createFileSystemWatcher(globbingPath);
+        const watcher = vscode.workspace.createFileSystemWatcher(RazorLanguage.globbingPattern);
         const didCreateRegistration = watcher.onDidCreate(
             async (uri: vscode.Uri) => this.addDocument(uri));
         const didDeleteRegistration = watcher.onDidDelete(

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguage.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguage.ts
@@ -9,7 +9,8 @@ import { DocumentSelector } from 'vscode-languageclient/lib/main';
 export class RazorLanguage {
     public static id = 'aspnetcorerazor';
     public static fileExtension = 'cshtml';
-    public static documentSelector: DocumentSelector =  [ { pattern: `**/*.${RazorLanguage.fileExtension}` } ];
+    public static globbingPattern = `**/*.${RazorLanguage.fileExtension}`;
+    public static documentSelector: DocumentSelector =  [ { pattern: RazorLanguage.globbingPattern } ];
     public static languageConfig = vscode.workspace.getConfiguration('razor');
     public static serverConfig = vscode.workspace.getConfiguration('razor.languageServer');
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -25,26 +25,36 @@ export class RazorLanguageServiceClient {
     }
 
     public async addDocument(documentUri: vscode.Uri) {
+        await this.ensureStarted();
+
         const request = new AddDocumentRequest(documentUri.fsPath);
         await this.serverClient.sendRequest<AddDocumentRequest>('projects/addDocument', request);
     }
 
     public async removeDocument(documentUri: vscode.Uri) {
+        await this.ensureStarted();
+
         const request = new RemoveDocumentRequest(documentUri.fsPath);
         await this.serverClient.sendRequest<RemoveDocumentRequest>('projects/removeDocument', request);
     }
 
     public async addProject(projectFileUri: vscode.Uri) {
+        await this.ensureStarted();
+
         const request = new AddProjectRequest(projectFileUri.fsPath);
         await this.serverClient.sendRequest<AddProjectRequest>('projects/addProject', request);
     }
 
     public async removeProject(projectFileUri: vscode.Uri) {
+        await this.ensureStarted();
+
         const request = new RemoveProjectRequest(projectFileUri.fsPath);
         await this.serverClient.sendRequest<RemoveProjectRequest>('projects/removeProject', request);
     }
 
     public async updateProject(project: IRazorProject) {
+        await this.ensureStarted();
+
         const request: UpdateProjectRequest = {
             projectFilePath: project.uri.fsPath,
             tagHelpers: project.configuration ? project.configuration.tagHelpers : [],
@@ -55,6 +65,8 @@ export class RazorLanguageServiceClient {
     }
 
     public async languageQuery(position: vscode.Position, uri: vscode.Uri) {
+        await this.ensureStarted();
+
         const request = new LanguageQueryRequest(position, uri);
         const response = await this.serverClient.sendRequest<LanguageQueryResponse>('razor/languageQuery', request);
         response.position = new vscode.Position(response.position.line, response.position.character);
@@ -66,5 +78,10 @@ export class RazorLanguageServiceClient {
         const document = await vscode.workspace.openTextDocument(clientUri);
 
         return new RazorTextDocumentItem(document);
+    }
+
+    private async ensureStarted() {
+        // If the server is already started this will instantly return.
+        await this.serverClient.start();
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
@@ -25,10 +25,14 @@ export class RazorLogger implements vscode.Disposable {
         this.logRazorInformation();
     }
 
+    public logAlways(message: string) {
+        this.logWithmarker(message);
+    }
+
     public logError(message: string) {
         // Always log errors
         const errorPrefixedMessage = `(Error) ${message}`;
-        this.logWithmarker(errorPrefixedMessage);
+        this.logAlways(errorPrefixedMessage);
     }
 
     public logMessage(message: string) {


### PR DESCRIPTION
- Updated dev package.json to reflect omnisharp activation events.
- We delay the start of the language server until a Razor file has been created or a Razor file has been opened. One thing to note, is when opening a Razor file in an unrelated workspace you run into #244.
- Added an ensure mechanism to the `RazorLanguageServiceClient` to ensure that any requests that need to make their way through the system will wait on the server starting since we now delay its start.
- Added an `alwaysLog`method to the logger to allow us to notify users when we're delay starting the language server.
- Had to add an `onStarted` event to the server client in order to allow for initialization of our document and project managers.

#222