### PR TITLE
Added 1_0 functional test.

### DIFF
--- a/client/test/Completions.test.ts
+++ b/client/test/Completions.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { extensionActivated } from '../src/extension';
 import {
-    basicRazorAppRoot,
+    basicRazorApp21Root,
     csharpExtensionReady,
     dotnetRestore,
     htmlLanguageFeaturesExtensionReady,
@@ -23,11 +23,11 @@ describe('Completions', () => {
     before(async () => {
         await csharpExtensionReady();
         await htmlLanguageFeaturesExtensionReady();
-        await dotnetRestore(basicRazorAppRoot);
+        await dotnetRestore(basicRazorApp21Root);
     });
 
     beforeEach(async () => {
-        const filePath = path.join(basicRazorAppRoot, 'Pages', 'Index.cshtml');
+        const filePath = path.join(basicRazorApp21Root, 'Pages', 'Index.cshtml');
         doc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(doc);
         await extensionActivated;

--- a/client/test/Completions1_0.test.ts
+++ b/client/test/Completions1_0.test.ts
@@ -1,0 +1,54 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { extensionActivated } from '../src/extension';
+import {
+    basicRazorApp10Root,
+    csharpExtensionReady,
+    dotnetRestore,
+    htmlLanguageFeaturesExtensionReady,
+    pollUntil,
+} from './TestUtil';
+
+let doc: vscode.TextDocument;
+let editor: vscode.TextEditor;
+
+describe('Completions 1.0', () => {
+    before(async () => {
+        await csharpExtensionReady();
+        await htmlLanguageFeaturesExtensionReady();
+        await dotnetRestore(basicRazorApp10Root);
+    });
+
+    beforeEach(async () => {
+        const filePath = path.join(basicRazorApp10Root, 'Views', 'Index.cshtml');
+        doc = await vscode.workspace.openTextDocument(filePath);
+        editor = await vscode.window.showTextDocument(doc);
+        await extensionActivated;
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(() => vscode.window.visibleTextEditors.length === 0, 1000);
+    });
+
+    it('Can complete Razor directive', async () => {
+        const firstLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(firstLine, '@\n'));
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            new vscode.Position(0, 1));
+
+        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
+
+        assert.ok(!hasCompletion('page'), 'Should not have completion for "page"');
+        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
+        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+    });
+});

--- a/client/test/HtmlTyping.test.ts
+++ b/client/test/HtmlTyping.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { extensionActivated } from '../src/extension';
 import {
-    basicRazorAppRoot,
+    basicRazorApp21Root,
     ensureNoChangesFor,
     htmlLanguageFeaturesExtensionReady,
     pollUntil,
@@ -24,7 +24,7 @@ describe('Html Typing', () => {
     });
 
     beforeEach(async () => {
-        const filePath = path.join(basicRazorAppRoot, 'Pages', 'Index.cshtml');
+        const filePath = path.join(basicRazorApp21Root, 'Pages', 'Index.cshtml');
         doc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(doc);
         await extensionActivated;

--- a/client/test/SignatureHelp.test.ts
+++ b/client/test/SignatureHelp.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { extensionActivated } from '../src/extension';
 import {
-    basicRazorAppRoot,
+    basicRazorApp21Root,
     csharpExtensionReady,
     dotnetRestore,
     htmlLanguageFeaturesExtensionReady,
@@ -23,11 +23,11 @@ describe('Signature help', () => {
     before(async () => {
         await htmlLanguageFeaturesExtensionReady();
         await csharpExtensionReady();
-        await dotnetRestore(basicRazorAppRoot);
+        await dotnetRestore(basicRazorApp21Root);
     });
 
     beforeEach(async () => {
-        const filePath = path.join(basicRazorAppRoot, 'Pages', 'Index.cshtml');
+        const filePath = path.join(basicRazorApp21Root, 'Pages', 'Index.cshtml');
         doc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(doc);
         await extensionActivated;

--- a/client/test/TestUtil.ts
+++ b/client/test/TestUtil.ts
@@ -8,7 +8,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 export const repoRoot = path.join(__dirname, '..', '..', '..');
-export const basicRazorAppRoot = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp2_1');
+export const basicRazorApp21Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp2_1');
+export const basicRazorApp10Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp1_0');
 
 export async function pollUntil(fn: () => boolean, timeoutMs: number) {
     const pollInterval = 50;


### PR DESCRIPTION
- This test verifies the core criteria of `@page` not being a directive in 1.0 apps.
- Note: This test will fail on machines that have dev16 on them unless you also add a `razor.plugin.path` variable that points to this repos OmniSharp plugin dll.

#197