### PR TITLE
Report a Razor issue feature.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">$(MicrosoftNETCoreApp22PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreApp30PackageVersion)</RuntimeFrameworkVersion>
     <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
     <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>

--- a/Razor.VSCode.sln
+++ b/Razor.VSCode.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28315.86
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}"
 EndProject

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,12 +1,18 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.6.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.7.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview-18606-0098</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview-18606-0098</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview-18606-0098</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-alpha1-10643</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview-18606-0098</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
@@ -15,6 +21,9 @@
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <OmniSharpExtensionsLanguageServerPackageVersion>0.10.0</OmniSharpExtensionsLanguageServerPackageVersion>
+    <SystemRuntimeHandlesPackageVersion>4.3.0</SystemRuntimeHandlesPackageVersion>
+    <SystemIOFileSystemPrimitivesPackageVersion>4.3.0</SystemIOFileSystemPrimitivesPackageVersion>
+    <SystemTextEncodingExtensionsPackageVersion>4.3.0</SystemTextEncodingExtensionsPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -17,6 +17,8 @@
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETCoreApp22PackageVersion>2.2.0-preview2-26905-02</MicrosoftNETCoreApp22PackageVersion>
+    <MicrosoftNetCoreApp30PackageVersion>3.0.0-preview1-26907-05</MicrosoftNetCoreApp30PackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview-18577-0036</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -6,6 +6,7 @@
   <ItemGroup>
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp22PackageVersion)" />
+    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp30PackageVersion)" />
   </ItemGroup>
 
   <Target Name="CodeSign" AfterTargets="Package" DependsOnTargets="GetToolsets" Condition=" '$(OS)' == 'Windows_NT' ">

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -178,7 +178,7 @@
                 },
                 "supports-color": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 }
@@ -1061,6 +1061,10 @@
                 "vscode-languageclient": "^5.1.0"
             },
             "dependencies": {
+                "@types/clipboardy": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
                 "@types/node": {
                     "version": "10.9.4",
                     "bundled": true
@@ -3634,9 +3638,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+            "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1056,6 +1056,7 @@
         "microsoft.aspnetcore.razor.vscode": {
             "version": "file:../src/Microsoft.AspNetCore.Razor.VSCode",
             "requires": {
+                "clipboardy": "1.2.3",
                 "vscode-html-languageservice": "^2.1.7",
                 "vscode-languageclient": "^5.1.0"
             },
@@ -1106,6 +1107,10 @@
                     "requires": {
                         "buffer-equal": "^1.0.0"
                     }
+                },
+                "arch": {
+                    "version": "2.1.1",
+                    "bundled": true
                 },
                 "argparse": {
                     "version": "1.0.10",
@@ -1294,6 +1299,14 @@
                         }
                     }
                 },
+                "clipboardy": {
+                    "version": "1.2.3",
+                    "bundled": true,
+                    "requires": {
+                        "arch": "^2.1.0",
+                        "execa": "^0.8.0"
+                    }
+                },
                 "clone": {
                     "version": "0.2.0",
                     "bundled": true
@@ -1351,6 +1364,15 @@
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
                 },
                 "dashdash": {
                     "version": "1.14.1",
@@ -1440,6 +1462,19 @@
                         "split": "0.3",
                         "stream-combiner": "~0.0.4",
                         "through": "~2.3.1"
+                    }
+                },
+                "execa": {
+                    "version": "0.8.0",
+                    "bundled": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
                 "expand-brackets": {
@@ -1578,6 +1613,10 @@
                 },
                 "function-bind": {
                     "version": "1.1.1",
+                    "bundled": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
                     "bundled": true
                 },
                 "getpass": {
@@ -2108,6 +2147,10 @@
                     "version": "1.0.0",
                     "bundled": true
                 },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
                 "isobject": {
                     "version": "2.1.0",
                     "bundled": true,
@@ -2189,6 +2232,14 @@
                 "lodash.isequal": {
                     "version": "4.5.0",
                     "bundled": true
+                },
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "bundled": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
                 },
                 "map-stream": {
                     "version": "0.1.0",
@@ -2346,6 +2397,13 @@
                         "once": "^1.3.2"
                     }
                 },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
                 "oauth-sign": {
                     "version": "0.9.0",
                     "bundled": true
@@ -2391,6 +2449,10 @@
                         "readable-stream": "^2.0.1"
                     }
                 },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
                 "parse-glob": {
                     "version": "3.0.4",
                     "bundled": true,
@@ -2420,6 +2482,10 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
+                    "bundled": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
                     "bundled": true
                 },
                 "path-parse": {
@@ -2458,6 +2524,10 @@
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
+                    "bundled": true
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
                     "bundled": true
                 },
                 "psl": {
@@ -2635,6 +2705,21 @@
                     "version": "5.5.1",
                     "bundled": true
                 },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "bundled": true
@@ -2727,6 +2812,10 @@
                         "first-chunk-stream": "^1.0.0",
                         "strip-bom": "^2.0.0"
                     }
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true
                 },
                 "supports-color": {
                     "version": "4.4.0",
@@ -3096,12 +3185,23 @@
                     "version": "1.0.6",
                     "bundled": true
                 },
+                "which": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true
                 },
                 "xtend": {
                     "version": "4.0.1",
+                    "bundled": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
                     "bundled": true
                 },
                 "yauzl": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
         "Other"
     ],
     "activationEvents": [
+        "onWebviewPanel:razorReportIssue",
         "onDebugInitialConfigurations",
         "onDebugResolve:coreclr",
         "onDebugResolve:clr",
@@ -59,11 +60,18 @@
         "commands": [
             {
                 "command": "extension.showRazorCSharpWindow",
-                "title": "Show Razor CSharp"
+                "title": "Show Razor CSharp",
+                "category": "Razor"
             },
             {
                 "command": "extension.showRazorHtmlWindow",
-                "title": "Show Razor Html"
+                "title": "Show Razor Html",
+                "category": "Razor"
+            },
+            {
+                "command": "razor.reportIssue",
+                "title": "Report a Razor issue",
+                "category": "Razor"
             }
         ],
         "menus": {
@@ -74,6 +82,10 @@
                 },
                 {
                     "command": "extension.showRazorHtmlWindow",
+                    "when": "resourceLangId == aspnetcorerazor"
+                },
+                {
+                    "command": "razor.reportIssue",
                     "when": "resourceLangId == aspnetcorerazor"
                 }
             ]

--- a/client/test/Completions3_0.test.ts
+++ b/client/test/Completions3_0.test.ts
@@ -1,0 +1,54 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { extensionActivated } from '../src/extension';
+import {
+    basicRazorApp30Root,
+    csharpExtensionReady,
+    dotnetRestore,
+    htmlLanguageFeaturesExtensionReady,
+    pollUntil,
+} from './TestUtil';
+
+let doc: vscode.TextDocument;
+let editor: vscode.TextEditor;
+
+describe('Completions 3.0', () => {
+    before(async () => {
+        await csharpExtensionReady();
+        await htmlLanguageFeaturesExtensionReady();
+        await dotnetRestore(basicRazorApp30Root);
+    });
+
+    beforeEach(async () => {
+        const filePath = path.join(basicRazorApp30Root, 'Pages', 'Index.cshtml');
+        doc = await vscode.workspace.openTextDocument(filePath);
+        editor = await vscode.window.showTextDocument(doc);
+        await extensionActivated;
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(() => vscode.window.visibleTextEditors.length === 0, 1000);
+    });
+
+    it('Can complete Razor directive', async () => {
+        const firstLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(firstLine, '@\n'));
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            new vscode.Position(0, 1));
+
+        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
+
+        assert.ok(hasCompletion('page'), 'Should have completion for "page"');
+        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
+        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+    });
+});

--- a/client/test/TestUtil.ts
+++ b/client/test/TestUtil.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 export const repoRoot = path.join(__dirname, '..', '..', '..');
+export const basicRazorApp30Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp3_0');
 export const basicRazorApp21Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp2_1');
 export const basicRazorApp10Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp1_0');
 

--- a/client/unittest/Mocks/TestProjectedDocument.ts
+++ b/client/unittest/Mocks/TestProjectedDocument.ts
@@ -1,0 +1,27 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { IProjectedDocument } from 'microsoft.aspnetcore.razor.vscode/dist/IProjectedDocument';
+import * as vscode from 'microsoft.aspnetcore.razor.vscode/dist/vscodeAdapter';
+
+export class TestProjectedDocument implements IProjectedDocument {
+    constructor(
+        public readonly content: string,
+        public readonly uri: vscode.Uri,
+        public readonly path = uri.path) {
+    }
+
+    public get hostDocumentSyncVersion(): number | null {
+        throw new Error('Not Implemented.');
+    }
+
+    public get projectedDocumentSyncVersion(): number {
+        throw new Error('Not Implemented.');
+    }
+
+    public getContent(): string {
+        return this.content;
+    }
+}

--- a/client/unittest/Mocks/TestRazorDocument.ts
+++ b/client/unittest/Mocks/TestRazorDocument.ts
@@ -1,0 +1,22 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { IProjectedDocument } from 'microsoft.aspnetcore.razor.vscode/dist/IProjectedDocument';
+import { IRazorDocument } from 'microsoft.aspnetcore.razor.vscode/dist/IRazorDocument';
+import * as vscode from 'microsoft.aspnetcore.razor.vscode/dist/vscodeAdapter';
+import { TestProjectedDocument } from './TestProjectedDocument';
+import { TestUri } from './TestUri';
+
+export class TestRazorDocument implements IRazorDocument {
+    public csharpDocument: IProjectedDocument;
+    public htmlDocument: IProjectedDocument;
+
+    constructor(
+        public readonly uri: vscode.Uri,
+        public readonly path: string = uri.path) {
+        this.csharpDocument = new TestProjectedDocument('C#', new TestUri(`${this.path}.cs`));
+        this.htmlDocument = new TestProjectedDocument('Html', new TestUri(`${this.path}.cs`));
+    }
+}

