### PR TITLE
Update to latest Razor

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">$(MicrosoftNETCoreApp22PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreApp30PackageVersion)</RuntimeFrameworkVersion>
     <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
     <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>

--- a/Razor.VSCode.sln
+++ b/Razor.VSCode.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28315.86
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}"
 EndProject

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,12 +1,18 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.6.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.7.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview-18606-0098</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview-18606-0098</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview-18606-0098</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-alpha1-10643</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview-18606-0098</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>2.11.0-beta3-63519-01</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
@@ -15,6 +21,9 @@
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <OmniSharpExtensionsLanguageServerPackageVersion>0.10.0</OmniSharpExtensionsLanguageServerPackageVersion>
+    <SystemRuntimeHandlesPackageVersion>4.3.0</SystemRuntimeHandlesPackageVersion>
+    <SystemIOFileSystemPrimitivesPackageVersion>4.3.0</SystemIOFileSystemPrimitivesPackageVersion>
+    <SystemTextEncodingExtensionsPackageVersion>4.3.0</SystemTextEncodingExtensionsPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -17,6 +17,8 @@
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETCoreApp22PackageVersion>2.2.0-preview2-26905-02</MicrosoftNETCoreApp22PackageVersion>
+    <MicrosoftNetCoreApp30PackageVersion>3.0.0-preview1-26907-05</MicrosoftNetCoreApp30PackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview-18577-0036</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -6,6 +6,7 @@
   <ItemGroup>
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp22PackageVersion)" />
+    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp30PackageVersion)" />
   </ItemGroup>
 
   <Target Name="CodeSign" AfterTargets="Package" DependsOnTargets="GetToolsets" Condition=" '$(OS)' == 'Windows_NT' ">

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -178,7 +178,7 @@
                 },
                 "supports-color": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 }
@@ -1061,6 +1061,10 @@
                 "vscode-languageclient": "^5.1.0"
             },
             "dependencies": {
+                "@types/clipboardy": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
                 "@types/node": {
                     "version": "10.9.4",
                     "bundled": true
@@ -3634,9 +3638,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+            "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",

--- a/client/test/Completions3_0.test.ts
+++ b/client/test/Completions3_0.test.ts
@@ -1,0 +1,54 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { extensionActivated } from '../src/extension';
+import {
+    basicRazorApp30Root,
+    csharpExtensionReady,
+    dotnetRestore,
+    htmlLanguageFeaturesExtensionReady,
+    pollUntil,
+} from './TestUtil';
+
+let doc: vscode.TextDocument;
+let editor: vscode.TextEditor;
+
+describe('Completions 3.0', () => {
+    before(async () => {
+        await csharpExtensionReady();
+        await htmlLanguageFeaturesExtensionReady();
+        await dotnetRestore(basicRazorApp30Root);
+    });
+
+    beforeEach(async () => {
+        const filePath = path.join(basicRazorApp30Root, 'Pages', 'Index.cshtml');
+        doc = await vscode.workspace.openTextDocument(filePath);
+        editor = await vscode.window.showTextDocument(doc);
+        await extensionActivated;
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(() => vscode.window.visibleTextEditors.length === 0, 1000);
+    });
+
+    it('Can complete Razor directive', async () => {
+        const firstLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(firstLine, '@\n'));
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            new vscode.Position(0, 1));
+
+        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
+
+        assert.ok(hasCompletion('page'), 'Should have completion for "page"');
+        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
+        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+    });
+});

