### PR TITLE
Add unit test infrastructure for VSCode project.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,23 @@
                 "${workspaceFolder}/client/out/test/**/*.js"
             ],
             "preLaunchTask": "client-npm-watch"
-        }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Unit Tests",
+            "program": "${workspaceFolder}/client/node_modules/mocha/bin/_mocha",
+            "args": [
+                "-u",
+                "tdd",
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceFolder}/client/out/unittest"
+            ],
+            "sourceMaps": true,
+            "internalConsoleOptions": "openOnSessionStart",
+            "preLaunchTask": "client-npm-compile"
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,41 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "client-npm-compile",
+            "dependsOn": [
+                "client-npm-compile:shell",
+                "client-npm-compile:package"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "isBackground": true,
+            "problemMatcher": []
+        },
+        {
+            "label": "client-npm-compile:shell",
+            "type": "npm",
+            "script": "compile",
+            "path": "client/",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            }
+        },
+        {
+            "label": "client-npm-compile:package",
+            "type": "npm",
+            "script": "compile",
+            "path": "src/Microsoft.AspNetCore.Razor.VSCode/",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            }
+        },
+        {
             "label": "client-npm-watch",
             "dependsOn": [
                 "client-npm-watch:shell",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,9 +17,9 @@
             "dev": true
         },
         "ajv": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-            "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+            "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -119,11 +119,6 @@
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
         },
-        "array-unique": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -217,16 +212,6 @@
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -497,22 +482,6 @@
                 "through": "~2.3.1"
             }
         },
-        "expand-brackets": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "requires": {
-                "is-posix-bracket": "^0.1.0"
-            }
-        },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "requires": {
-                "fill-range": "^2.1.0"
-            }
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -524,21 +493,6 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "requires": {
                 "kind-of": "^1.1.0"
-            }
-        },
-        "extglob": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "requires": {
-                "is-extglob": "^1.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                }
             }
         },
         "extsprintf": {
@@ -564,28 +518,6 @@
                 "pend": "~1.2.0"
             }
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-        },
-        "fill-range": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-            "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-            "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
-            }
-        },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
-        },
         "flush-write-stream": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
@@ -593,19 +525,6 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.4"
-            }
-        },
-        "for-in": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-        },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "requires": {
-                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -679,38 +598,6 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "requires": {
-                        "is-glob": "^2.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
-            }
-        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -721,62 +608,20 @@
             }
         },
         "glob-stream": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "requires": {
                 "extend": "^3.0.0",
-                "glob": "^5.0.3",
-                "glob-parent": "^3.0.0",
-                "micromatch": "^2.3.7",
-                "ordered-read-streams": "^0.3.0",
-                "through2": "^0.6.0",
-                "to-absolute-glob": "^0.1.1",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
                 "unique-stream": "^2.0.2"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
             }
         },
         "graceful-fs": {
@@ -887,51 +732,6 @@
                 }
             }
         },
-        "gulp-sourcemaps": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-            "requires": {
-                "convert-source-map": "^1.1.1",
-                "graceful-fs": "^4.1.2",
-                "strip-bom": "^2.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-symdest": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.1.tgz",
-            "integrity": "sha512-UHd3MokfIN7SrFdsbV5uZTwzBpL0ZSTu7iq98fuDqBGZ0dlHxgbQBJwfd6qjCW83snkQ3Hz9IY4sMRMz2iTq7w==",
-            "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "^0.5.1",
-                "queue": "^3.1.0",
-                "vinyl-fs": "^2.4.3"
-            }
-        },
         "gulp-untar": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
@@ -990,53 +790,6 @@
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
-                "glob-stream": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-                    "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-                    "requires": {
-                        "extend": "^3.0.0",
-                        "glob": "^7.1.1",
-                        "glob-parent": "^3.1.0",
-                        "is-negated-glob": "^1.0.0",
-                        "ordered-read-streams": "^1.0.0",
-                        "pumpify": "^1.3.5",
-                        "readable-stream": "^2.1.5",
-                        "remove-trailing-separator": "^1.0.1",
-                        "to-absolute-glob": "^2.0.0",
-                        "unique-stream": "^2.0.2"
-                    }
-                },
-                "is-valid-glob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-                    "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
-                },
-                "ordered-read-streams": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-                    "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-                    "requires": {
-                        "readable-stream": "^2.0.1"
-                    }
-                },
-                "queue": {
-                    "version": "4.5.1",
-                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
-                    "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
-                    "requires": {
-                        "inherits": "~2.0.0"
-                    }
-                },
-                "to-absolute-glob": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-                    "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-                    "requires": {
-                        "is-absolute": "^1.0.0",
-                        "is-negated-glob": "^1.0.0"
-                    }
-                },
                 "vinyl": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
@@ -1048,30 +801,6 @@
                         "cloneable-readable": "^1.0.0",
                         "remove-trailing-separator": "^1.0.1",
                         "replace-ext": "^1.0.0"
-                    }
-                },
-                "vinyl-fs": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-                    "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-                    "requires": {
-                        "fs-mkdirp-stream": "^1.0.0",
-                        "glob-stream": "^6.1.0",
-                        "graceful-fs": "^4.0.0",
-                        "is-valid-glob": "^1.0.0",
-                        "lazystream": "^1.0.0",
-                        "lead": "^1.0.0",
-                        "object.assign": "^4.0.4",
-                        "pumpify": "^1.3.5",
-                        "readable-stream": "^2.3.3",
-                        "remove-bom-buffer": "^3.0.0",
-                        "remove-bom-stream": "^1.2.0",
-                        "resolve-options": "^1.1.0",
-                        "through2": "^2.0.0",
-                        "to-through": "^2.0.0",
-                        "value-or-function": "^3.0.0",
-                        "vinyl": "^2.0.0",
-                        "vinyl-sourcemap": "^1.1.0"
                     }
                 }
             }
@@ -1147,9 +876,9 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "is": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+            "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
         },
         "is-absolute": {
             "version": "1.0.0",
@@ -1164,24 +893,6 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "requires": {
-                "is-primitive": "^2.0.0"
-            }
-        },
-        "is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -1201,38 +912,10 @@
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
             "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
         },
-        "is-number": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "requires": {
-                "kind-of": "^3.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "is-obj": {
             "version": "1.0.1",
             "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
         "is-relative": {
             "version": "1.0.0",
@@ -1241,11 +924,6 @@
             "requires": {
                 "is-unc-path": "^1.0.0"
             }
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -1266,9 +944,9 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
         },
         "is-valid-glob": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
         },
         "is-windows": {
             "version": "1.0.2",
@@ -1285,14 +963,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
-        },
-        "isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "requires": {
-                "isarray": "1.0.0"
-            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -1330,23 +1000,15 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
-        "json-stable-stringify": {
+        "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "requires": {
-                "jsonify": "~0.0.0"
-            }
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
         },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsprim": {
             "version": "1.4.1",