--- a/client/unittest/Mocks/TestRazorDocumentManager.ts
+++ b/client/unittest/Mocks/TestRazorDocumentManager.ts
@@ -1,0 +1,35 @@
+/* --------------------------------------------------------------------------------------------
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT License. See License.txt in the project root for license information.
+* ------------------------------------------------------------------------------------------ */
+
+import { IRazorDocument } from 'microsoft.aspnetcore.razor.vscode/dist/IRazorDocument';
+import { IRazorDocumentChangeEvent } from 'microsoft.aspnetcore.razor.vscode/dist/IRazorDocumentChangeEvent';
+import { IRazorDocumentManager } from 'microsoft.aspnetcore.razor.vscode/dist/IRazorDocumentManager';
+import * as vscode from 'microsoft.aspnetcore.razor.vscode/dist/vscodeAdapter';
+
+export class TestRazorDocumentManager implements IRazorDocumentManager {
+    public get onChange(): vscode.Event<IRazorDocumentChangeEvent> {
+        throw new Error('Not implemented');
+    }
+
+    public get documents(): IRazorDocument[] {
+        throw new Error('Not implemented');
+    }
+
+    public getDocument(uri: vscode.Uri): Promise<IRazorDocument> {
+        throw new Error('Not implemented');
+    }
+
+    public getActiveDocument(): Promise<IRazorDocument | null> {
+        throw new Error('Not implemented');
+    }
+
+    public initialize(): Promise<void> {
+        throw new Error('Not implemented');
+    }
+
+    public register(): vscode.Disposable {
+        throw new Error('Not implemented');
+    }
+}

--- a/client/unittest/RazorLogger.test.ts
+++ b/client/unittest/RazorLogger.test.ts
@@ -22,9 +22,10 @@ describe('RazorLogger', () => {
         // Arrange
         const api = createTestVSCodeApi();
         const sink = api.getOutputChannelSink();
+        const eventEmitterFactory = new TestEventEmitterFactory();
 
         // Act
-        const logger = new RazorLogger(api, Trace.Off);
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
 
         // Assert
         const log = getAndAssertLog(sink);
@@ -36,7 +37,8 @@ describe('RazorLogger', () => {
         // Arrange
         const api = createTestVSCodeApi();
         const sink = api.getOutputChannelSink();
-        const logger = new RazorLogger(api, Trace.Off);
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
 
         // Act
         logger.logAlways('Test');
@@ -51,7 +53,8 @@ describe('RazorLogger', () => {
         // Arrange
         const api = createTestVSCodeApi();
         const sink = api.getOutputChannelSink();
-        const logger = new RazorLogger(api, Trace.Off);
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
 
         // Act
         logger.logError('Test Error');
@@ -66,7 +69,8 @@ describe('RazorLogger', () => {
         // Arrange
         const api = createTestVSCodeApi();
         const sink = api.getOutputChannelSink();
-        const logger = new RazorLogger(api, Trace.Off);
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
 
         // Act
         logger.logMessage('Test message');
@@ -82,7 +86,8 @@ describe('RazorLogger', () => {
             // Arrange
             const api = createTestVSCodeApi();
             const sink = api.getOutputChannelSink();
-            const logger = new RazorLogger(api, trace);
+            const eventEmitterFactory = new TestEventEmitterFactory();
+            const logger = new RazorLogger(api, eventEmitterFactory, trace);
 
             // Act
             logger.logMessage('Test message');
@@ -99,7 +104,8 @@ describe('RazorLogger', () => {
             // Arrange
             const api = createTestVSCodeApi();
             const sink = api.getOutputChannelSink();
-            const logger = new RazorLogger(api, trace);
+            const eventEmitterFactory = new TestEventEmitterFactory();
+            const logger = new RazorLogger(api, eventEmitterFactory, trace);
 
             // Act
             logger.logVerbose('Test message');
@@ -115,7 +121,8 @@ describe('RazorLogger', () => {
         // Arrange
         const api = createTestVSCodeApi();
         const sink = api.getOutputChannelSink();
-        const logger = new RazorLogger(api, Trace.Verbose);
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Verbose);
 
         // Act
         logger.logVerbose('Test message');

--- a/client/unittest/ReportIssueCreator.test.ts
+++ b/client/unittest/ReportIssueCreator.test.ts
@@ -1,0 +1,291 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import { IReportIssueDataCollectionResult } from 'microsoft.aspnetcore.razor.vscode/dist/Diagnostics/IReportIssueDataCollectionResult';
+import { ReportIssueCreator } from 'microsoft.aspnetcore.razor.vscode/dist/Diagnostics/ReportIssueCreator';
+import { IRazorDocument } from 'microsoft.aspnetcore.razor.vscode/dist/IRazorDocument';
+import { IRazorDocumentManager } from 'microsoft.aspnetcore.razor.vscode/dist/IRazorDocumentManager';
+import * as vscode from 'microsoft.aspnetcore.razor.vscode/dist/vscodeAdapter';
+import { TestProjectedDocument } from './Mocks/TestProjectedDocument';
+import { TestRazorDocument } from './Mocks/TestRazorDocument';
+import { TestRazorDocumentManager } from './Mocks/TestRazorDocumentManager';
+import { TestTextDocument } from './Mocks/TestTextDocument';
+import { createTestVSCodeApi } from './Mocks/TestVSCodeApi';
+
+describe('ReportIssueCreator', () => {
+    function getReportIssueCreator(api: vscode.api) {
+        const documentManager = new TestRazorDocumentManager();
+        const issueCreator = new TestReportIssueCreator(api, documentManager);
+        return issueCreator;
+    }
+
+    it('create can operate when no content is available', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const issueCreator = getReportIssueCreator(api);
+        const collectionResult: IReportIssueDataCollectionResult = {
+            document: undefined,
+            logOutput: '',
+        };
+
+        // Act
+        const issueContent = await issueCreator.create(collectionResult);
+
+        // Assert
+        assert.ok(issueContent.indexOf('Bug') > 0);
+    });
+
+    it('getRazor returns text documents contents', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const issueCreator = getReportIssueCreator(api);
+        const expectedContent = 'TextDocument content';
+        const textDocument = new TestTextDocument(expectedContent, api.Uri.parse('C:/path/to/file.cshtml'));
+
+        // Act
+        const razorContent = await issueCreator.getRazor(textDocument);
+
+        // Assert
+        assert.equal(razorContent, expectedContent);
+    });
+
+    it('getProjectedCSharp returns projected CSharp and vscodes text document CSharp', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const expectedVSCodeCSharpContent = 'VSCode seen CSharp content';
+        const csharpDocumentUri = api.Uri.parse('C:/path/to/file.cshtml.__virtual.cs');
+        const csharpTextDocument = new TestTextDocument(expectedVSCodeCSharpContent, csharpDocumentUri);
+        api.setWorkspaceDocuments(csharpTextDocument);
+        const hostDocumentUri = api.Uri.parse('C:/path/to/file.cshtml');
+        const expectedProjectedCSharpContent = 'Projected CSharp content';
+        const razorDocument = new TestRazorDocument(hostDocumentUri, hostDocumentUri.path);
+        razorDocument.csharpDocument = new TestProjectedDocument(expectedProjectedCSharpContent, csharpDocumentUri);
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const razorContent = await issueCreator.getProjectedCSharp(razorDocument);
+
+        // Assert
+        assert.ok(razorContent.indexOf(expectedVSCodeCSharpContent) > 0);
+        assert.ok(razorContent.indexOf(expectedProjectedCSharpContent) > 0);
+    });
+
+    it('getProjectedCSharp returns only projected CSharp if cannot locate vscodes text document', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const csharpDocumentUri = api.Uri.parse('C:/path/to/file.cshtml.__virtual.cs');
+        const hostDocumentUri = api.Uri.parse('C:/path/to/file.cshtml');
+        const expectedProjectedCSharpContent = 'Projected CSharp content';
+        const razorDocument = new TestRazorDocument(hostDocumentUri, hostDocumentUri.path);
+        razorDocument.csharpDocument = new TestProjectedDocument(expectedProjectedCSharpContent, csharpDocumentUri);
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const razorContent = await issueCreator.getProjectedCSharp(razorDocument);
+
+        // Assert
+        assert.ok(razorContent.indexOf(expectedProjectedCSharpContent) > 0);
+    });
+
+    it('getProjectedHtml returns projected Html and vscodes text document Html', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const expectedVSCodeHtmlContent = 'VSCode seen Html content';
+        const htmlDocumentUri = api.Uri.parse('C:/path/to/file.cshtml.__virtual.cs');
+        const htmlTextDocument = new TestTextDocument(expectedVSCodeHtmlContent, htmlDocumentUri);
+        api.setWorkspaceDocuments(htmlTextDocument);
+        const hostDocumentUri = api.Uri.parse('C:/path/to/file.cshtml');
+        const expectedProjectedHtmlContent = 'Projected Html content';
+        const razorDocument = new TestRazorDocument(hostDocumentUri, hostDocumentUri.path);
+        razorDocument.htmlDocument = new TestProjectedDocument(expectedProjectedHtmlContent, htmlDocumentUri);
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const razorContent = await issueCreator.getProjectedHtml(razorDocument);
+
+        // Assert
+        assert.ok(razorContent.indexOf(expectedVSCodeHtmlContent) > 0);
+        assert.ok(razorContent.indexOf(expectedProjectedHtmlContent) > 0);
+    });
+
+    it('getProjectedHtml returns only projected Html if cannot locate vscodes text document', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const htmlDocumentUri = api.Uri.parse('C:/path/to/file.cshtml.__virtual.html');
+        const hostDocumentUri = api.Uri.parse('C:/path/to/file.cshtml');
+        const expectedProjectedHtmlContent = 'Projected Html content';
+        const razorDocument = new TestRazorDocument(hostDocumentUri, hostDocumentUri.path);
+        razorDocument.htmlDocument = new TestProjectedDocument(expectedProjectedHtmlContent, htmlDocumentUri);
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const razorContent = await issueCreator.getProjectedHtml(razorDocument);
+
+        // Assert
+        assert.ok(razorContent.indexOf(expectedProjectedHtmlContent) > 0);
+    });
+
+    const omniSharpExtension: vscode.Extension<any> = {
+        id: 'ms-vscode.csharp',
+        packageJSON: {
+            name: 'OmniSharp',
+            version: '1234',
+            isBuiltin: false,
+        },
+    };
+    const razorClientExtension: vscode.Extension<any> = {
+        id: 'ms-vscode.razor-vscode',
+        packageJSON: {
+            name: 'Razor',
+            version: '5678',
+            isBuiltin: false,
+        },
+    };
+
+    it('getExtensionVersion returns OmniSharp extension version', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        api.setExtensions(omniSharpExtension, razorClientExtension);
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const extensionVersion = issueCreator.getExtensionVersion();
+
+        // Assert
+        assert.equal(extensionVersion, '1234');
+    });
+
+    it('getExtensionVersion can not find extension', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act & Assert
+        assert.doesNotThrow(async () => issueCreator.getExtensionVersion());
+    });
+
+    it('getInstalledExtensions returns non built-in extensions sorted by name', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const builtinExtension: vscode.Extension<any> = {
+            id: 'something.builtin',
+            packageJSON: {
+                name: 'BuiltInThing',
+                isBuiltin: true,
+            },
+        };
+        api.setExtensions(razorClientExtension, builtinExtension, omniSharpExtension);
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const extensions = issueCreator.getInstalledExtensions();
+
+        // Assert
+        assert.deepEqual(extensions, [omniSharpExtension, razorClientExtension]);
+    });
+
+    it('sortExtensions OmniSharp is before Razor', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const value = issueCreator.sortExtensions(omniSharpExtension, razorClientExtension);
+
+        // Assert
+        assert.equal(-1, value);
+    });
+
+    it('sortExtensions Razor is after OmniSharp', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const value = issueCreator.sortExtensions(razorClientExtension, omniSharpExtension);
+
+        // Assert
+        assert.equal(1, value);
+    });
+
+    it('sortExtensions OmniSharp is identical to OmniSharp', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const value = issueCreator.sortExtensions(omniSharpExtension, omniSharpExtension);
+
+        // Assert
+        assert.equal(0, value);
+    });
+
+    it('generateExtensionTable returns all non-builtin extensions in string format', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const builtinExtension: vscode.Extension<any> = {
+            id: 'something.builtin',
+            packageJSON: {
+                name: 'BuiltInThing',
+                version: 'ShouldNotShowUp',
+                isBuiltin: true,
+            },
+        };
+        api.setExtensions(razorClientExtension, builtinExtension, omniSharpExtension);
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act
+        const table = issueCreator.generateExtensionTable();
+
+        // Assert
+        assert.ok(table.indexOf(omniSharpExtension.packageJSON.version) > 0);
+        assert.ok(table.indexOf(razorClientExtension.packageJSON.version) > 0);
+        assert.ok(table.indexOf(builtinExtension.packageJSON.version) === -1);
+    });
+
+    it('generateExtensionTable can operate when 0 extensions', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const issueCreator = getReportIssueCreator(api);
+
+        // Act & Assert
+        assert.doesNotThrow(() => issueCreator.generateExtensionTable());
+    });
+});
+
+class TestReportIssueCreator extends ReportIssueCreator {
+    constructor(vscodeApi: vscode.api, documentManager: IRazorDocumentManager) {
+        super(vscodeApi, documentManager);
+    }
+
+    public getRazor(document: vscode.TextDocument) {
+        return super.getRazor(document);
+    }
+
+    public getProjectedCSharp(razorDocument: IRazorDocument) {
+        return super.getProjectedCSharp(razorDocument);
+    }
+
+    public getProjectedHtml(razorDocument: IRazorDocument) {
+        return super.getProjectedHtml(razorDocument);
+    }
+
+    public getExtensionVersion() {
+        return super.getExtensionVersion();
+    }
+
+    public getInstalledExtensions() {
+        return super.getInstalledExtensions();
+    }
+
+    public sortExtensions(a: vscode.Extension<any>, b: vscode.Extension<any>): number {
+        return super.sortExtensions(a, b);
+    }
+
+    public generateExtensionTable() {
+        return super.generateExtensionTable();
+    }
+}