--- a/client/test/TestUtil.ts
+++ b/client/test/TestUtil.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 export const repoRoot = path.join(__dirname, '..', '..', '..');
+export const basicRazorApp30Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp3_0');
 export const basicRazorApp21Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp2_1');
 export const basicRazorApp10Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp1_0');
 

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.0-preview2-20181026.4
-commithash:f05a283e6c1eb66ef29a32526f75f8b567a986c9
+version:3.0.0-build-20181219.1
+commithash:afd496cf364425795024e88b6581b7b443294b90

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
-  "channel": "dev",
+  "channel": "master",
   "toolsets": {
     "visualstudio": {
       "required": false,
       "includePrerelease": true,
-      "minVersion": "15.8.0",
+      "versionRange": "[15.8.0, 16.0.0)",
       "requiredWorkloads": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostDocumentFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostDocumentFactory.cs
@@ -47,7 +47,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public override HostDocument Create(string documentFilePath)
         {
-            var hostDocument = new HostDocument(documentFilePath, documentFilePath);
+            // Representing all of our host documents with a re-normalized target path to workaround GetRelatedDocument limitations.
+            var targetPath = documentFilePath.Replace('/', '\\').TrimStart('\\');
+            var hostDocument = new HostDocument(documentFilePath, targetPath);
             hostDocument.GeneratedCodeContainer.GeneratedCodeChanged += (sender, args) =>
             {
                 var generatedCodeContainer = (GeneratedCodeContainer)sender;

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
@@ -67,6 +67,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                             () => new ProjectEngineFactory_2_1(),
                             new ExportCustomProjectEngineFactoryAttribute("MVC-2.1") { SupportsSerialization = true }),
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
+                            () => new ProjectEngineFactory_3_0(),
+                            new ExportCustomProjectEngineFactoryAttribute("MVC-3.0") { SupportsSerialization = true }),
+                        new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                             () => new ProjectEngineFactory_Unsupported(),
                             new ExportCustomProjectEngineFactoryAttribute(UnsupportedRazorConfiguration.Instance.ConfigurationName) { SupportsSerialization = true }),
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -14,18 +14,25 @@
   <ItemGroup>
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="$(OmniSharpExtensionsLanguageServerPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="$(MicrosoftCodeAnalysisRazorWorkspacesPackageVersion)" />
+
+    <!-- Needed to make use of the adhoc workspace -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion)" />
+
+    <!-- Blazor dependencies. We have to lift a few runtime packages to make things work with our other dependnecies -->
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Razor.Extensions" Version="$(MicrosoftAspNetCoreBlazorExtensionsPackageVersion)" />
+    <PackageReference Include="System.Runtime.Handles" Version="$(SystemRuntimeHandlesPackageVersion)" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(SystemIOFileSystemPrimitivesPackageVersion)" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="$(SystemTextEncodingExtensionsPackageVersion)" />
   </ItemGroup>
 
   <Target Name="PublishLanguageServerNativeExecutables" AfterTargets="Pack" DependsOnTargets="PublishAllRids" />
 
   <Target Name="IncludeOmniSharpPlugin" AfterTargets="Publish" Condition="Exists('$(PublishDir)')">
-    <MSBuild
-      Projects="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj"
-      Properties="PublishDir=$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish;RuntimeIdentifier="
-      Targets="Publish" />
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj" Properties="PublishDir=$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish;RuntimeIdentifier=" Targets="Publish" />
 
     <PropertyGroup>
       <PluginReferenceOutputPath>$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish</PluginReferenceOutputPath>
@@ -33,13 +40,13 @@
     </PropertyGroup>
 
     <RemoveDir Directories="$(TargetPluginOutputPath)" />
-    <MakeDir Directories="$(TargetPluginOutputPath)" /> 
+    <MakeDir Directories="$(TargetPluginOutputPath)" />
 
     <ItemGroup>
       <PluginAssets Include="$(PluginReferenceOutputPath)\**\*.*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(PluginAssets)" DestinationFiles="@(PluginAssets->'$(TargetPluginOutputPath)\%(RecursiveDir)%(Filename)%(Extension)')" /> 
