### PR TITLE
Add support for 3.0 Razor projects.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">$(MicrosoftNETCoreApp22PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreApp30PackageVersion)</RuntimeFrameworkVersion>
     <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
     <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -17,6 +17,8 @@
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETCoreApp22PackageVersion>2.2.0-preview2-26905-02</MicrosoftNETCoreApp22PackageVersion>
+    <MicrosoftNetCoreApp30PackageVersion>3.0.0-preview1-26907-05</MicrosoftNetCoreApp30PackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview-18577-0036</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -6,6 +6,7 @@
   <ItemGroup>
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp22PackageVersion)" />
+    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp30PackageVersion)" />
   </ItemGroup>
 
   <Target Name="CodeSign" AfterTargets="Package" DependsOnTargets="GetToolsets" Condition=" '$(OS)' == 'Windows_NT' ">

--- a/client/test/Completions3_0.test.ts
+++ b/client/test/Completions3_0.test.ts
@@ -1,0 +1,54 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { extensionActivated } from '../src/extension';
+import {
+    basicRazorApp30Root,
+    csharpExtensionReady,
+    dotnetRestore,
+    htmlLanguageFeaturesExtensionReady,
+    pollUntil,
+} from './TestUtil';
+
+let doc: vscode.TextDocument;
+let editor: vscode.TextEditor;
+
+describe('Completions 3.0', () => {
+    before(async () => {
+        await csharpExtensionReady();
+        await htmlLanguageFeaturesExtensionReady();
+        await dotnetRestore(basicRazorApp30Root);
+    });
+
+    beforeEach(async () => {
+        const filePath = path.join(basicRazorApp30Root, 'Pages', 'Index.cshtml');
+        doc = await vscode.workspace.openTextDocument(filePath);
+        editor = await vscode.window.showTextDocument(doc);
+        await extensionActivated;
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(() => vscode.window.visibleTextEditors.length === 0, 1000);
+    });
+
+    it('Can complete Razor directive', async () => {
+        const firstLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(firstLine, '@\n'));
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            new vscode.Position(0, 1));
+
+        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
+
+        assert.ok(hasCompletion('page'), 'Should have completion for "page"');
+        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
+        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+    });
+});

--- a/client/test/TestUtil.ts
+++ b/client/test/TestUtil.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 export const repoRoot = path.join(__dirname, '..', '..', '..');
+export const basicRazorApp30Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp3_0');
 export const basicRazorApp21Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp2_1');
 export const basicRazorApp10Root = path.join(repoRoot, 'test', 'testapps', 'BasicRazorApp1_0');
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
@@ -67,6 +67,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                             () => new ProjectEngineFactory_2_1(),
                             new ExportCustomProjectEngineFactoryAttribute("MVC-2.1") { SupportsSerialization = true }),
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
+                            () => new ProjectEngineFactory_3_0(),
+                            new ExportCustomProjectEngineFactoryAttribute("MVC-3.0") { SupportsSerialization = true }),
+                        new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                             () => new ProjectEngineFactory_Unsupported(),
                             new ExportCustomProjectEngineFactoryAttribute(UnsupportedRazorConfiguration.Instance.ConfigurationName) { SupportsSerialization = true }),
                         new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_3_0.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectEngineFactory_3_0.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class ProjectEngineFactory_3_0 : IProjectEngineFactory
+    {
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.
+            var assemblyName = new AssemblyName(typeof(ProjectEngineFactory_3_0).Assembly.FullName);
+            assemblyName.Name = AssemblyName;
+
+            var extension = new AssemblyExtension(configuration.ConfigurationName, Assembly.Load(assemblyName));
+            var initializer = extension.CreateInitializer();
+
+            return RazorProjectEngine.Create(configuration, fileSystem, b =>
+            {
+                initializer.Initialize(b);
+                configure?.Invoke(b);
+            });
+        }
+    }
+}

--- a/test/testapps/BasicRazorApp3_0/BasicRazorApp3_0.csproj
+++ b/test/testapps/BasicRazorApp3_0/BasicRazorApp3_0.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/test/testapps/BasicRazorApp3_0/Pages/Index.cshtml
+++ b/test/testapps/BasicRazorApp3_0/Pages/Index.cshtml
@@ -1,0 +1,7 @@
+﻿@page
+
+@{
+    var message = "Hello";
+}
+
+<h1>@(message)</h1>

--- a/test/testapps/BasicRazorApp3_0/Program.cs
+++ b/test/testapps/BasicRazorApp3_0/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace BasicRazorApp2_1
+namespace BasicRazorApp3_0
 {
     public class Program
     {


### PR DESCRIPTION
- Added a 3.0 project engine. However, given the current Razor SDK the engine itself wont be used in practice (the SDK sets 3.0 projects to use 2.1 at design time).
- Added a test to verify 3.0 Razor projects; however, we don't treat 3.0 as the mainstream scenario because the current CLI that's in use can't 100% build the repo by itself (3.0 work is still in progress).
- Added a 3.0 test app.

#250