@@ -1380,11 +1042,6 @@
                 "flush-write-stream": "^1.0.2"
             }
         },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-        },
         "make-error": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -1395,70 +1052,6 @@
             "version": "0.1.0",
             "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-        },
-        "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
-        },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "requires": {
-                "readable-stream": "^2.0.1"
-            }
-        },
-        "micromatch": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
         },
         "microsoft.aspnetcore.razor.vscode": {
             "version": "file:../src/Microsoft.AspNetCore.Razor.VSCode",
@@ -3601,7 +3194,7 @@
         },
         "multimatch": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "requires": {
                 "array-differ": "^1.0.0",
@@ -3646,11 +3239,6 @@
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
         "object-keys": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -3667,15 +3255,6 @@
                 "object-keys": "^1.0.11"
             }
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
-            }
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3685,38 +3264,11 @@
             }
         },
         "ordered-read-streams": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "requires": {
-                "is-stream": "^1.0.1",
                 "readable-stream": "^2.0.1"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
             }
         },
         "path-dirname": {
@@ -3771,20 +3323,15 @@
                 "extend-shallow": "^1.1.2"
             }
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-        },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "psl": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
         },
         "pump": {
             "version": "2.0.1",
@@ -3821,33 +3368,11 @@
             "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
         },
         "queue": {
-            "version": "3.1.0",
-            "resolved": "http://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
-            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
+            "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
             "requires": {
                 "inherits": "~2.0.0"
-            }
-        },
-        "randomatic": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-            "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                }
             }
         },
         "readable-stream": {
@@ -3862,14 +3387,6 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
-            }
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "requires": {
-                "is-equal-shallow": "^0.1.3"
             }
         },
         "remove-bom-buffer": {
@@ -3895,16 +3412,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-        },
-        "repeat-element": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
-        },
-        "repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "replace-ext": {
             "version": "1.0.0",
@@ -3944,12 +3451,12 @@
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "resolve": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+            "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "^1.0.6"
             }
         },
         "resolve-options": {
@@ -4022,7 +3529,7 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
@@ -4090,23 +3597,6 @@
                 "ansi-regex": "^2.0.0"
             }
         },
-        "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "requires": {
-                "is-utf8": "^0.2.0"
-            }
-        },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "requires": {
-                "first-chunk-stream": "^1.0.0",
-                "strip-bom": "^2.0.0"
-            }
-        },
         "supports-color": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
@@ -4140,30 +3630,21 @@
             }
         },
         "through2-filter": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "requires": {
                 "through2": "~2.0.0",
                 "xtend": "~4.0.0"
             }
         },
         "to-absolute-glob": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "requires": {
-                "extend-shallow": "^2.0.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                }
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
             }
         },
         "to-through": {
@@ -4221,9 +3702,9 @@
             "dev": true
         },
         "tslint": {
-            "version": "5.11.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-            "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.0.tgz",
+            "integrity": "sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==",
             "dev": true,
             "requires": {
                 "babel-code-frame": "^6.22.0",
@@ -4282,12 +3763,12 @@
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
         },
         "unique-stream": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
             "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
             }
         },
         "uri-js": {
@@ -4317,11 +3798,6 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
-        },
         "value-or-function": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
@@ -4347,47 +3823,50 @@
             }
         },
         "vinyl-fs": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "requires": {
-                "duplexify": "^3.2.0",
-                "glob-stream": "^5.3.2",
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
                 "graceful-fs": "^4.0.0",
-                "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "^0.3.0",
+                "is-valid-glob": "^1.0.0",
                 "lazystream": "^1.0.0",
-                "lodash.isequal": "^4.0.0",
-                "merge-stream": "^1.0.0",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.0",
-                "readable-stream": "^2.0.4",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
                 "through2": "^2.0.0",
-                "through2-filter": "^2.0.0",
-                "vali-date": "^1.0.0",
-                "vinyl": "^1.0.0"
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
                 },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
                 "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
-                        "replace-ext": "0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -4441,23 +3920,23 @@
             }
         },
         "vscode": {
-            "version": "1.1.22",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.22.tgz",
-            "integrity": "sha512-G/zu7PRAN1yF80wg+l6ebIexDflU3uXXeabacJuLearTIfObKw4JaI8aeHwDEmpnCkc3MkIr3Bclkju2gtEz6A==",
+            "version": "1.1.26",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.26.tgz",
+            "integrity": "sha512-z1Nf5J38gjUFbuDCbJHPN6OJ//5EG+e/yHlh6ERxj/U9B2Qc3aiHaFr38/fee/GGnxvRw/XegLMOG+UJwKi/Qg==",
             "requires": {
                 "glob": "^7.1.2",
                 "gulp-chmod": "^2.0.0",
                 "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
                 "gulp-remote-src-vscode": "^0.5.1",
-                "gulp-symdest": "^1.1.1",
                 "gulp-untar": "^0.0.7",
                 "gulp-vinyl-zip": "^2.1.2",
                 "mocha": "^4.0.1",
-                "request": "^2.83.0",
+                "request": "^2.88.0",
                 "semver": "^5.4.1",
                 "source-map-support": "^0.5.0",
                 "url-parse": "^1.4.3",
+                "vinyl-fs": "^3.0.3",
                 "vinyl-source-stream": "^1.1.0"
             }
         },
@@ -4490,9 +3969,9 @@
             }
         },
         "yazl": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.0.tgz",
-            "integrity": "sha512-rgptqKwX/f1/7bIRF1FHb4HGsP5k11QyxBpDl1etUDfNpTa7CNjDOYNPFnIaEzZ9dRq0c47IEJS+sy+T39JCLw==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "requires": {
                 "buffer-crc32": "~0.2.3"
             }

--- a/client/package.json
+++ b/client/package.json
@@ -111,9 +111,10 @@
         "lint": "tslint --project ./",
         "watch": "npm run clean && npm run lint && tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && npm run test:unit && npm run test:functional",
-        "test:unit": "mocha --recursive out/unittest",
-        "test:unit:watch": "mocha -r ts-node/register --recursive unittest/**/*.ts --watch --watch-extensions ts",
+        "test": "npm run compile && npm run test:unitcore && npm run test:functional",
+        "unittest": "npm run compile && npm run test:unitcore",
+        "test:unitcore": "mocha --recursive out/unittest",
+        "test:unitcore:watch": "mocha -r ts-node/register --recursive unittest/**/*.ts --watch --watch-extensions ts",
         "test:functional": "cross-env CODE_TESTS_WORKSPACE=../test/testapps node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {

--- a/client/unittest/RazorLogger.test.ts
+++ b/client/unittest/RazorLogger.test.ts
@@ -1,0 +1,127 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import { RazorLogger } from 'microsoft.aspnetcore.razor.vscode/dist/RazorLogger';
+import { Trace } from 'microsoft.aspnetcore.razor.vscode/dist/Trace';
+import { createLogSink as useOutputChannelSink, getFakeVsCodeApi } from './vscodeMock';
+
+describe('Razor Logger', () => {
+    function getAndAssertLog(sink: { [logName: string]: string[] }) {
+        const log = sink[RazorLogger.logName];
+        assert.ok(log);
+        assert.ok(log.length > 0);
+
+        return log;
+    }
+
+    it('Always logs information header', () => {
+        // Arrange
+        const vscodeApi = getFakeVsCodeApi();
+        const sink = useOutputChannelSink(vscodeApi);
+
+        // Act
+        const logger = new RazorLogger(vscodeApi, Trace.Off);
+
+        // Assert
+        const log = getAndAssertLog(sink);
+        const logContent = log.join('LF');
+        assert.ok(logContent.indexOf('currently set to \'Off\'') > 0);
+    });
+
+    it('logAlways logs when trace is Off', () => {
+        // Arrange
+        const vscodeApi = getFakeVsCodeApi();
+        const sink = useOutputChannelSink(vscodeApi);
+        const logger = new RazorLogger(vscodeApi, Trace.Off);
+
+        // Act
+        logger.logAlways('Test');
+
+        // Assert
+        const log = getAndAssertLog(sink);
+        const lastLog = log[log.length - 1].trim();
+        assert.ok(lastLog.endsWith('Test'));
+    });
+
+    it('logError logs when trace is Off', () => {
+        // Arrange
+        const vscodeApi = getFakeVsCodeApi();
+        const sink = useOutputChannelSink(vscodeApi);
+        const logger = new RazorLogger(vscodeApi, Trace.Off);
+
+        // Act
+        logger.logError('Test Error');
+
+        // Assert
+        const log = getAndAssertLog(sink);
+        const lastLog = log[log.length - 1].trim();
+        assert.ok(lastLog.endsWith('Test Error'));
+    });
+
+    it('logMessage does not log when trace is Off', () => {
+        // Arrange
+        const vscodeApi = getFakeVsCodeApi();
+        const sink = useOutputChannelSink(vscodeApi);
+        const logger = new RazorLogger(vscodeApi, Trace.Off);
+
+        // Act
+        logger.logMessage('Test message');
+
+        // Assert
+        const log = getAndAssertLog(sink);
+        const lastLog = log[log.length - 1].trim();
+        assert.ok(lastLog.indexOf('Test message') === -1);
+    });
+
+    for (const trace of [Trace.Messages, Trace.Verbose]) {
+        it(`logMessage logs when trace is ${Trace[trace]}`, () => {
+            // Arrange
+            const vscodeApi = getFakeVsCodeApi();
+            const sink = useOutputChannelSink(vscodeApi);
+            const logger = new RazorLogger(vscodeApi, trace);
+
+            // Act
+            logger.logMessage('Test message');
+
+            // Assert
+            const log = getAndAssertLog(sink);
+            const lastLog = log[log.length - 1].trim();
+            assert.ok(lastLog.endsWith('Test message'));
+        });
+    }
+
+    for (const trace of [Trace.Off, Trace.Messages]) {
+        it(`logVerbose does not log when trace is ${Trace[trace]}`, () => {
+            // Arrange
+            const vscodeApi = getFakeVsCodeApi();
+            const sink = useOutputChannelSink(vscodeApi);
+            const logger = new RazorLogger(vscodeApi, trace);
+
+            // Act
+            logger.logVerbose('Test message');
+
+            // Assert
+            const log = getAndAssertLog(sink);
+            const lastLog = log[log.length - 1].trim();
+            assert.ok(lastLog.indexOf('Test message') === -1);
+        });
+    }
+
+    it('logVerbose logs when trace is Verbose', () => {
+        // Arrange
+        const vscodeApi = getFakeVsCodeApi();
+        const sink = useOutputChannelSink(vscodeApi);
+        const logger = new RazorLogger(vscodeApi, Trace.Verbose);
+
+        // Act
+        logger.logVerbose('Test message');
+
+        // Assert
+        const log = getAndAssertLog(sink);
+        const lastLog = log[log.length - 1].trim();
+        assert.ok(lastLog.endsWith('Test message'));
+    });
+});