+    <Copy SourceFiles="@(PluginAssets)" DestinationFiles="@(PluginAssets->'$(TargetPluginOutputPath)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_0.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_0.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class ProjectEngineFactory_2_0 : IProjectEngineFactory
     {
-        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X";
 
         public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_1.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_2_1.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class ProjectEngineFactory_2_1 : IProjectEngineFactory
     {
-        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X";
         public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
             // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_3_0.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_3_0.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class ProjectEngineFactory_3_0 : IProjectEngineFactory
+    {
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.
+            var assemblyName = new AssemblyName(typeof(ProjectEngineFactory_3_0).Assembly.FullName);
+            assemblyName.Name = AssemblyName;
+
+            var extension = new AssemblyExtension(configuration.ConfigurationName, Assembly.Load(assemblyName));
+            var initializer = extension.CreateInitializer();
+
+            return RazorProjectEngine.Create(configuration, fileSystem, b =>
+            {
+                initializer.Initialize(b);
+                configure?.Invoke(b);
+            });
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
@@ -37,13 +37,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         public override RazorProjectEngine Create(
-            ProjectSnapshot project,
-            RazorProjectFileSystem fileSystem,
+            RazorConfiguration configuration, 
+            RazorProjectFileSystem fileSystem, 
             Action<RazorProjectEngineBuilder> configure)
         {
             var remoteFileSystem = new RemoteRazorProjectFileSystem(_filePathNormalizer);
 
-            return base.Create(project, remoteFileSystem, configure);
+            return base.Create(configuration, remoteFileSystem, configure);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
@@ -33,6 +35,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var physicalFilePath = _filePathNormalizer.Normalize(path);
 
             return new RemoteProjectItem(path, physicalFilePath);
+        }
+
+        protected override string NormalizeAndEnsureValidPath(string path)
+        {
+            return _filePathNormalizer.Normalize(path);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
@@ -23,6 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="$(MicrosoftCodeAnalysisRazorWorkspacesPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -39,7 +39,7 @@ export async function activate(context: ExtensionContext, languageServerDir: str
         const logger = new RazorLogger(vscode, eventEmitterFactory, languageServerTrace);
         const languageServerOptions = resolveRazorLanguageServerOptions(vscode, languageServerDir, languageServerTrace, logger);
         const languageServerClient = new RazorLanguageServerClient(languageServerOptions, telemetryReporter, logger);
-        const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
+        const languageServiceClient = new RazorLanguageServiceClient(languageServerClient, logger);
         const documentManager = new RazorDocumentManager(languageServerClient, logger);
         reportTelemetryForDocuments(documentManager, telemetryReporter);
         const projectManager = new RazorProjectManager(logger);

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
@@ -163,7 +163,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var router = new TestRouter();
-            var document = TestDocumentSnapshot.Create("C:/path/file.cshtml", VersionStamp.Default.GetNewerVersion());
+            var documentVersion = VersionStamp.Default.GetNewerVersion();
+            var document = TestDocumentSnapshot.Create("C:/path/file.cshtml", documentVersion);
             var cache = new TestDocumentVersionCache(new Dictionary<DocumentSnapshot, long>()
             {
                 [document] = 1337,
@@ -171,7 +172,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, document);
+            document.State.HostDocument.GeneratedCodeContainer.SetOutput(document, csharpDocument, documentVersion.GetNewerVersion(), VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
@@ -199,7 +200,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            oldDocument.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, lastDocument);
+            oldDocument.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(oldDocument.FilePath, oldDocument) };
@@ -227,7 +228,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, lastDocument);
+            document.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
@@ -255,7 +256,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpDocument = RazorCSharpDocument.Create("Anything", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedCodeContainer.SetOutput(csharpDocument, lastDocument);
+            document.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
             var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
@@ -90,8 +90,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             document.TryGetTextVersion(out var textVersion);
             var textAndVersion = TextAndVersion.Create(text, textVersion);
             documentVersionCache.TrackDocumentVersion(document, 1337);
-            projectSnapshotManager.HostProjectAdded(document.Project.HostProject);
-            projectSnapshotManager.DocumentAdded(document.Project.HostProject, document.State.HostDocument, TextLoader.From(textAndVersion));
+            projectSnapshotManager.HostProjectAdded(document.ProjectInternal.HostProject);
+            projectSnapshotManager.DocumentAdded(document.ProjectInternal.HostProject, document.State.HostDocument, TextLoader.From(textAndVersion));
 
             // Act - 1
             var result = documentVersionCache.TryGetDocumentVersion(document, out var version);
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.True(result);
 
             // Act - 2
-            projectSnapshotManager.DocumentRemoved(document.Project.HostProject, document.State.HostDocument);
+            projectSnapshotManager.DocumentRemoved(document.ProjectInternal.HostProject, document.State.HostDocument);
             result = documentVersionCache.TryGetDocumentVersion(document, out version);
 
             // Assert - 2
@@ -120,9 +120,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             document.TryGetTextVersion(out var textVersion);
             var textAndVersion = TextAndVersion.Create(text, textVersion);
             documentVersionCache.TrackDocumentVersion(document, 1337);
-            projectSnapshotManager.HostProjectAdded(document.Project.HostProject);
+            projectSnapshotManager.HostProjectAdded(document.ProjectInternal.HostProject);
             var textLoader = TextLoader.From(textAndVersion);
-            projectSnapshotManager.DocumentAdded(document.Project.HostProject, document.State.HostDocument, textLoader);
+            projectSnapshotManager.DocumentAdded(document.ProjectInternal.HostProject, document.State.HostDocument, textLoader);
 
             // Act - 1
             var result = documentVersionCache.TryGetDocumentVersion(document, out var version);
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.True(result);
 
             // Act - 2
-            projectSnapshotManager.DocumentClosed(document.Project.HostProject.FilePath, document.State.HostDocument.FilePath, textLoader);
+            projectSnapshotManager.DocumentClosed(document.ProjectInternal.HostProject.FilePath, document.State.HostDocument.FilePath, textLoader);
             result = documentVersionCache.TryGetDocumentVersion(document, out version);
 
             // Assert - 2

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure;
 using Microsoft.CodeAnalysis;
@@ -98,74 +99,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
-        public void TryUpdateViewImportDependencies_OnlyUpdatesOpenDocuments()
-        {
-            // Arrange
-            var importFilePath = "/C:/path/to/_ViewImports.cshtml";
-            var documentFilePath = "/C:/path/to/Index.cshtml";
-            var closedDocumentFilePath = "/C:/path/to/About.cshtml";
-            var ownerProject = TestProjectSnapshot.Create(
-                "/C:/path/to/project.csproj",
-                new[]
-                {
-                    importFilePath,
-                    documentFilePath,
-                    closedDocumentFilePath,
-                });
-            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
-            projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, It.IsAny<TextLoader>()));
-            projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(documentFilePath)).Returns(true);
-            projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(closedDocumentFilePath)).Returns(false);
-            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
-
-            // Act
-            projectService.TryUpdateViewImportDependencies(importFilePath, ownerProject);
-
-            // Assert
-            projectSnapshotManager.VerifyAll();
-        }
-
-        [Fact]
-        public void TryUpdateViewImportDependencies_UpdatesOtherDocuments()
-        {
-            // Arrange
-            var importFilePath = "/C:/path/to/_ViewImports.cshtml";
-            var documentFilePath = "/C:/path/to/Index.cshtml";
-            var ownerProject = TestProjectSnapshot.Create(
-                "/C:/path/to/project.csproj",
-                new[]
-                {
-                    importFilePath,
-                    documentFilePath,
-                });
-            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
-            projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, It.IsAny<TextLoader>()));
-            projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(documentFilePath)).Returns(true);
-            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
-
-            // Act
-            projectService.TryUpdateViewImportDependencies(importFilePath, ownerProject);
-
-            // Assert
-            projectSnapshotManager.VerifyAll();
-        }
-
-        [Fact]
-        public void TryUpdateViewImportDependencies_NoopsForNonViewImportFiles()
-        {
-            // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
-            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
-            projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, It.IsAny<TextLoader>()))
-                .Throws(new XunitException("Should not have been called."));
-            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
-
-            // Act & Assert
-            projectService.TryUpdateViewImportDependencies(documentFilePath, ownerProject);
-        }
-
-        [Fact]
         public void CloseDocument_ClosesDocumentInOwnerProject()
         {
             // Arrange
@@ -176,7 +109,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("//__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentClosed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TextLoader>()))
                 .Callback<string, string, TextLoader>((projectFilePath, documentFilePath, text) =>
@@ -200,7 +133,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -233,7 +166,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Throws(new InvalidOperationException("This shouldn't have been called."));
@@ -261,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -298,7 +231,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Callback<HostProject, HostDocument, TextLoader>((hostProject, hostDocument, loader) =>
@@ -356,7 +289,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Callback<HostProject, HostDocument, TextLoader>((hostProject, hostDocument, loader) =>
@@ -380,7 +313,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
@@ -411,7 +344,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProject>(), It.IsAny<HostDocument>()))
                 .Callback<HostProject, HostDocument>((hostProject, hostDocument) =>
@@ -433,7 +366,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath });
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -464,7 +397,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProject>(), It.IsAny<HostDocument>()))
                 .Throws(new InvalidOperationException("Should not have been called."));
