### PR TITLE
Identify pre-2.0 Razor projects when dev16 is installed.

### DIFF
--- a/client/test/Completions.test.ts
+++ b/client/test/Completions.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { extensionActivated } from '../src/extension';
 import {
-    basicRazorAppRoot,
+    basicRazorApp21Root,
     csharpExtensionReady,
     dotnetRestore,
     htmlLanguageFeaturesExtensionReady,
@@ -23,11 +23,11 @@ describe('Completions', () => {
     before(async () => {
         await csharpExtensionReady();
         await htmlLanguageFeaturesExtensionReady();
-        await dotnetRestore(basicRazorAppRoot);
+        await dotnetRestore(basicRazorApp21Root);
     });
 
     beforeEach(async () => {
-        const filePath = path.join(basicRazorAppRoot, 'Pages', 'Index.cshtml');
+        const filePath = path.join(basicRazorApp21Root, 'Pages', 'Index.cshtml');
         doc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(doc);
         await extensionActivated;

--- a/client/test/Completions1_0.test.ts
+++ b/client/test/Completions1_0.test.ts
@@ -1,0 +1,54 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { extensionActivated } from '../src/extension';
+import {
+    basicRazorApp10Root,
+    csharpExtensionReady,
+    dotnetRestore,
+    htmlLanguageFeaturesExtensionReady,
+    pollUntil,
+} from './TestUtil';
+
+let doc: vscode.TextDocument;
+let editor: vscode.TextEditor;
+
+describe('Completions 1.0', () => {
+    before(async () => {
+        await csharpExtensionReady();
+        await htmlLanguageFeaturesExtensionReady();
+        await dotnetRestore(basicRazorApp10Root);
+    });
+
+    beforeEach(async () => {
+        const filePath = path.join(basicRazorApp10Root, 'Views', 'Index.cshtml');
+        doc = await vscode.workspace.openTextDocument(filePath);
+        editor = await vscode.window.showTextDocument(doc);
+        await extensionActivated;
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(() => vscode.window.visibleTextEditors.length === 0, 1000);
+    });
+
+    it('Can complete Razor directive', async () => {
+        const firstLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(firstLine, '@\n'));
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            new vscode.Position(0, 1));
+
+        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
+
+        assert.ok(!hasCompletion('page'), 'Should not have completion for "page"');
+        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
+        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+    });
+});

--- a/client/test/HtmlTyping.test.ts
+++ b/client/test/HtmlTyping.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { extensionActivated } from '../src/extension';
 import {
-    basicRazorAppRoot,
+    basicRazorApp21Root,
     ensureNoChangesFor,
     htmlLanguageFeaturesExtensionReady,
     pollUntil,
@@ -24,7 +24,7 @@ describe('Html Typing', () => {
     });
 
     beforeEach(async () => {
-        const filePath = path.join(basicRazorAppRoot, 'Pages', 'Index.cshtml');
+        const filePath = path.join(basicRazorApp21Root, 'Pages', 'Index.cshtml');
         doc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(doc);
         await extensionActivated;

--- a/client/test/SignatureHelp.test.ts
+++ b/client/test/SignatureHelp.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { extensionActivated } from '../src/extension';
 import {
-    basicRazorAppRoot,
+    basicRazorApp21Root,
     csharpExtensionReady,
     dotnetRestore,
     htmlLanguageFeaturesExtensionReady,
@@ -23,11 +23,11 @@ describe('Signature help', () => {
     before(async () => {
         await htmlLanguageFeaturesExtensionReady();
         await csharpExtensionReady();
-        await dotnetRestore(basicRazorAppRoot);
+        await dotnetRestore(basicRazorApp21Root);
     });
 
     beforeEach(async () => {
-        const filePath = path.join(basicRazorAppRoot, 'Pages', 'Index.cshtml');
+        const filePath = path.join(basicRazorApp21Root, 'Pages', 'Index.cshtml');
         doc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(doc);
         await extensionActivated;

--- a/client/test/TestUtil.ts
+++ b/client/test/TestUtil.ts
@@ -8,7 +8,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 export const repoRoot = path.join(__dirname, '..', '..', '..');
-export const basicRazorAppRoot = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp2_1');
+export const basicRazorApp21Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp2_1');
+export const basicRazorApp10Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp1_0');
 
 export async function pollUntil(fn: () => boolean, timeoutMs: number) {
     const pollInterval = 50;

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:3.0.0-alpha1-20181108.5
-commithash:dae1d0c39ad86505e53f3629665714313bfd0d7d
+version:2.2.0-preview2-20181026.4
+commithash:f05a283e6c1eb66ef29a32526f75f8b567a986c9

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/FallbackConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/FallbackConfigurationProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Composition;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -10,27 +9,18 @@ using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
-    [Shared]
-    [Export(typeof(RazorConfigurationProvider))]
-    internal class LegacyConfigurationProvider : CoreProjectConfigurationProvider
+    internal class FallbackConfigurationProvider : CoreProjectConfigurationProvider
     {
+        public static FallbackConfigurationProvider Instance = new FallbackConfigurationProvider();
+
         // Internal for testing
         internal const string ReferencePathWithRefAssembliesItemType = "ReferencePathWithRefAssemblies";
         internal const string MvcAssemblyFileName = "Microsoft.AspNetCore.Mvc.Razor.dll";
-
-        private const string MvcAssemblyName = "Microsoft.AspNetCore.Mvc.Razor";
 
         public override bool TryResolveConfiguration(RazorConfigurationProviderContext context, out RazorConfiguration configuration)
         {
             if (!HasRazorCoreCapability(context))
             {
-                configuration = null;
-                return false;
-            }
-
-            if (HasRazorCoreConfigurationCapability(context))
-            {
-                // Razor project is >= 2.1, we don't handle that.
                 configuration = null;
                 return false;
             }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectLoadListener.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectLoadListener.cs
@@ -123,6 +123,11 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 }
             }
 
+            if (FallbackConfigurationProvider.Instance.TryResolveConfiguration(context, out var fallbackConfiguration))
+            {
+                return fallbackConfiguration;
+            }
+
             return null;
         }
 

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/FallbackConfigurationProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/FallbackConfigurationProviderTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
-    public class LegacyConfigurationProviderTest
+    public class FallbackConfigurationProviderTest
     {
         public Version MvcAssemblyVersion { get; } = Version.Parse("2.1.0");
 
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public void TryResolveConfiguration_NoMvcVersion_ReturnsFalse()
         {
             // Arrange
-            var context = BuildContext("/some/path/to/some.dll", "/another/path/to/" + LegacyConfigurationProvider.MvcAssemblyFileName);
+            var context = BuildContext("/some/path/to/some.dll", "/another/path/to/" + FallbackConfigurationProvider.MvcAssemblyFileName);
             var provider = new TestLegacyConfigurationProvider(mvcAssemblyVersion: null);
 
             // Act
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public void TryResolveConfiguration_MvcWithVersion_ReturnsTrue()
         {
             // Arrange
-            var context = BuildContext("/some/path/to/some.dll", "/another/path/to/" + LegacyConfigurationProvider.MvcAssemblyFileName);
+            var context = BuildContext("/some/path/to/some.dll", "/another/path/to/" + FallbackConfigurationProvider.MvcAssemblyFileName);
             var provider = new TestLegacyConfigurationProvider(MvcAssemblyVersion);
             var expectedConfiguration = FallbackRazorConfiguration.SelectConfiguration(MvcAssemblyVersion);
 
@@ -102,13 +102,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
             foreach (var path in referencePaths)
             {
-                projectInstance.AddItem(LegacyConfigurationProvider.ReferencePathWithRefAssembliesItemType, path);
+                projectInstance.AddItem(FallbackConfigurationProvider.ReferencePathWithRefAssembliesItemType, path);
             }
             var context = new RazorConfigurationProviderContext(projectCapabilities, projectInstance);
             return context;
         }
 
-        private class TestLegacyConfigurationProvider : LegacyConfigurationProvider
+        private class TestLegacyConfigurationProvider : FallbackConfigurationProvider
         {
             private readonly Version _mvcAssemblyVersion;
 

--- a/test/testapps/Directory.Build.props
+++ b/test/testapps/Directory.Build.props
@@ -1,2 +1,4 @@
 <Project>
+  <Import Project="..\..\Directory.Build.props" />
+
 </Project>


### PR DESCRIPTION
- Reverted KoreBuild upgrade due to bugs in how it restored.
- Updated Directory.Build.props in testapps folder to ensure testapps have access to NuGet sources for restore.
- Changed `LegacyConfigurationProvider` to `FallbackConfigurationProvider` and made it always run after all other providers. The idea behind this is that if no other provider can suggest a valid configuration then we fallback to looking at the dlls for ASP.NET Core.

#246