--- a/client/unittest/vscodeMock.ts
+++ b/client/unittest/vscodeMock.ts
@@ -1,0 +1,87 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'Microsoft.AspNetCore.Razor.VSCode/dist/vscodeAdapter';
+import * as os from 'os';
+
+export function createLogSink(api: vscode.api) {
+    const sink: { [logIdentifier: string]: string[] } = {};
+    api.window.createOutputChannel = (name) => {
+        if (!sink[name]) {
+            sink[name] = [];
+        }
+        const outputChannel: vscode.OutputChannel = {
+            name,
+            append: (message) => sink[name].push(message),
+            appendLine: (message) => sink[name].push(`${message}${os.EOL}`),
+            clear: () => sink[name].length = 0,
+            dispose: Function,
+            hide: Function,
+            show: () => {
+                // @ts-ignore
+             },
+        };
+
+        return outputChannel;
+    };
+
+    return sink;
+}
+
+export function getFakeVsCodeApi(): vscode.api {
+    return {
+        commands: {
+            executeCommand: <T>(command: string, ...rest: any[]) => {
+                throw new Error('Not Implemented');
+            },
+        },
+        languages: {
+            match: (selector: vscode.DocumentSelector, document: vscode.TextDocument) => {
+                throw new Error('Not Implemented');
+            },
+        },
+        window: {
+            activeTextEditor: undefined,
+            showInformationMessage: <T extends vscode.MessageItem>(message: string, ...items: T[]) => {
+                throw new Error('Not Implemented');
+            },
+            showWarningMessage: <T extends vscode.MessageItem>(message: string, ...items: T[]) => {
+                throw new Error('Not Implemented');
+            },
+            showErrorMessage: (message: string, ...items: string[]) => {
+                throw new Error('Not Implemented');
+            },
+            createOutputChannel: (name: string) => {
+                throw new Error('Not implemented');
+            },
+        },
+        workspace: {
+            getConfiguration: (section?: string, resource?: vscode.Uri) => {
+                throw new Error('Not Implemented');
+            },
+            asRelativePath: (pathOrUri: string | vscode.Uri, includeWorkspaceFolder?: boolean) => {
+                throw new Error('Not Implemented');
+            },
+            createFileSystemWatcher: (globPattern: vscode.GlobPattern, ignoreCreateEvents?: boolean, ignoreChangeEvents?: boolean, ignoreDeleteEvents?: boolean) => {
+                throw new Error('Not Implemented');
+            },
+            onDidChangeConfiguration: (listener: (e: vscode.ConfigurationChangeEvent) => any, thisArgs?: any, disposables?: vscode.Disposable[]): vscode.Disposable => {
+                throw new Error('Not Implemented');
+            },
+        },
+        extensions: {
+            getExtension: () => {
+                throw new Error('Not Implemented');
+            },
+            all: [],
+        },
+        Uri: {
+            parse: () => {
+                throw new Error('Not Implemented');
+            },
+        },
+        version: '',
+    };
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/package.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/package.json
@@ -18,6 +18,8 @@
     "vscode": "^1.25.0"
   },
   "scripts": {
+    "clean": "rimraf out",
+    "compile": "npm run clean && npm run lint && tsc -p ./",
     "prepare": "node ./node_modules/vscode/bin/install",
     "lint": "tslint ./src/**/*.ts",
     "watch": "tsc -watch -p ./"

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -5,7 +5,6 @@
 
 import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
-import { Trace } from 'vscode-jsonrpc';
 import {
     GenericRequestHandler,
     LanguageClient,
@@ -15,6 +14,7 @@ import {
 import { RazorLanguageServerOptions } from './RazorLanguageServerOptions';
 import { RazorLogger } from './RazorLogger';
 import { TelemetryReporter } from './TelemetryReporter';
+import { Trace } from './Trace';
 
 const events = {
     ServerStart: 'ServerStart',

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptions.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptions.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as vscode from 'vscode';
-import { Trace } from 'vscode-jsonrpc';
+import { Trace } from './Trace';
 
 export interface RazorLanguageServerOptions {
     serverPath: string;

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
@@ -6,10 +6,10 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { Trace } from 'vscode-jsonrpc';
 import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageServerOptions } from './RazorLanguageServerOptions';
 import { RazorLogger } from './RazorLogger';
+import { Trace } from './Trace';
 
 export function resolveRazorLanguageServerOptions(languageServerDir: string, trace: Trace, logger: RazorLogger) {
     const languageServerExecutablePath = findLanguageServerExecutable(languageServerDir);

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerTraceResolver.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerTraceResolver.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { Trace } from 'vscode-jsonrpc';
 import { RazorLanguage } from './RazorLanguage';
+import { Trace } from './Trace';
 
 export function resolveRazorLanguageServerTrace() {
     const traceString = RazorLanguage.languageConfig.get<string>('trace');

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
@@ -5,22 +5,23 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as vscode from 'vscode';
-import { Trace } from 'vscode-jsonrpc';
+import { Trace } from './Trace';
+import * as vscode from './vscodeAdapter';
 
 export class RazorLogger implements vscode.Disposable {
+    public static readonly logName = 'Razor Log';
     public readonly verboseEnabled: boolean;
     public readonly messageEnabled: boolean;
     public readonly outputChannel: vscode.OutputChannel;
 
     private readonly trace: Trace;
 
-    constructor(trace: Trace) {
+    constructor(private readonly vscodeApi: vscode.api, trace: Trace) {
         this.trace = trace;
         this.verboseEnabled = this.trace >= Trace.Verbose;
         this.messageEnabled = this.trace >= Trace.Messages;
 
-        this.outputChannel = vscode.window.createOutputChannel('Razor Log');
+        this.outputChannel = this.vscodeApi.window.createOutputChannel(RazorLogger.logName);
 
         this.logRazorInformation();
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { Trace } from 'vscode-jsonrpc';
 import { HostEventStream, TelemetryEvent } from './HostEventStream';
 import { IRazorProject } from './IRazorProject';
+import { Trace } from './Trace';
 
 export class TelemetryReporter {
     private readonly razorDocuments: { [hostDocumentPath: string]: boolean } = {};

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Trace.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Trace.ts
@@ -3,12 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as assert from 'assert';
-
-describe('Sample', () => {
-    describe('Sample thing', () => {
-        it('should do arithmetic', () => {
-            assert.equal(1 + 1, 2);
-        });
-    });
-});
+export enum Trace {
+    Off = 0,
+    Messages = 1,
+    Verbose = 2,
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: ExtensionContext, languageServerDir: str
     const telemetryReporter = new TelemetryReporter(eventStream);
     try {
         const languageServerTrace = resolveRazorLanguageServerTrace();
-        const logger = new RazorLogger(languageServerTrace);
+        const logger = new RazorLogger(vscode, languageServerTrace);
         const languageServerOptions = resolveRazorLanguageServerOptions(languageServerDir, languageServerTrace, logger);
         const languageServerClient = new RazorLanguageServerClient(languageServerOptions, telemetryReporter, logger);
         const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/vscodeAdapter.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/vscodeAdapter.ts
@@ -1,0 +1,940 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/* tslint:disable */
+
+export interface OutputChannel {
+
+    /**
+     * The human-readable name of this output channel.
+     */
+    readonly name: string;
+
+    /**
+     * Append the given value to the channel.
+     *
+     * @param value A string, falsy values will not be printed.
+     */
+    append(value: string): void;
+
+    /**
+     * Append the given value and a line feed character
+     * to the channel.
+     *
+     * @param value A string, falsy values will be printed.
+     */
+    appendLine(value: string): void;
+
+    /**
+     * Removes all output from the channel.
+     */
+    clear(): void;
+
+    /**
+     * Reveal this channel in the UI.
+     *
+     * @param preserveFocus When `true` the channel will not take focus.
+     */
+    show(preserveFocus?: boolean): void;
+
+    /**
+     * Hide this channel from the UI.
+     */
+    hide(): void;
+
+    /**
+     * Dispose and free associated resources.
+     */
+    dispose(): void;
+}
+
+export enum ViewColumn {
+    /**
+     * A *symbolic* editor column representing the currently
+     * active column. This value can be used when opening editors, but the
+     * *resolved* [viewColumn](#TextEditor.viewColumn)-value of editors will always
+     * be `One`, `Two`, `Three`, or `undefined` but never `Active`.
+     */
+    Active = -1,
+    /**
+     * The left most editor column.
+     */
+    One = 1,
+    /**
+     * The center editor column.
+     */
+    Two = 2,
+    /**
+     * The right most editor column.
+     */
+    Three = 3
+}
+
+export interface WorkspaceConfiguration {
+
+    /**
+     * Return a value from this configuration.
+     *
+     * @param section Configuration name, supports _dotted_ names.
+     * @return The value `section` denotes or `undefined`.
+     */
+    get<T>(section: string): T | undefined;
+
+    /**
+     * Return a value from this configuration.
+     *
+     * @param section Configuration name, supports _dotted_ names.
+     * @param defaultValue A value should be returned when no value could be found, is `undefined`.
+     * @return The value `section` denotes or the default.
+     */
+    get<T>(section: string, defaultValue: T): T;
+
+    /**
+     * Check if this configuration has a certain value.
+     *
+     * @param section Configuration name, supports _dotted_ names.
+     * @return `true` if the section doesn't resolve to `undefined`.
+     */
+    has(section: string): boolean;
+
+    /**
+     * Retrieve all information about a configuration setting. A configuration value
+     * often consists of a *default* value, a global or installation-wide value,
+     * a workspace-specific value and a folder-specific value.
+     *
+     * The *effective* value (returned by [`get`](#WorkspaceConfiguration.get))
+     * is computed like this: `defaultValue` overwritten by `globalValue`,
+     * `globalValue` overwritten by `workspaceValue`. `workspaceValue` overwritten by `workspaceFolderValue`.
+     * Refer to [Settings Inheritence](https://code.visualstudio.com/docs/getstarted/settings)
+     * for more information.
+     *
+     * *Note:* The configuration name must denote a leaf in the configuration tree
+     * (`editor.fontSize` vs `editor`) otherwise no result is returned.
+     *
+     * @param section Configuration name, supports _dotted_ names.
+     * @return Information about a configuration setting or `undefined`.
+     */
+    inspect<T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T, workspaceFolderValue?: T } | undefined;
+
+    /**
+     * Update a configuration value. The updated configuration values are persisted.
+     *
+     * A value can be changed in
+     *
+     * - [Global configuration](#ConfigurationTarget.Global): Changes the value for all instances of the editor.
+     * - [Workspace configuration](#ConfigurationTarget.Workspace): Changes the value for current workspace, if available.
+     * - [Workspace folder configuration](#ConfigurationTarget.WorkspaceFolder): Changes the value for the
+     * [Workspace folder](#workspace.workspaceFolders) to which the current [configuration](#WorkspaceConfiguration) is scoped to.
+     *
+     * *Note 1:* Setting a global value in the presence of a more specific workspace value
+     * has no observable effect in that workspace, but in others. Setting a workspace value
+     * in the presence of a more specific folder value has no observable effect for the resources
+     * under respective [folder](#workspace.workspaceFolders), but in others. Refer to
+     * [Settings Inheritence](https://code.visualstudio.com/docs/getstarted/settings) for more information.
+     *
+     * *Note 2:* To remove a configuration value use `undefined`, like so: `config.update('somekey', undefined)`
+     *
+     * Will throw error when
+     * - Writing a configuration which is not registered.
+     * - Writing a configuration to workspace or folder target when no workspace is opened
+     * - Writing a configuration to folder target when there is no folder settings
+     * - Writing to folder target without passing a resource when getting the configuration (`workspace.getConfiguration(section, resource)`)
+     * - Writing a window configuration to folder target
+     *
+     * @param section Configuration name, supports _dotted_ names.
+     * @param value The new value.
+     * @param configurationTarget The [configuration target](#ConfigurationTarget) or a boolean value.
+     *	- If `true` configuration target is `ConfigurationTarget.Global`.
+     *	- If `false` configuration target is `ConfigurationTarget.Workspace`.
+     *	- If `undefined` or `null` configuration target is
+     *	`ConfigurationTarget.WorkspaceFolder` when configuration is resource specific
+     *	`ConfigurationTarget.Workspace` otherwise.
+     */
+    update(section: string, value: any, configurationTarget?: ConfigurationTarget | boolean): Thenable<void>;
+
+    /**
+     * Readable dictionary that backs this configuration.
+     */
+    readonly [key: string]: any;
+}
+
+/**
+ * The configuration target
+ */
+export enum ConfigurationTarget {
+    /**
+     * Global configuration
+    */
+    Global = 1,
+
+    /**
+     * Workspace configuration
+     */
+    Workspace = 2,
+
+    /**
+     * Workspace folder configuration
+     */
+    WorkspaceFolder = 3
+}
+
+/**
+ * Represents the alignment of status bar items.
+ */
+export enum StatusBarAlignment {
+
+    /**
+     * Aligned to the left side.
+     */
+    Left = 1,
+
+    /**
+     * Aligned to the right side.
+     */
+    Right = 2
+}
+
+
+export interface StatusBarItem {
+
+    /**
+     * The alignment of this item.
+     */
+    readonly alignment: StatusBarAlignment;
+
+    /**
+     * The priority of this item. Higher value means the item should
+     * be shown more to the left.
+     */
+    readonly priority: number;
+
+    /**
+     * The text to show for the entry. You can embed icons in the text by leveraging the syntax:
+     *
+     * `My text $(icon-name) contains icons like $(icon'name) this one.`
+     *
+     * Where the icon-name is taken from the [octicon](https://octicons.github.com) icon set, e.g.
+     * `light-bulb`, `thumbsup`, `zap` etc.
+     */
+    text: string;
+
+    /**
+     * The tooltip text when you hover over this entry.
+     */
+    tooltip: string | undefined;
+
+    /**
+     * The foreground color for this entry.
+     */
+    color: string | undefined;
+
+    /**
+     * The identifier of a command to run on click. The command must be
+     * [known](#commands.getCommands).
+     */
+    command: string | undefined;
+
+    /**
+     * Shows the entry in the status bar.
+     */
+    show(): void;
+
+    /**
+     * Hide the entry in the status bar.
+     */
+    hide(): void;
+
+    /**
+     * Dispose and free associated resources. Call
+     * [hide](#StatusBarItem.hide).
+     */
+    dispose(): void;
+}
+
+export interface Event<T> {
+
+    /**
+     * A function that represents an event to which you subscribe by calling it with
+     * a listener function as argument.
+     *
+     * @param listener The listener function will be called when the event happens.
+     * @param thisArgs The `this`-argument which will be used when calling the event listener.
+     * @param disposables An array to which a [disposable](#Disposable) will be added.
+     * @return A disposable which unsubscribes the event listener.
+     */
+    (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]): Disposable;
+}
+
+export interface Disposable {
+    /**
+     * Dispose this object.
+     */
+    dispose(): any;
+}
+
+
+export interface CancellationToken {
+
+    /**
+     * Is `true` when the token has been cancelled, `false` otherwise.
+     */
+    isCancellationRequested: boolean;
+
+    /**
+     * An [event](#Event) which fires upon cancellation.
+     */
+    onCancellationRequested: Event<any>;
+}
+
+
+export interface DocumentFilter {
+
+    /**
+     * A language id, like `typescript`.
+     */
+    language?: string;
+
+    /**
+     * A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+     */
+    scheme?: string;
+
+    /**
+     * A [glob pattern](#GlobPattern) that is matched on the absolute path of the document. Use a [relative pattern](#RelativePattern)
+     * to filter documents to a [workspace folder](#WorkspaceFolder).
+     */
+    pattern?: GlobPattern;
+}
+
+export type GlobPattern = string;
+
+export type DocumentSelector = string | DocumentFilter | (string | DocumentFilter)[];
+
+export interface MessageOptions {
+
+    /**
+     * Indicates that this message should be modal.
+     */
+    modal?: boolean;
+}
+
+export interface TextEditor {
+
+    /**
+     * The document associated with this text editor. The document will be the same for the entire lifetime of this text editor.
+     */
+    document: TextDocument;
+}
+
+/**
+	 * A universal resource identifier representing either a file on disk
+	 * or another resource, like untitled resources.
+	 */
+export interface Uri {
+
+    /**
+     * Create an URI from a file system path. The [scheme](#Uri.scheme)
+     * will be `file`.
+     *
+     * @param path A file system or UNC path.
+     * @return A new Uri instance.
+     */
+
+    /**
+     * Create an URI from a string. Will throw if the given value is not
+     * valid.
+     *
+     * @param value The string value of an Uri.
+     * @return A new Uri instance.
+     */
+    /**
+     * Scheme is the `http` part of `http://www.msft.com/some/path?query#fragment`.
+     * The part before the first colon.
+     */
+    readonly scheme: string;
+
+    /**
+     * Authority is the `www.msft.com` part of `http://www.msft.com/some/path?query#fragment`.
+     * The part between the first double slashes and the next slash.
+     */
+    readonly authority: string;
+
+    /**
+     * Path is the `/some/path` part of `http://www.msft.com/some/path?query#fragment`.
+     */
+    readonly path: string;
+
+    /**
+     * Query is the `query` part of `http://www.msft.com/some/path?query#fragment`.
+     */
+    readonly query: string;
+
+    /**
+     * Fragment is the `fragment` part of `http://www.msft.com/some/path?query#fragment`.
+     */
+    readonly fragment: string;
+
+    /**
+     * The string representing the corresponding file system path of this Uri.
+     *
+     * Will handle UNC paths and normalize windows drive letters to lower-case. Also
+     * uses the platform specific path separator. Will *not* validate the path for
+     * invalid characters and semantics. Will *not* look at the scheme of this Uri.
+     */
+    readonly fsPath: string;
+
+    /**
+     * Derive a new Uri from this Uri.
+     *
+     * ```ts
+     * let file = Uri.parse('before:some/file/path');
+     * let other = file.with({ scheme: 'after' });
+     * assert.ok(other.toString() === 'after:some/file/path');
+     * ```
+     *
+     * @param change An object that describes a change to this Uri. To unset components use `null` or
+     *  the empty string.
+     * @return A new Uri that reflects the given change. Will return `this` Uri if the change
+     *  is not changing anything.
+     */
+    with(change: { scheme?: string; authority?: string; path?: string; query?: string; fragment?: string }): Uri;
+
+    /**
+     * Returns a string representation of this Uri. The representation and normalization
+     * of a URI depends on the scheme. The resulting string can be safely used with
+     * [Uri.parse](#Uri.parse).
+     *
+     * @param skipEncoding Do not percentage-encode the result, defaults to `false`. Note that
+     *	the `#` and `?` characters occuring in the path will always be encoded.
+     * @returns A string representation of this Uri.
+     */
+    toString(skipEncoding?: boolean): string;
+
+    /**
+     * Returns a JSON representation of this Uri.
+     *
+     * @return An object.
+     */
+    toJSON(): any;
+}
+
+export interface MessageItem {
+
+    /**
+     * A short title like 'Retry', 'Open Log' etc.
+     */
+    title: string;
+
+    /**
+     * Indicates that this item replaces the default
+     * 'Close' action.
+     */
+    isCloseAffordance?: boolean;
+}
+
+/**
+ * Represents a text document, such as a source file. Text documents have
+ * [lines](#TextLine) and knowledge about an underlying resource like a file.
+ */
+export interface TextDocument {
+
+    /**
+     * The associated URI for this document. Most documents have the __file__-scheme, indicating that they
+     * represent files on disk. However, some documents may have other schemes indicating that they are not
+     * available on disk.
+     */
+    readonly uri: Uri;
+
+    /**
+     * The file system path of the associated resource. Shorthand
+     * notation for [TextDocument.uri.fsPath](#TextDocument.uri). Independent of the uri scheme.
+     */
+    readonly fileName: string;
+
+    /**
+     * Is this document representing an untitled file.
+     */
+    readonly isUntitled: boolean;
+
+    /**
+     * The identifier of the language associated with this document.
+     */
+    readonly languageId: string;
+
+    /**
+     * The version number of this document (it will strictly increase after each
+     * change, including undo/redo).
+     */
+    readonly version: number;
+
+    /**
+     * `true` if there are unpersisted changes.
+     */
+    readonly isDirty: boolean;
+
+    /**
+     * `true` if the document have been closed. A closed document isn't synchronized anymore
+     * and won't be re-used when the same resource is opened again.
+     */
+    readonly isClosed: boolean;
+
+    /**
+     * Save the underlying file.
+     *
+     * @return A promise that will resolve to true when the file
+     * has been saved. If the file was not dirty or the save failed,
+     * will return false.
+     */
+    save(): Thenable<boolean>;
+
+    /**
+     * The [end of line](#EndOfLine) sequence that is predominately
+     * used in this document.
+     */
+    readonly eol: EndOfLine;
+
+    /**
+     * The number of lines in this document.
+     */
+    readonly lineCount: number;
+
+    /**
+     * Returns a text line denoted by the line number. Note
+     * that the returned object is *not* live and changes to the
+     * document are not reflected.
+     *
+     * @param line A line number in [0, lineCount).
+     * @return A [line](#TextLine).
+     */
+    lineAt(line: number): TextLine;
+
+    /**
+     * Returns a text line denoted by the position. Note
+     * that the returned object is *not* live and changes to the
+     * document are not reflected.
+     *
+     * The position will be [adjusted](#TextDocument.validatePosition).
+     *
+     * @see [TextDocument.lineAt](#TextDocument.lineAt)
+     * @param position A position.
+     * @return A [line](#TextLine).
+     */
+    lineAt(position: Position): TextLine;
+
+    /**
+     * Converts the position to a zero-based offset.
+     *
+     * The position will be [adjusted](#TextDocument.validatePosition).
+     *
+     * @param position A position.
+     * @return A valid zero-based offset.
+     */
+    offsetAt(position: Position): number;
+
+    /**
+     * Converts a zero-based offset to a position.
+     *
+     * @param offset A zero-based offset.
+     * @return A valid [position](#Position).
+     */
+    positionAt(offset: number): Position;
+
+    /**
+     * Get the text of this document. A substring can be retrieved by providing
+     * a range. The range will be [adjusted](#TextDocument.validateRange).
+     *
+     * @param range Include only the text included by the range.
+     * @return The text inside the provided range or the entire text.
+     */
+    getText(range?: Range): string;
+
+    /**
+     * Get a word-range at the given position. By default words are defined by
+     * common separators, like space, -, _, etc. In addition, per languge custom
+     * [word definitions](#LanguageConfiguration.wordPattern) can be defined. It
+     * is also possible to provide a custom regular expression.
+     *
+     * * *Note 1:* A custom regular expression must not match the empty string and
+     * if it does, it will be ignored.
+     * * *Note 2:* A custom regular expression will fail to match multiline strings
+     * and in the name of speed regular expressions should not match words with
+     * spaces. Use [`TextLine.text`](#TextLine.text) for more complex, non-wordy, scenarios.
+     *
+     * The position will be [adjusted](#TextDocument.validatePosition).
+     *
+     * @param position A position.
+     * @param regex Optional regular expression that describes what a word is.
+     * @return A range spanning a word, or `undefined`.
+     */
+    getWordRangeAtPosition(position: Position, regex?: RegExp): Range | undefined;
+
+    /**
+     * Ensure a range is completely contained in this document.
+     *
+     * @param range A range.
+     * @return The given range or a new, adjusted range.
+     */
+    validateRange(range: Range): Range;
+
+    /**
+     * Ensure a position is contained in the range of this document.
+     *
+     * @param position A position.
+     * @return The given position or a new, adjusted position.
+     */
+    validatePosition(position: Position): Position;
+}
+
+/**
+ * Represents an end of line character sequence in a [document](#TextDocument).
+ */
+export enum EndOfLine {
+    /**
+     * The line feed `\n` character.
+     */
+    LF = 1,
+    /**
+     * The carriage return line feed `\r\n` sequence.
+     */
+    CRLF = 2
+}
+
+/**
+ * Represents a line and character position, such as
+ * the position of the cursor.
+ *
+ * Position objects are __immutable__. Use the [with](#Position.with) or
+ * [translate](#Position.translate) methods to derive new positions
+ * from an existing position.
+ */
+export interface Position {
+
+    /**
+     * The zero-based line value.
+     */
+    readonly line: number;
+
+    /**
+     * The zero-based character value.
+     */
+    readonly character: number;
+
+    /**
+     * @param line A zero-based line value.
+     * @param character A zero-based character value.
+     */
+
+    /**
+     * Check if `other` is before this position.
+     *
+     * @param other A position.
+     * @return `true` if position is on a smaller line
+     * or on the same line on a smaller character.
+     */
+    isBefore(other: Position): boolean;
+
+    /**
+     * Check if `other` is before or equal to this position.
+     *
+     * @param other A position.
+     * @return `true` if position is on a smaller line
+     * or on the same line on a smaller or equal character.
+     */
+    isBeforeOrEqual(other: Position): boolean;
+
+    /**
+     * Check if `other` is after this position.
+     *
+     * @param other A position.
+     * @return `true` if position is on a greater line
+     * or on the same line on a greater character.
+     */
+    isAfter(other: Position): boolean;
+
+    /**
+     * Check if `other` is after or equal to this position.
+     *
+     * @param other A position.
+     * @return `true` if position is on a greater line
+     * or on the same line on a greater or equal character.
+     */
+    isAfterOrEqual(other: Position): boolean;
+
+    /**
+     * Check if `other` equals this position.
+     *
+     * @param other A position.
+     * @return `true` if the line and character of the given position are equal to
+     * the line and character of this position.
+     */
+    isEqual(other: Position): boolean;
+
+    /**
+     * Compare this to `other`.
+     *
+     * @param other A position.
+     * @return A number smaller than zero if this position is before the given position,
+     * a number greater than zero if this position is after the given position, or zero when
+     * this and the given position are equal.
+     */
+    compareTo(other: Position): number;
+
+    /**
+     * Create a new position relative to this position.
+     *
+     * @param lineDelta Delta value for the line value, default is `0`.
+     * @param characterDelta Delta value for the character value, default is `0`.
+     * @return A position which line and character is the sum of the current line and
+     * character and the corresponding deltas.
+     */
+    translate(lineDelta?: number, characterDelta?: number): Position;
+
+    /**
+     * Derived a new position relative to this position.
+     *
+     * @param change An object that describes a delta to this position.
+     * @return A position that reflects the given delta. Will return `this` position if the change
+     * is not changing anything.
+     */
+    translate(change: { lineDelta?: number; characterDelta?: number; }): Position;
+
+    /**
+     * Create a new position derived from this position.
+     *
+     * @param line Value that should be used as line value, default is the [existing value](#Position.line)
+     * @param character Value that should be used as character value, default is the [existing value](#Position.character)
+     * @return A position where line and character are replaced by the given values.
+     */
+    with(line?: number, character?: number): Position;
+
+    /**
+     * Derived a new position from this position.
+     *
+     * @param change An object that describes a change to this position.
+     * @return A position that reflects the given change. Will return `this` position if the change
+     * is not changing anything.
+     */
+    with(change: { line?: number; character?: number; }): Position;
+}
+
+export interface Range {
+
+    /**
+     * The start position. It is before or equal to [end](#Range.end).
+     */
+    readonly start: Position;
+
+    /**
+     * The end position. It is after or equal to [start](#Range.start).
+     */
+    readonly end: Position;
+
+    /**
+     * `true` if `start` and `end` are equal.
+     */
+    isEmpty: boolean;
+
+    /**
+     * `true` if `start.line` and `end.line` are equal.
+     */
+    isSingleLine: boolean;
+
+    /**
+     * Check if a position or a range is contained in this range.
+     *
+     * @param positionOrRange A position or a range.
+     * @return `true` if the position or range is inside or equal
+     * to this range.
+     */
+    contains(positionOrRange: Position | Range): boolean;
+
+    /**
+     * Check if `other` equals this range.
+     *
+     * @param other A range.
+     * @return `true` when start and end are [equal](#Position.isEqual) to
+     * start and end of this range.
+     */
+    isEqual(other: Range): boolean;
+
+    /**
+     * Intersect `range` with this range and returns a new range or `undefined`
+     * if the ranges have no overlap.
+     *
+     * @param range A range.
+     * @return A range of the greater start and smaller end positions. Will
+     * return undefined when there is no overlap.
+     */
+    intersection(range: Range): Range | undefined;
+
+    /**
+     * Compute the union of `other` with this range.
+     *
+     * @param other A range.
+     * @return A range of smaller start position and the greater end position.
+     */
+    union(other: Range): Range;
+
+    /**
+     * Derived a new range from this range.
+     *
+     * @param start A position that should be used as start. The default value is the [current start](#Range.start).
+     * @param end A position that should be used as end. The default value is the [current end](#Range.end).
+     * @return A range derived from this range with the given start and end position.
+     * If start and end are not different `this` range will be returned.
+     */
+    with(start?: Position, end?: Position): Range;
+
+    /**
+     * Derived a new range from this range.
+     *
+     * @param change An object that describes a change to this range.
+     * @return A range that reflects the given change. Will return `this` range if the change
+     * is not changing anything.
+     */
+    with(change: { start?: Position, end?: Position }): Range;
+}
+
+/**
+ * Represents a line of text, such as a line of source code.
+ *
+ * TextLine objects are __immutable__. When a [document](#TextDocument) changes,
+ * previously retrieved lines will not represent the latest state.
+ */
+export interface TextLine {
+
+    /**
+     * The zero-based line number.
+     */
+    readonly lineNumber: number;
+
+    /**
+     * The text of this line without the line separator characters.
+     */
+    readonly text: string;
+
+    /**
+     * The range this line covers without the line separator characters.
+     */
+    readonly range: Range;
+
+    /**
+     * The range this line covers with the line separator characters.
+     */
+    readonly rangeIncludingLineBreak: Range;
+
+    /**
+     * The offset of the first character which is not a whitespace character as defined
+     * by `/\s/`. **Note** that if a line is all whitespaces the length of the line is returned.
+     */
+    readonly firstNonWhitespaceCharacterIndex: number;
+
+    /**
+     * Whether this line is whitespace only, shorthand
+     * for [TextLine.firstNonWhitespaceCharacterIndex](#TextLine.firstNonWhitespaceCharacterIndex) === [TextLine.text.length](#TextLine.text).
+     */
+    readonly isEmptyOrWhitespace: boolean;
+}
+
+export interface FileSystemWatcher extends Disposable {
+
+    /**
+     * true if this file system watcher has been created such that
+     * it ignores creation file system events.
+     */
+    ignoreCreateEvents: boolean;
+
+    /**
+     * true if this file system watcher has been created such that
+     * it ignores change file system events.
+     */
+    ignoreChangeEvents: boolean;
+
+    /**
+     * true if this file system watcher has been created such that
+     * it ignores delete file system events.
+     */
+    ignoreDeleteEvents: boolean;
+
+    /**
+     * An event which fires on file/folder creation.
+     */
+    onDidCreate: Event<Uri>;
+
+    /**
+     * An event which fires on file/folder change.
+     */
+    onDidChange: Event<Uri>;
+
+    /**
+     * An event which fires on file/folder deletion.
+     */
+    onDidDelete: Event<Uri>;
+}
+
+export interface ConfigurationChangeEvent {
+
+    /**
+     * Returns `true` if the given section for the given resource (if provided) is affected.
+     *
+     * @param section Configuration name, supports _dotted_ names.
+     * @param resource A resource Uri.
+     * @return `true` if the given section for the given resource (if provided) is affected.
+     */
+    affectsConfiguration(section: string, resource?: Uri): boolean;
+}
+
+
+/**
+ * Thenable is a common denominator between ES6 promises, Q, jquery.Deferred, WinJS.Promise,
+ * and others. This API makes no assumption about what promise libary is being used which
+ * enables reusing existing code without migrating to a specific promise implementation. Still,
+ * we recommend the use of native promises which are available in this editor.
+ */
+interface Thenable<T> {
+    /**
+	* Attaches callbacks for the resolution and/or rejection of the Promise.
+	* @param onfulfilled The callback to execute when the Promise is resolved.
+	* @param onrejected The callback to execute when the Promise is rejected.
+	* @returns A Promise for the completion of which ever callback is executed.
+	*/
+    then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
+}
+
+export interface Extension<T>{
+    readonly id: string;
+    readonly packageJSON: any;
+}
+
+export interface api {
+    commands: {
+        executeCommand: <T>(command: string, ...rest: any[]) => Thenable<T | undefined>;
+    };
+    languages: {
+        match: (selector: DocumentSelector, document: TextDocument) => number;
+    };
+    window: {
+        activeTextEditor: TextEditor | undefined;
+        showInformationMessage: <T extends MessageItem>(message: string, ...items: T[]) => Thenable<T | undefined>;
+        showWarningMessage: <T extends MessageItem>(message: string, ...items: T[]) => Thenable<T | undefined>;
+        showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>;
+		createOutputChannel(name: string): OutputChannel;
+    };
+    workspace: {
+        getConfiguration: (section?: string, resource?: Uri) => WorkspaceConfiguration;
+        asRelativePath: (pathOrUri: string | Uri, includeWorkspaceFolder?: boolean) => string;
+        createFileSystemWatcher(globPattern: GlobPattern, ignoreCreateEvents?: boolean, ignoreChangeEvents?: boolean, ignoreDeleteEvents?: boolean): FileSystemWatcher;
+        onDidChangeConfiguration: Event<ConfigurationChangeEvent>;
+    };
+    extensions: {
+        getExtension(extensionId: string): Extension<any> | undefined;
+        all: Extension<any>[];
+    };
+    Uri: {
+        parse(value: string): Uri;
+    };
+
+    version: string;
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/tslint.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/tslint.json
@@ -10,6 +10,11 @@
         "object-literal-sort-keys": false,
         "prefer-template": true,
         "quotemark": [true, "single"],
-        "variable-name": [true, "check-format"]
+        "variable-name": [true, "check-format"],
+        "max-line-length": {
+            "options": {
+                "limit": 200
+            }
+        }
     }
 }

--- a/test/ClientTests/ClientTests.csproj
+++ b/test/ClientTests/ClientTests.csproj
@@ -7,11 +7,18 @@
             some other VSCode instance at the same time, which is fine in CI but inconvenient locally.
         -->
         <CallTarget Targets="RunFunctionalTests" Condition="'$(IncludeFunctionalTests)'=='true'" />
+        <CallTarget Targets="RunUnitTests" />
     </Target>
 
     <Target Name="RunFunctionalTests">
         <Message Importance="high" Text="Running functional tests" />
         <Exec Command="npm install" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\client" />
         <Exec Command="npm test" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\client" />
+    </Target>
+
+    <Target Name="RunUnitTests">
+        <Message Importance="high" Text="Running unit tests" />
+        <Exec Command="npm install" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\client" />
+        <Exec Command="npm run unittest" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\client" />
     </Target>
 </Project>


### PR DESCRIPTION
- VSCode's API package only contains definitions for the various VSCode APIs. This PR implements a lot of those definitions in "not implemented" ways. Basically, we provide an implementation for an API that by default throws; the test then needs to override the expectation of the VSCode API.
- Added tests for `RazorLogger` to showcase what this looks like.
- Added a `Launch Unit Tests` profile to allow us to run unit tests from VSCode via F5. Also added the pre-requisite tasks to ensure running tests in VSCode forces a compile of both the client (the test code) and the src assets.
- Changed `RazorLogger` and a few dependent classes to use APIs that have implementations so we can properly test them.
- Removed old arithmetic unit test because we actually have a unit test that validates product code.
- Added unit test running to the default ./build.