@@ -479,7 +412,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new string[0]);
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new string[0]);
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -503,7 +436,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var newText = SourceText.From("Something New");
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, newText))
@@ -527,10 +460,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath });
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var newText = SourceText.From("Something New");
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentChanged(miscellaneousProject.FilePath, documentFilePath, newText))
@@ -560,7 +493,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             DocumentSnapshot documentSnapshot = TestDocumentSnapshot.Create(documentFilePath);
             var documentResolver = Mock.Of<DocumentResolver>(resolver => resolver.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true);
             var documentVersionCache = new Mock<DocumentVersionCache>(MockBehavior.Strict);
@@ -595,7 +528,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
             var documentVersionCache = new Mock<DocumentVersionCache>();
             documentVersionCache.Setup(cache => cache.TrackDocumentVersion(It.IsAny<DocumentSnapshot>(), It.IsAny<long>()))
                 .Throws<XunitException>();
@@ -614,7 +547,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectFilePath = "/C:/path/to/project.csproj";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.HostProjectAdded(It.IsAny<HostProject>()))
@@ -638,7 +571,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var projectFilePath = "/C:/path/to/project.csproj";
             var ownerProject = TestProjectSnapshot.Create(projectFilePath);
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
@@ -662,7 +595,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectFilePath = "C:/path/to/project.csproj";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.HostProjectRemoved(It.IsAny<HostProject>()))
@@ -677,9 +610,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateDocumentsFromRemovedProject_MigratesDocumentsToNonMiscProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
+            var documentFilePath1 = "C:/path/to/some/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/some/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
             var removedProject = TestProjectSnapshot.Create("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
             var projectToBeMigratedTo = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
@@ -705,7 +638,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             projectService.TryMigrateDocumentsFromRemovedProject(removedProject);
 
             // Assert
-            Assert.Collection(migratedDocuments,
+            Assert.Collection(migratedDocuments.OrderBy(doc => doc.FilePath),
                 document => Assert.Equal(documentFilePath1, document.FilePath),
                 document => Assert.Equal(documentFilePath2, document.FilePath));
         }
@@ -714,10 +647,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateDocumentsFromRemovedProject_MigratesDocumentsToMiscProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__");
-            var removedProject = TestProjectSnapshot.Create("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
+            var documentFilePath1 = "/C:/path/to/some/document1.cshtml";
+            var documentFilePath2 = "/C:/path/to/some/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var removedProject = TestProjectSnapshot.Create("/C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var migratedDocuments = new List<HostDocument>();
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
@@ -735,7 +668,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             projectService.TryMigrateDocumentsFromRemovedProject(removedProject);
 
             // Assert
-            Assert.Collection(migratedDocuments,
+            Assert.Collection(migratedDocuments.OrderBy(doc => doc.FilePath),
                 document => Assert.Equal(documentFilePath1, document.FilePath),
                 document => Assert.Equal(documentFilePath2, document.FilePath));
         }
@@ -744,9 +677,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateMiscellaneousDocumentsToProject_DoesNotMigrateDocumentsIfNoOwnerProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var documentFilePath1 = "/C:/path/to/document1.cshtml";
+            var documentFilePath2 = "/C:/path/to/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
@@ -761,10 +694,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateMiscellaneousDocumentsToProject_MigratesDocumentsToNewOwnerProject()
         {
             // Arrange
-            var documentFilePath1 = "C:/path/to/document1.cshtml";
-            var documentFilePath2 = "C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
-            var projectToBeMigratedTo = TestProjectSnapshot.Create("C:/path/to/project.csproj");
+            var documentFilePath1 = "/C:/path/to/document1.cshtml";
+            var documentFilePath2 = "/C:/path/to/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var projectToBeMigratedTo = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
@@ -795,7 +728,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             projectService.TryMigrateMiscellaneousDocumentsToProject();
 
             // Assert
-            Assert.Collection(migratedDocuments,
+            Assert.Collection(migratedDocuments.OrderBy(doc => doc.FilePath),
                 document => Assert.Equal(documentFilePath1, document.FilePath),
                 document => Assert.Equal(documentFilePath2, document.FilePath));
         }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestLanguageServices.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestLanguageServices.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    internal class TestLanguageServices : HostLanguageServices
+    {
+        private readonly HostWorkspaceServices _workspaceServices;
+        private readonly IEnumerable<ILanguageService> _languageServices;
+
+        public TestLanguageServices(HostWorkspaceServices workspaceServices, IEnumerable<ILanguageService> languageServices)
+        {
+            if (workspaceServices == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceServices));
+            }
+
+            if (languageServices == null)
+            {
+                throw new ArgumentNullException(nameof(languageServices));
+            }
+
+            _workspaceServices = workspaceServices;
+            _languageServices = languageServices;
+        }
+
+        public override HostWorkspaceServices WorkspaceServices => _workspaceServices;
+
+        public override string Language => RazorLanguage.Name;
+
+        public override TLanguageService GetService<TLanguageService>()
+        {
+            var service = _languageServices.OfType<TLanguageService>().FirstOrDefault();
+
+            if (service == null)
+            {
+                throw new InvalidOperationException($"Test Razor language services not configured properly, missing language service '{typeof(TLanguageService).FullName}'.");
+            }
+
+            return service;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshot.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshot.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 
@@ -17,7 +18,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
 
         public static TestProjectSnapshot Create(string filePath, string[] documentFilePaths)
         {
-            var workspace = TestWorkspace.Create();
+            var workspaceServices = new List<IWorkspaceService>()
+            {
+                new TestProjectSnapshotProjectEngineFactory(),
+            };
+            var languageServices = new List<ILanguageService>();
+
+            var hostServices = TestServices.Create(workspaceServices, languageServices);
+            var workspace = TestWorkspace.Create(hostServices);
             var hostProject = new HostProject(filePath, RazorConfiguration.Default);
             var state = ProjectState.Create(workspace.Services, hostProject);
             foreach (var documentFilePath in documentFilePaths)

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshotProjectEngineFactory.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestProjectSnapshotProjectEngineFactory.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    internal class TestProjectSnapshotProjectEngineFactory : ProjectSnapshotProjectEngineFactory
+    {
+        public Action<RazorProjectEngineBuilder> Configure { get; set; }
+
+        public RazorProjectEngine Engine { get; set; }
+
+        public override RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            return Engine ?? RazorProjectEngine.Create(configuration, fileSystem, configure ?? Configure);
+        }
+
+        public override IProjectEngineFactory FindFactory(ProjectSnapshot project)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IProjectEngineFactory FindSerializableFactory(ProjectSnapshot project)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestServices.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestServices.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    public class TestServices : HostServices
+    {
+        private readonly IEnumerable<IWorkspaceService> _workspaceServices;
+        private readonly IEnumerable<ILanguageService> _razorLanguageServices;
+
+        private TestServices(IEnumerable<IWorkspaceService> workspaceServices, IEnumerable<ILanguageService> razorLanguageServices)
+        {
+            if (workspaceServices == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceServices));
+            }
+
+            if (razorLanguageServices == null)
+            {
+                throw new ArgumentNullException(nameof(razorLanguageServices));
+            }
+
+            _workspaceServices = workspaceServices;
+            _razorLanguageServices = razorLanguageServices;
+        }
+
+        protected override HostWorkspaceServices CreateWorkspaceServices(Workspace workspace)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            return new TestWorkspaceServices(this, _workspaceServices, _razorLanguageServices, workspace);
+        }
+
+        public static HostServices Create(IEnumerable<ILanguageService> razorLanguageServices)
+            => Create(Enumerable.Empty<IWorkspaceService>(), razorLanguageServices);
+
+        public static HostServices Create(IEnumerable<IWorkspaceService> workspaceServices, IEnumerable<ILanguageService> razorLanguageServices)
+            => new TestServices(workspaceServices, razorLanguageServices);
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestWorkspaceServices.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestWorkspaceServices.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
+{
+    internal class TestWorkspaceServices : HostWorkspaceServices
+    {
+        private static readonly Workspace DefaultWorkspace = TestWorkspace.Create();
+
+        private readonly HostServices _hostServices;
+        private readonly HostLanguageServices _razorLanguageServices;
+        private readonly IEnumerable<IWorkspaceService> _workspaceServices;
+        private readonly Workspace _workspace;
+
+        public TestWorkspaceServices(
+            HostServices hostServices,
+            IEnumerable<IWorkspaceService> workspaceServices,
+            IEnumerable<ILanguageService> languageServices,
+            Workspace workspace)
+        {
+            if (hostServices == null)
+            {
+                throw new ArgumentNullException(nameof(hostServices));
+            }
+
+            if (workspaceServices == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceServices));
+            }
+
+            if (languageServices == null)
+            {
+                throw new ArgumentNullException(nameof(languageServices));
+            }
+
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _hostServices = hostServices;
+            _workspaceServices = workspaceServices;
+            _workspace = workspace;
+
+            _razorLanguageServices = new TestLanguageServices(this, languageServices);
+        }
+
+        public override HostServices HostServices => _hostServices;
+
+        public override Workspace Workspace => _workspace;
+
+        public override TWorkspaceService GetService<TWorkspaceService>()
+        {
+            var service = _workspaceServices.OfType<TWorkspaceService>().FirstOrDefault();
+
+            if (service == null)
+            {
+                // Fallback to default host services to resolve roslyn specific features.
+                service = DefaultWorkspace.Services.GetService<TWorkspaceService>();
+            }
+
+            return service;
+        }
+
+        public override HostLanguageServices GetLanguageServices(string languageName)
+        {
+            if (languageName == RazorLanguage.Name)
+            {
+                return _razorLanguageServices;
+            }
+
+            // Fallback to default host services to resolve roslyn specific features.
+            return DefaultWorkspace.Services.GetLanguageServices(languageName);
+        }
+
+        public override IEnumerable<string> SupportedLanguages => new[] { RazorLanguage.Name };
+
+        public override bool IsSupported(string languageName) => languageName == RazorLanguage.Name;
+
+        public override IEnumerable<TLanguageService> FindLanguageServices<TLanguageService>(MetadataFilter filter) => throw new NotImplementedException();
+    }
+}