--- a/client/unittest/ReportIssueCreator.test.ts
+++ b/client/unittest/ReportIssueCreator.test.ts
@@ -187,42 +187,6 @@ describe('ReportIssueCreator', () => {
         assert.deepEqual(extensions, [omniSharpExtension, razorClientExtension]);
     });
 
-    it('sortExtensions OmniSharp is before Razor', async () => {
-        // Arrange
-        const api = createTestVSCodeApi();
-        const issueCreator = getReportIssueCreator(api);
-
-        // Act
-        const value = issueCreator.sortExtensions(omniSharpExtension, razorClientExtension);
-
-        // Assert
-        assert.equal(-1, value);
-    });
-
-    it('sortExtensions Razor is after OmniSharp', async () => {
-        // Arrange
-        const api = createTestVSCodeApi();
-        const issueCreator = getReportIssueCreator(api);
-
-        // Act
-        const value = issueCreator.sortExtensions(razorClientExtension, omniSharpExtension);
-
-        // Assert
-        assert.equal(1, value);
-    });
-
-    it('sortExtensions OmniSharp is identical to OmniSharp', async () => {
-        // Arrange
-        const api = createTestVSCodeApi();
-        const issueCreator = getReportIssueCreator(api);
-
-        // Act
-        const value = issueCreator.sortExtensions(omniSharpExtension, omniSharpExtension);
-
-        // Assert
-        assert.equal(0, value);
-    });
-
     it('generateExtensionTable returns all non-builtin extensions in string format', async () => {
         // Arrange
         const api = createTestVSCodeApi();
@@ -279,10 +243,6 @@ class TestReportIssueCreator extends ReportIssueCreator {
 
     public getInstalledExtensions() {
         return super.getInstalledExtensions();
-    }
-
-    public sortExtensions(a: vscode.Extension<any>, b: vscode.Extension<any>): number {
-        return super.sortExtensions(a, b);
     }
 
     public generateExtensionTable() {

--- a/client/unittest/ReportIssueDataCollector.test.ts
+++ b/client/unittest/ReportIssueDataCollector.test.ts
@@ -1,0 +1,94 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import { ReportIssueDataCollector } from 'microsoft.aspnetcore.razor.vscode/dist/Diagnostics/ReportIssueDataCollector';
+import { RazorLogger } from 'microsoft.aspnetcore.razor.vscode/dist/RazorLogger';
+import { Trace } from 'microsoft.aspnetcore.razor.vscode/dist/Trace';
+import * as vscode from 'microsoft.aspnetcore.razor.vscode/dist/vscodeAdapter';
+import { TestEventEmitterFactory } from './Mocks/TestEventEmitterFactory';
+import { TestTextDocument } from './Mocks/TestTextDocument';
+import { createTestVSCodeApi } from './Mocks/TestVSCodeApi';
+
+describe('ReportIssueDataCollector', () => {
+
+    it('start always logs the starting of data collection', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const razorOutputChannel = api.getRazorOutputChannel();
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
+        const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
+        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
+
+        // Act
+        dataCollector.start();
+
+        // Assert
+        const lastLog = razorOutputChannel[razorOutputChannel.length - 1].trim();
+        assert.ok(lastLog.indexOf('Starting') > 0);
+    });
+
+    it('stop always logs the stopping of data collection', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const razorOutputChannel = api.getRazorOutputChannel();
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
+        const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
+        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
+        dataCollector.start();
+
+        // Act
+        dataCollector.stop();
+
+        // Assert
+        const lastLog = razorOutputChannel[razorOutputChannel.length - 1].trim();
+        assert.ok(lastLog.indexOf('Stopping') > 0);
+    });
+
+    it('start->stop->collect captures the last focused Razor document', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
+        const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
+        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
+        const firstTextDocument = new TestTextDocument('empty', api.Uri.parse('C:/something.cshtml'));
+        const expectedTextDocument = new TestTextDocument('empty', api.Uri.parse('C:/something2.cshtml'));
+
+        // Act
+        dataCollector.start();
+        eventEmitter.fire(firstTextDocument);
+        eventEmitter.fire(expectedTextDocument);
+        dataCollector.stop();
+        const collectionResult = dataCollector.collect();
+
+        // Assert
+        assert.equal(collectionResult.document, expectedTextDocument);
+    });
+
+    it('start->stop->collect captures logs between start and stop', async () => {
+        // Arrange
+        const api = createTestVSCodeApi();
+        const eventEmitterFactory = new TestEventEmitterFactory();
+        const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
+        const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
+        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
+        const expectedLogContent = 'Expected Log Content';
+        const unexpectedLogContent = 'SHOULDNOTEXIST';
+        logger.logAlways(unexpectedLogContent);
+
+        // Act
+        dataCollector.start();
+        logger.logAlways(expectedLogContent);
+        dataCollector.stop();
+        const collectionResult = dataCollector.collect();
+
+        // Assert
+        assert.ok(collectionResult.logOutput.indexOf(expectedLogContent) >= 0);
+        assert.ok(collectionResult.logOutput.indexOf(unexpectedLogContent) === -1);
+    });
+});

--- a/client/unittest/ReportIssueDataCollector.test.ts
+++ b/client/unittest/ReportIssueDataCollector.test.ts
@@ -14,20 +14,19 @@ import { createTestVSCodeApi } from './Mocks/TestVSCodeApi';
 
 describe('ReportIssueDataCollector', () => {
 
-    it('start always logs the starting of data collection', async () => {
+    it('construction always logs the starting of data collection', async () => {
         // Arrange
         const api = createTestVSCodeApi();
         const razorOutputChannel = api.getRazorOutputChannel();
         const eventEmitterFactory = new TestEventEmitterFactory();
         const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
         const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
-        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
 
         // Act
-        dataCollector.start();
+        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
 
         // Assert
-        const lastLog = razorOutputChannel[razorOutputChannel.length - 1].trim();
+        const lastLog = razorOutputChannel[razorOutputChannel.length - 1];
         assert.ok(lastLog.indexOf('Starting') > 0);
     });
 
@@ -39,28 +38,26 @@ describe('ReportIssueDataCollector', () => {
         const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
         const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
         const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
-        dataCollector.start();
 
         // Act
         dataCollector.stop();
 
         // Assert
-        const lastLog = razorOutputChannel[razorOutputChannel.length - 1].trim();
+        const lastLog = razorOutputChannel[razorOutputChannel.length - 1];
         assert.ok(lastLog.indexOf('Stopping') > 0);
     });
 
-    it('start->stop->collect captures the last focused Razor document', async () => {
+    it('construction->stop->collect captures the last focused Razor document', async () => {
         // Arrange
         const api = createTestVSCodeApi();
         const eventEmitterFactory = new TestEventEmitterFactory();
         const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
         const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
-        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
         const firstTextDocument = new TestTextDocument('empty', api.Uri.parse('C:/something.cshtml'));
         const expectedTextDocument = new TestTextDocument('empty', api.Uri.parse('C:/something2.cshtml'));
 
         // Act
-        dataCollector.start();
+        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
         eventEmitter.fire(firstTextDocument);
         eventEmitter.fire(expectedTextDocument);
         dataCollector.stop();
@@ -70,21 +67,20 @@ describe('ReportIssueDataCollector', () => {
         assert.equal(collectionResult.document, expectedTextDocument);
     });
 
-    it('start->stop->collect captures logs between start and stop', async () => {
+    it('construction->stop->collect captures logs between construction and stop', async () => {
         // Arrange
         const api = createTestVSCodeApi();
         const eventEmitterFactory = new TestEventEmitterFactory();
         const logger = new RazorLogger(api, eventEmitterFactory, Trace.Off);
         const eventEmitter = eventEmitterFactory.create<vscode.TextDocument>();
-        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
         const expectedLogContent = 'Expected Log Content';
         const unexpectedLogContent = 'SHOULDNOTEXIST';
-        logger.logAlways(unexpectedLogContent);
 
         // Act
-        dataCollector.start();
+        const dataCollector = new ReportIssueDataCollector(eventEmitter.event, logger);
         logger.logAlways(expectedLogContent);
         dataCollector.stop();
+        logger.logAlways(unexpectedLogContent);
         const collectionResult = dataCollector.collect();
 
         // Assert

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.0-preview2-20181026.4
-commithash:f05a283e6c1eb66ef29a32526f75f8b567a986c9
+version:3.0.0-build-20181219.1
+commithash:afd496cf364425795024e88b6581b7b443294b90

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
-  "channel": "dev",
+  "channel": "master",
   "toolsets": {
     "visualstudio": {
       "required": false,
       "includePrerelease": true,
-      "minVersion": "15.8.0",
+      "versionRange": "[15.8.0, 16.0.0)",
       "requiredWorkloads": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostDocumentFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostDocumentFactory.cs
@@ -47,7 +47,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public override HostDocument Create(string documentFilePath)
         {
-            var hostDocument = new HostDocument(documentFilePath, documentFilePath);
+            // Representing all of our host documents with a re-normalized target path to workaround GetRelatedDocument limitations.
+            var targetPath = documentFilePath.Replace('/', '\\').TrimStart('\\');
+            var hostDocument = new HostDocument(documentFilePath, targetPath);
             hostDocument.GeneratedCodeContainer.GeneratedCodeChanged += (sender, args) =>
             {
                 var generatedCodeContainer = (GeneratedCodeContainer)sender;

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
@@ -67,6 +67,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                             () => new ProjectEngineFactory_2_1(),
                             new ExportCustomProjectEngineFactoryAttribute("MVC-2.1") { SupportsSerialization = true }),
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
+                            () => new ProjectEngineFactory_3_0(),
+                            new ExportCustomProjectEngineFactoryAttribute("MVC-3.0") { SupportsSerialization = true }),
+                        new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                             () => new ProjectEngineFactory_Unsupported(),
                             new ExportCustomProjectEngineFactoryAttribute(UnsupportedRazorConfiguration.Instance.ConfigurationName) { SupportsSerialization = true }),
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -14,18 +14,25 @@
   <ItemGroup>
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="$(OmniSharpExtensionsLanguageServerPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="$(MicrosoftCodeAnalysisRazorWorkspacesPackageVersion)" />
+
+    <!-- Needed to make use of the adhoc workspace -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion)" />
+
+    <!-- Blazor dependencies. We have to lift a few runtime packages to make things work with our other dependnecies -->
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Razor.Extensions" Version="$(MicrosoftAspNetCoreBlazorExtensionsPackageVersion)" />
+    <PackageReference Include="System.Runtime.Handles" Version="$(SystemRuntimeHandlesPackageVersion)" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(SystemIOFileSystemPrimitivesPackageVersion)" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="$(SystemTextEncodingExtensionsPackageVersion)" />
   </ItemGroup>
 
   <Target Name="PublishLanguageServerNativeExecutables" AfterTargets="Pack" DependsOnTargets="PublishAllRids" />
 
   <Target Name="IncludeOmniSharpPlugin" AfterTargets="Publish" Condition="Exists('$(PublishDir)')">
-    <MSBuild
-      Projects="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj"
-      Properties="PublishDir=$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish;RuntimeIdentifier="
-      Targets="Publish" />
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj" Properties="PublishDir=$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish;RuntimeIdentifier=" Targets="Publish" />
 
     <PropertyGroup>
       <PluginReferenceOutputPath>$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish</PluginReferenceOutputPath>
@@ -33,13 +40,13 @@
     </PropertyGroup>
 
     <RemoveDir Directories="$(TargetPluginOutputPath)" />
-    <MakeDir Directories="$(TargetPluginOutputPath)" /> 
+    <MakeDir Directories="$(TargetPluginOutputPath)" />
 
     <ItemGroup>
       <PluginAssets Include="$(PluginReferenceOutputPath)\**\*.*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(PluginAssets)" DestinationFiles="@(PluginAssets->'$(TargetPluginOutputPath)\%(RecursiveDir)%(Filename)%(Extension)')" /> 
+    <Copy SourceFiles="@(PluginAssets)" DestinationFiles="@(PluginAssets->'$(TargetPluginOutputPath)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_0.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_0.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class ProjectEngineFactory_2_0 : IProjectEngineFactory
     {
-        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X";
 
         public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_1.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_1.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class ProjectEngineFactory_2_1 : IProjectEngineFactory
     {
-        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X";
         public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
             // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_3_0.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_3_0.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class ProjectEngineFactory_3_0 : IProjectEngineFactory
+    {
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.
+            var assemblyName = new AssemblyName(typeof(ProjectEngineFactory_3_0).Assembly.FullName);
+            assemblyName.Name = AssemblyName;
+
+            var extension = new AssemblyExtension(configuration.ConfigurationName, Assembly.Load(assemblyName));
+            var initializer = extension.CreateInitializer();
+
+            return RazorProjectEngine.Create(configuration, fileSystem, b =>
+            {
+                initializer.Initialize(b);
+                configure?.Invoke(b);
+            });
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
@@ -37,13 +37,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         public override RazorProjectEngine Create(
-            ProjectSnapshot project,
-            RazorProjectFileSystem fileSystem,
+            RazorConfiguration configuration, 
+            RazorProjectFileSystem fileSystem, 
             Action<RazorProjectEngineBuilder> configure)
         {
             var remoteFileSystem = new RemoteRazorProjectFileSystem(_filePathNormalizer);
 
-            return base.Create(project, remoteFileSystem, configure);
+            return base.Create(configuration, remoteFileSystem, configure);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
@@ -33,6 +35,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var physicalFilePath = _filePathNormalizer.Normalize(path);
 
             return new RemoteProjectItem(path, physicalFilePath);
+        }
+
+        protected override string NormalizeAndEnsureValidPath(string path)
+        {
+            return _filePathNormalizer.Normalize(path);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
@@ -23,6 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="$(MicrosoftCodeAnalysisRazorWorkspacesPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Razor.VSCode/package-lock.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/clipboardy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/clipboardy/-/clipboardy-1.1.0.tgz",
+      "integrity": "sha512-KOxf4ah9diZWmREM5jCupx2+pZaBPwKk5d5jeNK2+TY6IgEO35uhG55NnDT4cdXeRX8irDSHQPtdRrr0JOTQIw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
@@ -66,6 +72,11 @@
       "requires": {
         "buffer-equal": "^1.0.0"
       }
+    },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -320,6 +331,15 @@
         }
       }
     },
+    "clipboardy": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+      "requires": {
+        "arch": "^2.1.0",
+        "execa": "^0.8.0"
+      }
+    },
     "clone": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
@@ -399,6 +419,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -516,6 +546,20 @@
         "split": "0.3",
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
+      }
+    },
+    "execa": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -701,6 +745,11 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
@@ -1340,8 +1389,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1381,6 +1429,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "2.1.0",
@@ -1493,6 +1546,15 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "map-stream": {
       "version": "0.1.0",
@@ -1690,6 +1752,14 @@
         "once": "^1.3.2"
       }
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1749,6 +1819,11 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -1789,6 +1864,11 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -1841,6 +1921,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.29",
@@ -2068,6 +2153,24 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
       "integrity": "sha1-ff3YgUvbfKvHvg+x1zTPtmyUBHc="
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2188,6 +2291,11 @@
         "first-chunk-stream": "^1.0.0",
         "strip-bom": "^2.0.0"
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "supports-color": {
       "version": "4.4.0",
@@ -2646,6 +2754,14 @@
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha1-a48UGwu8RK17B+lPgvForHYIrU0="
     },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2657,6 +2773,11 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/src/Microsoft.AspNetCore.Razor.VSCode/package.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/package.json
@@ -4,13 +4,15 @@
   "description": "Implements parts of a VS Code extension for Razor language support.",
   "devDependencies": {
     "@types/node": "^10.9.4",
+    "@types/clipboardy": "1.1.0",
     "tslint": "^5.11.0",
     "typescript": "^3.0.3",
     "vscode": "^1.1.22"
   },
   "dependencies": {
     "vscode-html-languageservice": "^2.1.7",
-    "vscode-languageclient": "^5.1.0"
+    "vscode-languageclient": "^5.1.0",
+    "clipboardy": "1.2.3"
   },
   "main": "./dist/extension.js",
   "types": "./dist/extension.d.ts",

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/IReportIssueDataCollectionResult.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/IReportIssueDataCollectionResult.ts
@@ -3,11 +3,9 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as vscode from './vscodeAdapter';
+import * as vscode from 'vscode';
 
-export class RazorLanguage {
-    public static id = 'aspnetcorerazor';
-    public static fileExtension = 'cshtml';
-    public static globbingPattern = `**/*.${RazorLanguage.fileExtension}`;
-    public static documentSelector: vscode.DocumentSelector =  [ { pattern: RazorLanguage.globbingPattern } ];
+export interface IReportIssueDataCollectionResult {
+    readonly document: vscode.TextDocument | undefined;
+    readonly logOutput: string;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/RazorIssueDataCollector.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/RazorIssueDataCollector.ts
@@ -1,0 +1,48 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as os from 'os';
+import * as vscode from 'vscode';
+import { RazorLogger } from '../RazorLogger';
+import { IReportIssueDataCollectionResult } from './IReportIssueDataCollectionResult';
+
+export class ReportIssueDataCollector {
+    private readonly logMessages: string[] = [];
+    private logOutput = '';
+    private focusRegistration: vscode.Disposable | undefined;
+    private logRegistration: vscode.Disposable | undefined;
+    private lastFocusedRazorDocument: vscode.TextDocument | undefined;
+    constructor(
+        private readonly razorFileFocusChange: vscode.Event<vscode.TextDocument>,
+        private readonly logger: RazorLogger) {
+    }
+
+    public start() {
+        this.focusRegistration = this.razorFileFocusChange((razorDocument) => this.lastFocusedRazorDocument = razorDocument);
+        this.logRegistration = this.logger.onLog(message => this.logMessages.push(message));
+
+        this.logger.outputChannel.show(/* preserveFocus: */ true);
+        this.logger.logAlways('-- Starting Issue Data Collection-- ');
+    }
+
+    public stop() {
+        this.logger.logAlways('-- Stopping Issue Data Collection-- ');
+        this.logOutput = this.logMessages.join(os.EOL);
+        this.logMessages.length = 0;
+        if (this.focusRegistration) {
+            this.focusRegistration.dispose();
+        }
+        if (this.logRegistration) {
+            this.logRegistration.dispose();
+        }
+    }
+
+    public collect(): IReportIssueDataCollectionResult {
+        return {
+            document: this.lastFocusedRazorDocument,
+            logOutput: this.logOutput,
+        };
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueCommand.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueCommand.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RazorDocumentManager } from '../RazorDocumentManager';
+import { RazorLogger } from '../RazorLogger';
+import { api } from '../vscodeAdapter';
+import * as vscode from '../vscodeAdapter';
+import { ReportIssueCreator } from './ReportIssueCreator';
+import { ReportIssueDataCollectorFactory } from './ReportIssueDataCollectorFactory';
+import { ReportIssuePanel } from './ReportIssuePanel';
+
+export class ReportIssueCommand {
+    private readonly issuePanel: ReportIssuePanel;
+    private readonly issueCreator: ReportIssueCreator;
+    private readonly dataCollectorFactory: ReportIssueDataCollectorFactory;
+
+    constructor(
+        private readonly vscodeApi: api,
+        documentManager: RazorDocumentManager,
+        logger: RazorLogger) {
+        this.dataCollectorFactory = new ReportIssueDataCollectorFactory(logger);
+        this.issueCreator = new ReportIssueCreator(this.vscodeApi, documentManager);
+        this.issuePanel = new ReportIssuePanel(this.dataCollectorFactory, this.issueCreator, logger);
+    }
+
+    public register() {
+        const registrations: vscode.Disposable[] = [];
+        registrations.push(
+            this.dataCollectorFactory.register(),
+            this.vscodeApi.commands.registerCommand('razor.reportIssue', () => this.issuePanel.show()));
+        if (this.vscodeApi.window.registerWebviewPanelSerializer) {
+            registrations.push(this.vscodeApi.window.registerWebviewPanelSerializer(ReportIssuePanel.viewType, {
+                deserializeWebviewPanel: async (panel: vscode.WebviewPanel) => {
+                    await this.issuePanel.revive(panel);
+                },
+            }));
+        }
+
+        return this.vscodeApi.Disposable.from(...registrations);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueCreator.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueCreator.ts
@@ -1,0 +1,244 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as cp from 'child_process';
+import * as os from 'os';
+import { IRazorDocument } from '../IRazorDocument';
+import { IRazorDocumentManager } from '../IRazorDocumentManager';
+import { razorExtensionId } from '../RazorExtensionId';
+import * as vscode from '../vscodeAdapter';
+import { IReportIssueDataCollectionResult } from './IReportIssueDataCollectionResult';
+
+export class ReportIssueCreator {
+    constructor(
+        private readonly vscodeApi: vscode.api,
+        private readonly documentManager: IRazorDocumentManager) {
+    }
+
+    public async create(collectionResult: IReportIssueDataCollectionResult) {
+        let razorContent: string;
+        let csharpContent: string;
+        let htmlContent: string;
+
+        if (collectionResult.document) {
+            razorContent = await this.getRazor(collectionResult.document);
+
+            const razorDocument = await this.documentManager.getDocument(collectionResult.document.uri);
+            csharpContent = await this.getProjectedCSharp(razorDocument);
+            htmlContent = await this.getProjectedHtml(razorDocument);
+        } else {
+            razorContent = 'Non Razor file as active document';
+            csharpContent = 'Could not determine CSharp content';
+            htmlContent = 'Could not determine Html content';
+        }
+
+        const razorExtensionVersion = this.getExtensionVersion();
+        const dotnetInfo = await this.getDotnetInfo();
+        const extensionTable = this.generateExtensionTable();
+        return `## Is this a Bug or Feature request?:
+Bug
+
+## Steps to reproduce
+------------------- Please fill in this section -------------------------
+
+## Description of the problem:
+------------------- Please fill in this section -------------------------
+
+Expected behavior:
+
+Actual behavior:
+
+## Logs
+
+#### OmniSharp
+------------------- Please fill in this section -------------------------
+To find the OmniSharp log, open VS Code's "Output" pane, then in the dropdown choose "OmniSharp Log".
+
+#### Razor
+<details><summary>Expand</summary>
+<p>
+
+\`\`\`
+${collectionResult.logOutput}
+\`\`\`
+
+</p>
+</details>
+
+## Workspace information
+
+#### Razor document:
+<details><summary>Expand</summary>
+<p>
+
+\`\`\`Razor
+${razorContent}
+\`\`\`
+
+</p>
+</details>
+
+#### Projected CSharp document:
+<details><summary>Expand</summary>
+<p>
+
+\`\`\`C#
+${csharpContent}
+\`\`\`
+
+</p>
+</details>
+
+#### Projected Html document:
+<details><summary>Expand</summary>
+<p>
+
+\`\`\`Html
+${htmlContent}
+\`\`\`
+
+</p>
+</details>
+
+## Machine information
+
+
+**VSCode version**: ${this.vscodeApi.version}
+**Razor.VSCode version**: ${razorExtensionVersion}
+#### \`dotnet --info\`
+
+<details><summary>Expand</summary>
+<p>
+
+\`\`\`
+${dotnetInfo}
+\`\`\`
+
+</p>
+</details>
+
+#### Extensions
+<details><summary>Expand</summary>
+<p>
+
+${extensionTable}
+
+</p>
+</details>`;
+    }
+
+    // Protected for testing
+    protected async getRazor(document: vscode.TextDocument) {
+        const content = document.getText();
+
+        return content;
+    }
+
+    // Protected for testing
+    protected async getProjectedCSharp(razorDocument: IRazorDocument) {
+        let csharpContent = `////////////////////// Projected CSharp as seen by extension ///////////////////////
+${razorDocument.csharpDocument.getContent()}
+
+
+////////////////////// Projected CSharp as seen by VSCode ///////////////////////`;
+
+        const csharpTextDocument = await this.vscodeApi.workspace.openTextDocument(razorDocument.csharpDocument.uri);
+        if (csharpTextDocument) {
+            csharpContent = `${csharpContent}
+${csharpTextDocument.getText()}`;
+        } else {
+            csharpContent = `${csharpContent}
+Unable to resolve VSCode's version of CSharp`;
+        }
+
+        return csharpContent;
+    }
+
+    // Protected for testing
+    protected async getProjectedHtml(razorDocument: IRazorDocument) {
+        let htmlContent = `////////////////////// Projected Html as seen by extension ///////////////////////
+${razorDocument.htmlDocument.getContent()}
+
+
+////////////////////// Projected Html as seen by VSCode ///////////////////////`;
+
+        const htmlTextDocument = await this.vscodeApi.workspace.openTextDocument(razorDocument.htmlDocument.uri);
+        if (htmlTextDocument) {
+            htmlContent = `${htmlContent}
+${htmlTextDocument.getText()}`;
+        } else {
+            htmlContent = `${htmlContent}
+Unable to resolve VSCode's version of Html`;
+        }
+
+        return htmlContent;
+    }
+
+    // Protected for testing
+    protected getExtensionVersion(): string {
+        const extension = this.vscodeApi.extensions.getExtension(razorExtensionId);
+        if (!extension) {
+            return 'Unable to find Razor extension version.';
+        }
+        return extension.packageJSON.version;
+    }
+
+    // Protected for testing
+    protected getInstalledExtensions() {
+        const extensions: Array<vscode.Extension<any>> = this.vscodeApi.extensions.all
+            .filter(extension => extension.packageJSON.isBuiltin === false);
+
+        return extensions.sort(this.sortExtensions);
+    }
+
+    // Protected for testing
+    protected sortExtensions(a: vscode.Extension<any>, b: vscode.Extension<any>): number {
+        const aName = a.packageJSON.name.toLowerCase();
+        const bName = b.packageJSON.name.toLowerCase();
+        if (aName < bName) {
+            return -1;
+        }
+        if (aName > bName) {
+            return 1;
+        }
+        return 0;
+    }
+
+    // Protected for testing
+    protected generateExtensionTable() {
+        const extensions = this.getInstalledExtensions();
+        if (extensions.length <= 0) {
+            return 'none';
+        }
+
+        const tableHeader = `|Extension|Author|Version|\n|---|---|---|`;
+        const table = extensions.map(
+            (e) => `|${e.packageJSON.name}|${e.packageJSON.publisher}|${e.packageJSON.version}|`).join(os.EOL);
+
+        const extensionTable = `
+${tableHeader}\n${table};
+`;
+
+        return extensionTable;
+    }
+
+    private getDotnetInfo(): Promise<string> {
+        return new Promise<string>((resolve) => {
+            try {
+                cp.exec('dotnet --info', { cwd: process.cwd(), maxBuffer: 500 * 1024 }, (error, stdout, stderr) => {
+                    if (error) {
+                        throw error;
+                    } else if (stderr && stderr.length > 0) {
+                        throw new Error(stderr);
+                    } else {
+                        resolve(stdout);
+                    }
+                });
+            } catch (error) {
+                resolve(`A valid dotnet installation could not be found: ${error}`);
+            }
+        });
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueDataCollector.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueDataCollector.ts
@@ -1,0 +1,48 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as os from 'os';
+import * as vscode from 'vscode';
+import { RazorLogger } from '../RazorLogger';
+import { IReportIssueDataCollectionResult } from './IReportIssueDataCollectionResult';
+
+export class ReportIssueDataCollector {
+    private readonly logMessages: string[] = [];
+    private logOutput = '';
+    private focusRegistration: vscode.Disposable | undefined;
+    private logRegistration: vscode.Disposable | undefined;
+    private lastFocusedRazorDocument: vscode.TextDocument | undefined;
+    constructor(
+        private readonly razorFileFocusChange: vscode.Event<vscode.TextDocument>,
+        private readonly logger: RazorLogger) {
+    }
+
+    public start() {
+        this.focusRegistration = this.razorFileFocusChange((razorDocument) => this.lastFocusedRazorDocument = razorDocument);
+        this.logRegistration = this.logger.onLog(message => this.logMessages.push(message));
+
+        this.logger.outputChannel.show(/* preserveFocus: */ true);
+        this.logger.logAlways('-- Starting Issue Data Collection-- ');
+    }
+
+    public stop() {
+        this.logger.logAlways('-- Stopping Issue Data Collection-- ');
+        this.logOutput = this.logMessages.join(os.EOL);
+        this.logMessages.length = 0;
+        if (this.focusRegistration) {
+            this.focusRegistration.dispose();
+        }
+        if (this.logRegistration) {
+            this.logRegistration.dispose();
+        }
+    }
+
+    public collect(): IReportIssueDataCollectionResult {
+        return {
+            document: this.lastFocusedRazorDocument,
+            logOutput: this.logOutput,
+        };
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueDataCollector.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueDataCollector.ts
@@ -17,9 +17,7 @@ export class ReportIssueDataCollector {
     constructor(
         private readonly razorFileFocusChange: vscode.Event<vscode.TextDocument>,
         private readonly logger: RazorLogger) {
-    }
 
-    public start() {
         this.focusRegistration = this.razorFileFocusChange((razorDocument) => this.lastFocusedRazorDocument = razorDocument);
         this.logRegistration = this.logger.onLog(message => this.logMessages.push(message));
 

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueDataCollectorFactory.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssueDataCollectorFactory.ts
@@ -1,0 +1,30 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { RazorLanguage } from '../RazorLanguage';
+import { RazorLogger } from '../RazorLogger';
+import { ReportIssueDataCollector } from './ReportIssueDataCollector';
+
+export class ReportIssueDataCollectorFactory {
+    private onRazorDocumentFocusedEmitter = new vscode.EventEmitter<vscode.TextDocument>();
+
+    constructor(private readonly logger: RazorLogger) {
+        this.onRazorDocumentFocusedEmitter = new vscode.EventEmitter<vscode.TextDocument>();
+    }
+
+    public register() {
+        return vscode.window.onDidChangeActiveTextEditor((newEditor) => {
+            if (newEditor && newEditor.document.fileName.endsWith(RazorLanguage.fileExtension)) {
+                this.onRazorDocumentFocusedEmitter.fire(newEditor.document);
+            }
+        });
+    }
+
+    public create() {
+        const collector = new ReportIssueDataCollector(this.onRazorDocumentFocusedEmitter.event, this.logger);
+        return collector;
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
@@ -1,0 +1,170 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as clipboardy from 'clipboardy';
+import * as vscode from 'vscode';
+import { Trace } from 'vscode-jsonrpc';
+import { RazorLogger } from '../RazorLogger';
+import { ReportIssueCreator } from './ReportIssueCreator';
+import { ReportIssueDataCollector } from './ReportIssueDataCollector';
+import { ReportIssueDataCollectorFactory } from './ReportIssueDataCollectorFactory';
+
+export class ReportIssuePanel {
+    public static readonly viewType = 'razorReportIssue';
+
+    private panel: vscode.WebviewPanel | undefined;
+    private dataCollector: ReportIssueDataCollector | undefined;
+    private issueContent: string | undefined;
+
+    constructor(
+        private readonly dataCollectorFactory: ReportIssueDataCollectorFactory,
+        private readonly reportIssueCreator: ReportIssueCreator,
+        private readonly logger: RazorLogger) {
+    }
+
+    public async show() {
+        if (this.panel) {
+            this.panel.reveal(vscode.ViewColumn.Two);
+        } else {
+            this.panel = vscode.window.createWebviewPanel(
+                ReportIssuePanel.viewType,
+                'Report Razor Issue',
+                vscode.ViewColumn.Two, {
+                    enableScripts: true,
+                    // Dissallow any remote sources
+                    localResourceRoots: [],
+                });
+            this.attachToCurrentPanel();
+        }
+
+        await this.update();
+    }
+
+    public async revive(panel: vscode.WebviewPanel) {
+        this.panel = panel;
+        this.attachToCurrentPanel();
+        await this.update();
+    }
+
+    private attachToCurrentPanel() {
+        if (!this.panel) {
+            vscode.window.showErrorMessage('Unexpected error when attaching to report Razor issue window.');
+            return;
+        }
+
+        this.panel.webview.onDidReceiveMessage(async message => {
+            switch (message.command) {
+                case 'copyIssue':
+                    if (!this.issueContent) {
+                        if (!this.dataCollector) {
+                            vscode.window.showErrorMessage('You must first start the data collection before copying.');
+                            return;
+                        }
+                        const collectionResult = this.dataCollector.collect();
+                        this.issueContent = await this.reportIssueCreator.create(collectionResult);
+                        this.dataCollector = undefined;
+                    }
+
+                    await clipboardy.write(this.issueContent);
+                    vscode.window.showInformationMessage('Razor issue copied to clipboard');
+                    return;
+                case 'startIssue':
+                    this.issueContent = undefined;
+                    this.dataCollector = this.dataCollectorFactory.create();
+                    this.dataCollector.start();
+                    vscode.window.showInformationMessage('Razor issue data colletion started. Reproduce the issue then press "Stop"');
+                    return;
+                case 'stopIssue':
+                    if (!this.dataCollector) {
+                        vscode.window.showErrorMessage('You must first start the data collection before stopping.');
+                        return;
+                    }
+                    this.dataCollector.stop();
+                    vscode.window.showInformationMessage('Razor issue data colletion stopped. Copying issue content...');
+                    return;
+            }
+        });
+        this.panel.onDidDispose(() => this.panel = undefined);
+    }
+
+    private async update() {
+        if (!this.panel) {
+            return;
+        }
+
+        let panelBodyContent = '';
+        if (this.logger.trace === Trace.Verbose) {
+            panelBodyContent = `<ol>
+    <li>Press <button onclick="startIssue()">Start</button></li>
+    <li>Perform the actions (or no action) that resulted in your Razor issue</li>
+    <li>Click <button onclick="stopIssue()">Stop</button>. This will copy all relevant issue information.</li>
+    <li><a href="https://github.com/aspnet/Razor.VSCode/issues/new">Go to GitHub</a>, paste your issue contents as the body of the issue. Don't forget to fill out any details left unfilled.</li>
+</ol>
+
+<p><em>Note: the contents copied to your clipboard may contain personally identifiable information. Be sure to remove any information you don't feel
+fit to exist on GitHub from the issue prior to submitting it.</em></p>
+
+<button onclick="copyIssue()">Copy issue content again</button>`;
+        } else {
+            panelBodyContent = `<p>Cannot start collecting Razor logs when <strong><em>razor.trace</em></strong> is set to <strong><em>${Trace[this.logger.trace]}</em></strong>.
+Please set <strong><em>razor.trace</em></strong> to <strong><em>${Trace[Trace.Verbose]}</em></strong> and then reload your VSCode environment and re-run the report Razor issue command.</p>`;
+        }
+
+        this.panel.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Report a Razor issue</title>
+    <style>
+        button {
+            background-color: #eff3f6;
+            background-image: linear-gradient(-180deg,#fafbfc,#eff3f6 90%);
+            color: #24292e;
+            border: 1px solid rgba(27,31,35,.2);
+            border-radius: .25em;
+            font-size: 1.1em;
+            font-weight: 600;
+            line-height: 18px;
+            padding: 6px 12px;
+            vertical-align: middle;
+            cursor: pointer;
+        }
+        body {
+            font-size: 20px;
+        }
+        strong {
+            color: red;
+        }
+    </style>
+
+    <script type="text/javascript">
+        const vscode = acquireVsCodeApi();
+        function copyIssue() {
+            vscode.postMessage({
+                command: 'copyIssue'
+            });
+        }
+        function startIssue() {
+            vscode.postMessage({
+                command: 'startIssue'
+            });
+        }
+        function stopIssue() {
+            vscode.postMessage({
+                command: 'stopIssue'
+            });
+            copyIssue();
+        }
+    </script>
+</head>
+<body>
+<h3>Report a Razor issue</h3>
+${panelBodyContent}
+</body>
+</html>`;
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
@@ -71,9 +71,12 @@ export class ReportIssuePanel {
                     vscode.window.showInformationMessage('Razor issue copied to clipboard');
                     return;
                 case 'startIssue':
+                    if (this.dataCollector) {
+                        this.dataCollector.stop();
+                        this.dataCollector = undefined;
+                    }
                     this.issueContent = undefined;
                     this.dataCollector = this.dataCollectorFactory.create();
-                    this.dataCollector.start();
                     vscode.window.showInformationMessage('Razor issue data colletion started. Reproduce the issue then press "Stop"');
                     return;
                 case 'stopIssue':

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/IEventEmitterFactory.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/IEventEmitterFactory.ts
@@ -1,0 +1,10 @@
+/* --------------------------------------------------------------------------------------------
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT License. See License.txt in the project root for license information.
+* ------------------------------------------------------------------------------------------ */
+
+import { EventEmitter } from './vscodeAdapter';
+
+export interface IEventEmitterFactory {
+    create: <T>() => EventEmitter<T>;
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorDocumentManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorDocumentManager.ts
@@ -1,0 +1,17 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { IRazorDocument } from './IRazorDocument';
+import { IRazorDocumentChangeEvent } from './IRazorDocumentChangeEvent';
+import * as vscode from './vscodeAdapter';
+
+export interface IRazorDocumentManager {
+    readonly onChange: vscode.Event<IRazorDocumentChangeEvent>;
+    readonly documents: IRazorDocument[];
+    getDocument(uri: vscode.Uri): Promise<IRazorDocument>;
+    getActiveDocument(): Promise<IRazorDocument | null>;
+    initialize(): Promise<void>;
+    register(): vscode.Disposable;
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -8,6 +8,7 @@ import { CSharpProjectedDocument } from './CSharp/CSharpProjectedDocument';
 import { HtmlProjectedDocument } from './Html/HtmlProjectedDocument';
 import { IRazorDocument } from './IRazorDocument';
 import { IRazorDocumentChangeEvent } from './IRazorDocumentChangeEvent';
+import { IRazorDocumentManager } from './IRazorDocumentManager';
 import { RazorDocumentChangeKind } from './RazorDocumentChangeKind';
 import { createDocument } from './RazorDocumentFactory';
 import { RazorLanguage } from './RazorLanguage';
@@ -16,7 +17,7 @@ import { RazorLogger } from './RazorLogger';
 import { UpdateCSharpBufferRequest } from './RPC/UpdateCSharpBufferRequest';
 import { getUriPath } from './UriPaths';
 
-export class RazorDocumentManager {
+export class RazorDocumentManager implements IRazorDocumentManager {
     private readonly razorDocuments: { [hostDocumentPath: string]: IRazorDocument } = {};
     private onChangeEmitter = new vscode.EventEmitter<IRazorDocumentChangeEvent>();
 

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorExtensionId.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorExtensionId.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// The Razor experience is shipped as part of OmniSharp, this is their extension ID.
+export const razorExtensionId = 'ms-vscode.csharp';

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
@@ -10,10 +10,16 @@ import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageServerOptions } from './RazorLanguageServerOptions';
 import { RazorLogger } from './RazorLogger';
 import { Trace } from './Trace';
+import * as vscode from './vscodeAdapter';
 
-export function resolveRazorLanguageServerOptions(languageServerDir: string, trace: Trace, logger: RazorLogger) {
+export function resolveRazorLanguageServerOptions(
+    vscodeApi: vscode.api,
+    languageServerDir: string,
+    trace: Trace,
+    logger: RazorLogger) {
     const languageServerExecutablePath = findLanguageServerExecutable(languageServerDir);
-    const debugLanguageServer = RazorLanguage.serverConfig.get<boolean>('debug');
+    const serverConfig = vscodeApi.workspace.getConfiguration('razor.languageServer');
+    const debugLanguageServer = serverConfig.get<boolean>('debug');
 
     return {
         serverPath: languageServerExecutablePath,

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerTraceResolver.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerTraceResolver.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { RazorLanguage } from './RazorLanguage';
 import { Trace } from './Trace';
+import * as vscode from './vscodeAdapter';
 
-export function resolveRazorLanguageServerTrace() {
-    const traceString = RazorLanguage.languageConfig.get<string>('trace');
+export function resolveRazorLanguageServerTrace(vscodeApi: vscode.api) {
+    const languageConfig = vscodeApi.workspace.getConfiguration('razor');
+    const traceString = languageConfig.get<string>('trace');
     const trace = parseTraceString(traceString);
 
     return trace;

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -39,7 +39,7 @@ export async function activate(context: ExtensionContext, languageServerDir: str
         const logger = new RazorLogger(vscode, eventEmitterFactory, languageServerTrace);
         const languageServerOptions = resolveRazorLanguageServerOptions(vscode, languageServerDir, languageServerTrace, logger);
         const languageServerClient = new RazorLanguageServerClient(languageServerOptions, telemetryReporter, logger);
-        const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
+        const languageServiceClient = new RazorLanguageServiceClient(languageServerClient, logger);
         const documentManager = new RazorDocumentManager(languageServerClient, logger);
         reportTelemetryForDocuments(documentManager, telemetryReporter);
         const projectManager = new RazorProjectManager(logger);

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
@@ -163,7 +163,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var router = new TestRouter();
-            var document = TestDocumentSnapshot.Create("C:/path/file.cshtml", VersionStamp.Default.GetNewerVersion());
+            var documentVersion = VersionStamp.Default.GetNewerVersion();
+            var document = TestDocumentSnapshot.Create("C:/path/file.cshtml", documentVersion);
             var cache = new TestDocumentVersionCache(new Dictionary<DocumentSnapshot, long>()
             {
                 [document] = 1337,
@@ -171,7 +172,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, document);
+            document.State.HostDocument.GeneratedCodeContainer.SetOutput(document, csharpDocument, documentVersion.GetNewerVersion(), VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
@@ -199,7 +200,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            oldDocument.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, lastDocument);
+            oldDocument.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(oldDocument.FilePath, oldDocument) };
@@ -227,7 +228,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, lastDocument);
+            document.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
@@ -255,7 +256,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, lastDocument);
+            document.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
@@ -90,8 +90,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             document.TryGetTextVersion(out var textVersion);
             var textAndVersion = TextAndVersion.Create(text, textVersion);
             documentVersionCache.TrackDocumentVersion(document, 1337);
-            projectSnapshotManager.HostProjectAdded(document.Project.HostProject);
-            projectSnapshotManager.DocumentAdded(document.Project.HostProject, document.State.HostDocument, TextLoader.From(textAndVersion));
+            projectSnapshotManager.HostProjectAdded(document.ProjectInternal.HostProject);
+            projectSnapshotManager.DocumentAdded(document.ProjectInternal.HostProject, document.State.HostDocument, TextLoader.From(textAndVersion));
 
             // Act - 1
             var result = documentVersionCache.TryGetDocumentVersion(document, out var version);
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.True(result);
 
             // Act - 2
-            projectSnapshotManager.DocumentRemoved(document.Project.HostProject, document.State.HostDocument);
+            projectSnapshotManager.DocumentRemoved(document.ProjectInternal.HostProject, document.State.HostDocument);
             result = documentVersionCache.TryGetDocumentVersion(document, out version);
 
             // Assert - 2
@@ -120,9 +120,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             document.TryGetTextVersion(out var textVersion);
             var textAndVersion = TextAndVersion.Create(text, textVersion);
             documentVersionCache.TrackDocumentVersion(document, 1337);
-            projectSnapshotManager.HostProjectAdded(document.Project.HostProject);
+            projectSnapshotManager.HostProjectAdded(document.ProjectInternal.HostProject);
             var textLoader = TextLoader.From(textAndVersion);
-            projectSnapshotManager.DocumentAdded(document.Project.HostProject, document.State.HostDocument, textLoader);
+            projectSnapshotManager.DocumentAdded(document.ProjectInternal.HostProject, document.State.HostDocument, textLoader);
 
             // Act - 1
             var result = documentVersionCache.TryGetDocumentVersion(document, out var version);
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.True(result);
 
             // Act - 2
-            projectSnapshotManager.DocumentClosed(document.Project.HostProject.FilePath, document.State.HostDocument.FilePath, textLoader);
+            projectSnapshotManager.DocumentClosed(document.ProjectInternal.HostProject.FilePath, document.State.HostDocument.FilePath, textLoader);
             result = documentVersionCache.TryGetDocumentVersion(document, out version);
 
             // Assert - 2

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure;
 using Microsoft.CodeAnalysis;
@@ -98,74 +99,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
-        public void TryUpdateViewImportDependencies_OnlyUpdatesOpenDocuments()
-        {
-            // Arrange
-            var importFilePath = "/C:/path/to/_ViewImports.cshtml";
-            var documentFilePath = "/C:/path/to/Index.cshtml";
-            var closedDocumentFilePath = "/C:/path/to/About.cshtml";
-            var ownerProject = TestProjectSnapshot.Create(
-                "/C:/path/to/project.csproj",
-                new[]
-                {
-                    importFilePath,
-                    documentFilePath,
-                    closedDocumentFilePath,
-                });
-            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
-            projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, It.IsAny<TextLoader>()));
-            projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(documentFilePath)).Returns(true);
-            projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(closedDocumentFilePath)).Returns(false);
-            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
-
-            // Act
-            projectService.TryUpdateViewImportDependencies(importFilePath, ownerProject);
-
-            // Assert
-            projectSnapshotManager.VerifyAll();
-        }
-
-        [Fact]
-        public void TryUpdateViewImportDependencies_UpdatesOtherDocuments()
-        {
-            // Arrange
-            var importFilePath = "/C:/path/to/_ViewImports.cshtml";
-            var documentFilePath = "/C:/path/to/Index.cshtml";
-            var ownerProject = TestProjectSnapshot.Create(
-                "/C:/path/to/project.csproj",
-                new[]
-                {
-                    importFilePath,
-                    documentFilePath,
-                });
-            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
-            projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, It.IsAny<TextLoader>()));
-            projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(documentFilePath)).Returns(true);
-            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
-
-            // Act
-            projectService.TryUpdateViewImportDependencies(importFilePath, ownerProject);
-
-            // Assert
-            projectSnapshotManager.VerifyAll();
-        }
-
-        [Fact]
-        public void TryUpdateViewImportDependencies_NoopsForNonViewImportFiles()
-        {
-            // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
-            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
-            projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, It.IsAny<TextLoader>()))
-                .Throws(new XunitException("Should not have been called."));
-            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
-
-            // Act & Assert
-            projectService.TryUpdateViewImportDependencies(documentFilePath, ownerProject);
-        }
-
-        [Fact]
         public void CloseDocument_ClosesDocumentInOwnerProject()
         {
             // Arrange
@@ -176,7 +109,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("//__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentClosed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TextLoader>()))
                 .Callback<string, string, TextLoader>((projectFilePath, documentFilePath, text) =>
@@ -200,7 +133,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -233,7 +166,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Throws(new InvalidOperationException("This shouldn't have been called."));
@@ -261,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -298,7 +231,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Callback<HostProject, HostDocument, TextLoader>((hostProject, hostDocument, loader) =>
@@ -356,7 +289,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Callback<HostProject, HostDocument, TextLoader>((hostProject, hostDocument, loader) =>
@@ -380,7 +313,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
@@ -411,7 +344,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProject>(), It.IsAny<HostDocument>()))
                 .Callback<HostProject, HostDocument>((hostProject, hostDocument) =>
@@ -433,7 +366,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath });
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -464,7 +397,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProject>(), It.IsAny<HostDocument>()))
                 .Throws(new InvalidOperationException("Should not have been called."));
@@ -479,7 +412,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new string[0]);
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new string[0]);
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -503,7 +436,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var newText = SourceText.From("Something New");
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, newText))
@@ -527,10 +460,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath });
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var newText = SourceText.From("Something New");
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentChanged(miscellaneousProject.FilePath, documentFilePath, newText))
@@ -560,7 +493,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             DocumentSnapshot documentSnapshot = TestDocumentSnapshot.Create(documentFilePath);
             var documentResolver = Mock.Of<DocumentResolver>(resolver => resolver.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true);
             var documentVersionCache = new Mock<DocumentVersionCache>(MockBehavior.Strict);
@@ -595,7 +528,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var documentVersionCache = new Mock<DocumentVersionCache>();
             documentVersionCache.Setup(cache => cache.TrackDocumentVersion(It.IsAny<DocumentSnapshot>(), It.IsAny<long>()))
                 .Throws<XunitException>();
@@ -614,7 +547,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectFilePath = "/C:/path/to/project.csproj";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.HostProjectAdded(It.IsAny<HostProject>()))
@@ -638,7 +571,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var projectFilePath = "/C:/path/to/project.csproj";
             var ownerProject = TestProjectSnapshot.Create(projectFilePath);
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
@@ -662,7 +595,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectFilePath = "C:/path/to/project.csproj";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.HostProjectRemoved(It.IsAny<HostProject>()))
@@ -677,9 +610,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateDocumentsFromRemovedProject_MigratesDocumentsToNonMiscProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var documentFilePath1 = "C:/path/to/some/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/some/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var removedProject = TestProjectSnapshot.Create("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
             var projectToBeMigratedTo = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
@@ -705,7 +638,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             projectService.TryMigrateDocumentsFromRemovedProject(removedProject);
 
             // Assert
-            Assert.Collection(migratedDocuments,
+            Assert.Collection(migratedDocuments.OrderBy(doc => doc.FilePath),
                 document => Assert.Equal(documentFilePath1, document.FilePath),
                 document => Assert.Equal(documentFilePath2, document.FilePath));
         }
@@ -714,10 +647,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateDocumentsFromRemovedProject_MigratesDocumentsToMiscProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
-            var removedProject = TestProjectSnapshot.Create("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
+            var documentFilePath1 = "/C:/path/to/some/document1.cshtml";
+            var documentFilePath2 = "/C:/path/to/some/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var removedProject = TestProjectSnapshot.Create("/C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var migratedDocuments = new List<HostDocument>();
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
@@ -735,7 +668,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             projectService.TryMigrateDocumentsFromRemovedProject(removedProject);
 
             // Assert
-            Assert.Collection(migratedDocuments,
+            Assert.Collection(migratedDocuments.OrderBy(doc => doc.FilePath),
                 document => Assert.Equal(documentFilePath1, document.FilePath),
                 document => Assert.Equal(documentFilePath2, document.FilePath));
         }
@@ -744,9 +677,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateMiscellaneousDocumentsToProject_DoesNotMigrateDocumentsIfNoOwnerProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var documentFilePath1 = "/C:/path/to/document1.cshtml";
+            var documentFilePath2 = "/C:/path/to/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
@@ -761,10 +694,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateMiscellaneousDocumentsToProject_MigratesDocumentsToNewOwnerProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
-            var projectToBeMigratedTo = TestProjectSnapshot.Create("C:/path/to/project.csproj");
+            var documentFilePath1 = "/C:/path/to/document1.cshtml";
+            var documentFilePath2 = "/C:/path/to/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var projectToBeMigratedTo = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
@@ -795,7 +728,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             projectService.TryMigrateMiscellaneousDocumentsToProject();
 
             // Assert
-            Assert.Collection(migratedDocuments,
+            Assert.Collection(migratedDocuments.OrderBy(doc => doc.FilePath),
                 document => Assert.Equal(documentFilePath1, document.FilePath),
                 document => Assert.Equal(documentFilePath2, document.FilePath));
         }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestLanguageServices.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestLanguageServices.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    internal class TestLanguageServices : HostLanguageServices
+    {
+        private readonly HostWorkspaceServices _workspaceServices;
+        private readonly IEnumerable<ILanguageService> _languageServices;
+
+        public TestLanguageServices(HostWorkspaceServices workspaceServices, IEnumerable<ILanguageService> languageServices)
+        {
+            if (workspaceServices == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceServices));
+            }
+
+            if (languageServices == null)
+            {
+                throw new ArgumentNullException(nameof(languageServices));
+            }
+
+            _workspaceServices = workspaceServices;
+            _languageServices = languageServices;
+        }
+
+        public override HostWorkspaceServices WorkspaceServices => _workspaceServices;
+
+        public override string Language => RazorLanguage.Name;
+
+        public override TLanguageService GetService<TLanguageService>()
+        {
+            var service = _languageServices.OfType<TLanguageService>().FirstOrDefault();
+
+            if (service == null)
+            {
+                throw new InvalidOperationException($"Test Razor language services not configured properly, missing language service '{typeof(TLanguageService).FullName}'.");
+            }
+
+            return service;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshot.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshot.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 
@@ -17,7 +18,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
 
         public static TestProjectSnapshot Create(string filePath, string[] documentFilePaths)
         {
-            var workspace = TestWorkspace.Create();
+            var workspaceServices = new List<IWorkspaceService>()
+            {
+                new TestProjectSnapshotProjectEngineFactory(),
+            };
+            var languageServices = new List<ILanguageService>();
+
+            var hostServices = TestServices.Create(workspaceServices, languageServices);
+            var workspace = TestWorkspace.Create(hostServices);
             var hostProject = new HostProject(filePath, RazorConfiguration.Default);
             var state = ProjectState.Create(workspace.Services, hostProject);
             foreach (var documentFilePath in documentFilePaths)

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshotProjectEngineFactory.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshotProjectEngineFactory.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    internal class TestProjectSnapshotProjectEngineFactory : ProjectSnapshotProjectEngineFactory
+    {
+        public Action<RazorProjectEngineBuilder> Configure { get; set; }
+
+        public RazorProjectEngine Engine { get; set; }
+
+        public override RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            return Engine ?? RazorProjectEngine.Create(configuration, fileSystem, configure ?? Configure);
+        }
+
+        public override IProjectEngineFactory FindFactory(ProjectSnapshot project)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IProjectEngineFactory FindSerializableFactory(ProjectSnapshot project)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestServices.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestServices.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    public class TestServices : HostServices
+    {
+        private readonly IEnumerable<IWorkspaceService> _workspaceServices;
+        private readonly IEnumerable<ILanguageService> _razorLanguageServices;
+
+        private TestServices(IEnumerable<IWorkspaceService> workspaceServices, IEnumerable<ILanguageService> razorLanguageServices)
+        {
+            if (workspaceServices == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceServices));
+            }
+
+            if (razorLanguageServices == null)
+            {
+                throw new ArgumentNullException(nameof(razorLanguageServices));
+            }
+
+            _workspaceServices = workspaceServices;
+            _razorLanguageServices = razorLanguageServices;
+        }
+
+        protected override HostWorkspaceServices CreateWorkspaceServices(Workspace workspace)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            return new TestWorkspaceServices(this, _workspaceServices, _razorLanguageServices, workspace);
+        }
+
+        public static HostServices Create(IEnumerable<ILanguageService> razorLanguageServices)
+            => Create(Enumerable.Empty<IWorkspaceService>(), razorLanguageServices);
+
+        public static HostServices Create(IEnumerable<IWorkspaceService> workspaceServices, IEnumerable<ILanguageService> razorLanguageServices)
+            => new TestServices(workspaceServices, razorLanguageServices);
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestWorkspaceServices.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestWorkspaceServices.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    internal class TestWorkspaceServices : HostWorkspaceServices
+    {
+        private static readonly Workspace DefaultWorkspace = TestWorkspace.Create();
+
+        private readonly HostServices _hostServices;
+        private readonly HostLanguageServices _razorLanguageServices;
+        private readonly IEnumerable<IWorkspaceService> _workspaceServices;
+        private readonly Workspace _workspace;
+
+        public TestWorkspaceServices(
+            HostServices hostServices,
+            IEnumerable<IWorkspaceService> workspaceServices,
+            IEnumerable<ILanguageService> languageServices,
+            Workspace workspace)
+        {
+            if (hostServices == null)
+            {
+                throw new ArgumentNullException(nameof(hostServices));
+            }
+
+            if (workspaceServices == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceServices));
+            }
+
+            if (languageServices == null)
+            {
+                throw new ArgumentNullException(nameof(languageServices));
+            }
+
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _hostServices = hostServices;
+            _workspaceServices = workspaceServices;
+            _workspace = workspace;
+
+            _razorLanguageServices = new TestLanguageServices(this, languageServices);
+        }
+
+        public override HostServices HostServices => _hostServices;
+
+        public override Workspace Workspace => _workspace;
+
+        public override TWorkspaceService GetService<TWorkspaceService>()
+        {
+            var service = _workspaceServices.OfType<TWorkspaceService>().FirstOrDefault();
+
+            if (service == null)
+            {
+                // Fallback to default host services to resolve roslyn specific features.
+                service = DefaultWorkspace.Services.GetService<TWorkspaceService>();
+            }
+
+            return service;
+        }
+
+        public override HostLanguageServices GetLanguageServices(string languageName)
+        {
+            if (languageName == RazorLanguage.Name)
+            {
+                return _razorLanguageServices;
+            }
+
+            // Fallback to default host services to resolve roslyn specific features.
+            return DefaultWorkspace.Services.GetLanguageServices(languageName);
+        }
+
+        public override IEnumerable<string> SupportedLanguages => new[] { RazorLanguage.Name };
+
+        public override bool IsSupported(string languageName) => languageName == RazorLanguage.Name;
+
+        public override IEnumerable<TLanguageService> FindLanguageServices<TLanguageService>(MetadataFilter filter) => throw new NotImplementedException();
+    }
+}

--- a/test/testapps/BasicRazorApp3_0/BasicRazorApp3_0.csproj
+++ b/test/testapps/BasicRazorApp3_0/BasicRazorApp3_0.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/test/testapps/BasicRazorApp3_0/Pages/Index.cshtml
+++ b/test/testapps/BasicRazorApp3_0/Pages/Index.cshtml
@@ -1,0 +1,7 @@
+﻿@page
+
+@{
+    var message = "Hello";
+}
+
+<h1>@(message)</h1>

--- a/test/testapps/BasicRazorApp3_0/Program.cs
+++ b/test/testapps/BasicRazorApp3_0/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace BasicRazorApp2_1
+namespace BasicRazorApp3_0
 {
     public class Program
     {


### PR DESCRIPTION
From a design perspective I'm looking for feedback on how this works. Had to workaround several limitations in VSCode and this is what I came up with. Working on building unit tests for this feature.

- Added the ability to programatically collect usage data in order to make filing Razor issues easier.
- Built a report issue panel that can be interacted with to control how data is collected.
- There wasn't any valid APIs to navigate to GitHub.com's create new issue location with a large payload as the body. Therefore, I took the approach of copying issue content to the clipboard in order to aid in issue creation.
- Expanded the line length limit in tslint. 120 was too restricting and led to hard-to-read code.

How it looks (in two gifs because of upload limitations):
![image](https://i.imgur.com/0DUqU24.gif)
![image](https://i.imgur.com/HQFCwqS.gif)

The full issue content: 
[issueContent.txt](https://github.com/aspnet/Razor.VSCode/files/2691935/issueContent.txt)

#182 

FYI @akshita31 @rchande @danroth27 