--- a/test/testapps/BasicRazorApp3_0/BasicRazorApp3_0.csproj
+++ b/test/testapps/BasicRazorApp3_0/BasicRazorApp3_0.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/test/testapps/BasicRazorApp3_0/Pages/Index.cshtml
+++ b/test/testapps/BasicRazorApp3_0/Pages/Index.cshtml
@@ -1,0 +1,7 @@
+﻿@page
+
+@{
+    var message = "Hello";
+}
+
+<h1>@(message)</h1>

--- a/test/testapps/BasicRazorApp3_0/Program.cs
+++ b/test/testapps/BasicRazorApp3_0/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace BasicRazorApp2_1
+namespace BasicRazorApp3_0
 {
     public class Program
     {


### PR DESCRIPTION
 - Latest Razor included a ton of changes regarding the project system. One of those was the concept of "related documents". These changes consume those and remove the workaround logic we had to respond to _ViewImport documents being parsed and then causing re-parses of impacted documents.
- Updated tests and test infrastructure to work with new Razor bits. The biggest change here is the new Razor bits depend on certain workspace services to be available.
- Fixed an issue I encountered with adding/deleting _ViewImports files. There is a slight race where if the server asks for a file right as its being deleted the client throws. Changed this behavior to return an empty document instead of propogating the exceptino to the server.
- Fixed an issue where the BackgroundDocumentGenerator would null ref. Couldn't figure out why so added some logging and added pre-cautionary measures which ensure the generator continues to parse even after an explosion scenario.

#209