### PR TITLE
Publish Razor parse diagnostics.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/BackgroundDocumentGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/BackgroundDocumentGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +18,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentVersionCache _documentVersionCache;
+        private readonly IEnumerable<DocumentProcessedListener> _documentProcessedListeners;
         private readonly ILanguageServer _router;
         private readonly ILogger _logger;
         private readonly Dictionary<string, DocumentSnapshot> _work;
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public BackgroundDocumentGenerator(
             ForegroundDispatcher foregroundDispatcher,
             DocumentVersionCache documentVersionCache,
+            IEnumerable<DocumentProcessedListener> documentProcessedListeners,
             ILanguageServer router,
             ILoggerFactory loggerFactory)
         {
@@ -39,6 +40,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (documentVersionCache == null)
             {
                 throw new ArgumentNullException(nameof(documentVersionCache));
+            }
+
+            if (documentProcessedListeners == null)
+            {
+                throw new ArgumentNullException(nameof(documentProcessedListeners));
             }
 
             if (router == null)
@@ -53,6 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _foregroundDispatcher = foregroundDispatcher;
             _documentVersionCache = documentVersionCache;
+            _documentProcessedListeners = documentProcessedListeners;
             _router = router;
             _logger = loggerFactory.CreateLogger<BackgroundDocumentGenerator>();
             _work = new Dictionary<string, DocumentSnapshot>(StringComparer.Ordinal);
@@ -108,6 +115,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _projectManager = projectManager;
 
             _projectManager.Changed += ProjectSnapshotManager_Changed;
+
+            foreach (var documentProcessedListener in _documentProcessedListeners)
+            {
+                documentProcessedListener.Initialize(_projectManager);
+            }
         }
 
         private void OnStartingBackgroundWork()
@@ -208,7 +220,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 OnCompletingBackgroundWork();
 
                 await Task.Factory.StartNew(
-                    () => ReportUnsynchronizableContent(work),
+                    () =>
+                    {
+                        ReportUnsynchronizableContent(work);
+                        NotifyDocumentsProcessed(work);
+                    },
                     CancellationToken.None,
                     TaskCreationOptions.None,
                     _foregroundDispatcher.ForegroundScheduler);
@@ -236,6 +252,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 _timer?.Dispose();
                 _timer = null;
+            }
+        }
+
+        private void NotifyDocumentsProcessed(KeyValuePair<string, DocumentSnapshot>[] work)
+        {
+            _foregroundDispatcher.AssertForegroundThread();
+
+            for (var i = 0; i < work.Length; i++)
+            {
+                foreach (var documentProcessedTrigger in _documentProcessedListeners)
+                {
+                    documentProcessedTrigger.DocumentProcessed(work[i].Value);
+                }
             }
         }
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentProcessedListener.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentProcessedListener.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class DocumentProcessedListener
+    {
+        public abstract void Initialize(ProjectSnapshotManager projectManager);
+
+        public abstract void DocumentProcessed(DocumentSnapshot document);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -73,6 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<FilePathNormalizer>();
                         services.AddSingleton<RazorProjectService, DefaultRazorProjectService>();
                         services.AddSingleton<ProjectSnapshotChangeTrigger, BackgroundDocumentGenerator>();
+                        services.AddSingleton<DocumentProcessedListener, RazorDiagnosticsPublisher>();
                         services.AddSingleton<HostDocumentFactory, DefaultHostDocumentFactory>();
                         services.AddSingleton<ProjectSnapshotManagerAccessor, DefaultProjectSnapshotManagerAccessor>();
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class RazorDiagnosticConverter
+    {
+        public static Diagnostic Convert(RazorDiagnostic razorDiagnostic, SourceText sourceText)
+        {
+            if (razorDiagnostic == null)
+            {
+                throw new ArgumentNullException(nameof(razorDiagnostic));
+            }
+
+            if (sourceText == null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            var diagnostic = new Diagnostic()
+            {
+                Message = razorDiagnostic.GetMessage(),
+                Code = razorDiagnostic.Id,
+                Severity = ConvertSeverity(razorDiagnostic.Severity),
+                Range = ConvertSpanToRange(razorDiagnostic.Span, sourceText),
+            };
+
+            return diagnostic;
+        }
+
+        // Internal for testing
+        internal static DiagnosticSeverity ConvertSeverity(RazorDiagnosticSeverity severity)
+        {
+            switch (severity)
+            {
+                case RazorDiagnosticSeverity.Error:
+                    return DiagnosticSeverity.Error;
+                default:
+                    return DiagnosticSeverity.Information;
+            }
+        }
+
+        // Internal for testing
+        internal static Range ConvertSpanToRange(SourceSpan sourceSpan, SourceText sourceText)
+        {
+            if (sourceSpan == SourceSpan.Undefined)
+            {
+                return null;
+            }
+
+            var startPosition = sourceText.Lines.GetLinePosition(sourceSpan.AbsoluteIndex);
+            var start = new Position()
+            {
+                Line = startPosition.Line,
+                Character = startPosition.Character,
+            };
+            var endPosition = sourceText.Lines.GetLinePosition(sourceSpan.AbsoluteIndex + sourceSpan.Length);
+            var end = new Position()
+            {
+                Line = endPosition.Line,
+                Character = endPosition.Character,
+            };
+            var range = new Range()
+            {
+                Start = start,
+                End = end,
+            };
+
+            return range;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class RazorDiagnosticsPublisher : DocumentProcessedListener
+    {
+        // Internal for testing
+        internal readonly Dictionary<string, IReadOnlyList<RazorDiagnostic>> _publishedDiagnostics;
+        internal Timer _workTimer;
+        internal Timer _documentClosedTimer;
+
+        private static readonly TimeSpan PublishDelay = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan CheckForDocumentClosedDelay = TimeSpan.FromSeconds(5);
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly ILanguageServer _languageServer;
+        private readonly Dictionary<string, DocumentSnapshot> _work;
+        private readonly ILogger<RazorDiagnosticsPublisher> _logger;
+        private ProjectSnapshotManager _projectManager;
+
+        public RazorDiagnosticsPublisher(
+            ForegroundDispatcher foregroundDispatcher,
+            ILanguageServer languageServer,
+            ILoggerFactory loggerFactory)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (languageServer == null)
+            {
+                throw new ArgumentNullException(nameof(languageServer));
+            }
+
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _languageServer = languageServer;
+            _publishedDiagnostics = new Dictionary<string, IReadOnlyList<RazorDiagnostic>>(FilePathComparer.Instance);
+            _work = new Dictionary<string, DocumentSnapshot>(FilePathComparer.Instance);
+            _logger = loggerFactory.CreateLogger<RazorDiagnosticsPublisher>();
+        }
+
+        public override void Initialize(ProjectSnapshotManager projectManager)
+        {
+            if (projectManager == null)
+            {
+                throw new ArgumentNullException(nameof(projectManager));
+            }
+
+            _projectManager = projectManager;
+        }
+
+        public override void DocumentProcessed(DocumentSnapshot document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            _foregroundDispatcher.AssertForegroundThread();
+
+            lock (_work)
+            {
+                _work[document.FilePath] = document;
+                StartWorkTimer();
+                StartDocumentClosedCheckTimer();
+            }
+        }
+
+        private void StartWorkTimer()
+        {
+            _foregroundDispatcher.AssertForegroundThread();
+
+            // Access to the timer is protected by the lock in Synchronize and in Timer_Tick
+            if (_workTimer == null)
+            {
+                // Timer will fire after a fixed delay, but only once.
+                _workTimer = new Timer(WorkTimer_Tick, null, PublishDelay, Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        private void StartDocumentClosedCheckTimer()
+        {
+            _foregroundDispatcher.AssertForegroundThread();
+
+            if (_documentClosedTimer == null)
+            {
+                _documentClosedTimer = new Timer(DocumentClosedTimer_Tick, null, CheckForDocumentClosedDelay, Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        private async void DocumentClosedTimer_Tick(object state)
+        {
+            await Task.Factory.StartNew(
+                ClearClosedDocuments,
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                _foregroundDispatcher.ForegroundScheduler);
+        }
+
+        // Internal for testing
+        internal void ClearClosedDocuments()
+        {
+            lock (_publishedDiagnostics)
+            {
+                var publishedDiagnostics = new Dictionary<string, IReadOnlyList<RazorDiagnostic>>(_publishedDiagnostics);
+                foreach (var entry in publishedDiagnostics)
+                {
+                    if (!_projectManager.IsDocumentOpen(entry.Key))
+                    {
+                        // Document is now closed, we shouldn't track its diagnostics anymore.
+                        _publishedDiagnostics.Remove(entry.Key);
+
+                        // If the last published diagnostics for the document were > 0 then we need to clear them out so the user
+                        // doesn't have a ton of closed document errors that they can't get rid of.
+                        if (entry.Value.Count > 0)
+                        {
+                            PublishDiagnosticsForFilePath(entry.Key, Array.Empty<Diagnostic>());
+                        }
+                    }
+                }
+
+                _documentClosedTimer?.Dispose();
+                _documentClosedTimer = null;
+
+                if (_publishedDiagnostics.Count > 0)
+                {
+                    // There's no way for us to know when a document is closed at this layer. Therefore, we need to poll every X seconds
+                    // and check if the currently tracked documents are closed. In practice this work is super minimal.
+                    StartDocumentClosedCheckTimer();
+                }
+            }
+        }
+
+        // Internal for testing
+        internal void PublishDiagnostics(DocumentSnapshot document)
+        {
+            if (!document.TryGetGeneratedOutput(out var result))
+            {
+                Debug.Fail("Document output should already be available.");
+            }
+
+            var diagnostics = result.GetCSharpDocument().Diagnostics;
+
+            lock (_publishedDiagnostics)
+            {
+                if (_publishedDiagnostics.TryGetValue(document.FilePath, out var previousDiagnostics) &&
+                    diagnostics.SequenceEqual(previousDiagnostics))
+                {
+                    // Diagnostics are the same as last publish
+                    return;
+                }
+
+                _publishedDiagnostics[document.FilePath] = diagnostics;
+            }
+
+            if (!document.TryGetText(out var sourceText))
+            {
+                Debug.Fail("Document source text should already be available.");
+            }
+            var convertedDiagnostics = diagnostics.Select(razorDiagnostic => RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText));
+
+            PublishDiagnosticsForFilePath(document.FilePath, convertedDiagnostics);
+
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                var diagnosticString = string.Join(", ", diagnostics.Select(diagnostic => diagnostic.Id));
+                _logger.LogTrace($"Publishing diagnostics for document '{document.FilePath}': {diagnosticString}");
+            }
+        }
+
+        private void WorkTimer_Tick(object state)
+        {
+            DocumentSnapshot[] documents;
+            lock (_work)
+            {
+                documents = _work.Values.ToArray();
+                _work.Clear();
+            }
+
+            for (var i = 0; i < documents.Length; i++)
+            {
+                var document = documents[i];
+                PublishDiagnostics(document);
+            }
+
+            lock (_work)
+            {
+                // Resetting the timer allows another batch of work to start.
+                _workTimer.Dispose();
+                _workTimer = null;
+
+                // If more work came in while we were running start the timer again.
+                if (_work.Count > 0)
+                {
+                    StartWorkTimer();
+                }
+            }
+        }
+
+        private void PublishDiagnosticsForFilePath(string filePath, IEnumerable<Diagnostic> diagnostics)
+        {
+            var uriBuilder = new UriBuilder()
+            {
+                Scheme = Uri.UriSchemeFile,
+                Path = filePath,
+                Host = string.Empty,
+            };
+            _languageServer.Document.PublishDiagnostics(new PublishDiagnosticsParams()
+            {
+                Uri = uriBuilder.Uri,
+                Diagnostics = new Container<Diagnostic>(diagnostics),
+            });
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
@@ -38,6 +38,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var projectId2 = ProjectId.CreateNewId("Test2");
         }
 
+        private IEnumerable<DocumentProcessedListener> Listeners => Enumerable.Empty<DocumentProcessedListener>();
+
         private HostDocument[] Documents { get; }
 
         private HostProject HostProject1 { get; }
@@ -147,7 +149,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var router = new TestRouter();
             var cache = new TestDocumentVersionCache(new Dictionary<DocumentSnapshot, long>());
-            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
+            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, Listeners, router, LoggerFactory);
             var document = TestDocumentSnapshot.Create("C:/path/file.cshtml");
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
 
@@ -174,7 +176,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Force the state to already be up-to-date
             document.State.HostDocument.GeneratedCodeContainer.SetOutput(document, csharpDocument, documentVersion.GetNewerVersion(), VersionStamp.Default);
 
-            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
+            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, Listeners, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
 
             // Act
@@ -202,7 +204,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Force the state to already be up-to-date
             oldDocument.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
-            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
+            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, Listeners, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(oldDocument.FilePath, oldDocument) };
 
             // Act
@@ -230,7 +232,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Force the state to already be up-to-date
             document.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
-            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
+            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, Listeners, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
 
             // Act
@@ -258,7 +260,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Force the state to already be up-to-date
             document.State.HostDocument.GeneratedCodeContainer.SetOutput(lastDocument, csharpDocument, lastVersion, VersionStamp.Default);
 
-            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, router, LoggerFactory);
+            var backgroundGenerator = new BackgroundDocumentGenerator(Dispatcher, cache, Listeners, router, LoggerFactory);
             var work = new[] { new KeyValuePair<string, DocumentSnapshot>(document.FilePath, document) };
 
             // Act

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestDocumentSnapshot.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Infrastructure/TestDocumentSnapshot.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
 {
     internal class TestDocumentSnapshot : DefaultDocumentSnapshot
     {
+        private RazorCodeDocument _codeDocument;
+
         public static TestDocumentSnapshot Create(string filePath) => Create(filePath, string.Empty);
 
         public static TestDocumentSnapshot Create(string filePath, VersionStamp version) => Create(filePath, string.Empty, version);
@@ -53,7 +55,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure
 
         public override bool TryGetGeneratedOutput(out RazorCodeDocument result)
         {
-            throw new NotImplementedException();
+            if (_codeDocument == null)
+            {
+                throw new InvalidOperationException("You must call " + nameof(With) + " to set the code document for this document snapshot.");
+            }
+
+            result = _codeDocument;
+            return true;
+        }
+
+        public TestDocumentSnapshot With(RazorCodeDocument codeDocument)
+        {
+            if (codeDocument == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            _codeDocument = codeDocument;
+            return this;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticConverterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticConverterTest.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorDiagnosticConverterTest
+    {
+        [Fact]
+        public void Convert_Converts()
+        {
+            // Arrange
+            var razorDiagnostic = RazorDiagnosticFactory.CreateDirective_BlockDirectiveCannotBeImported("test");
+            var sourceText = SourceText.From(string.Empty);
+
+            // Act
+            var diagnostic = RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText);
+
+            // Assert
+            Assert.Equal(razorDiagnostic.Id, diagnostic.Code);
+            Assert.Equal(razorDiagnostic.GetMessage(), diagnostic.Message);
+            Assert.Null(diagnostic.Range);
+            Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        }
+
+        [Fact]
+        public void ConvertSeverity_ErrorReturnsError()
+        {
+            // Arrange
+            var expectedSeverity = DiagnosticSeverity.Error;
+
+            // Act
+            var severity = RazorDiagnosticConverter.ConvertSeverity(RazorDiagnosticSeverity.Error);
+
+            // Assert
+            Assert.Equal(expectedSeverity, severity);
+        }
+
+        [Fact]
+        public void ConvertSpanToRange_ReturnsConvertedRange()
+        {
+            // Arrange
+            var sourceSpan = new SourceSpan(3, 0, 3, 4);
+            var sourceText = SourceText.From("Hello World");
+            var expectedRange = new Range(
+                new Position(0, 3),
+                new Position(0, 7));
+
+            // Act
+            var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
+
+            // Assert
+            Assert.Equal(expectedRange, range);
+        }
+
+        [Fact]
+        public void ConvertSpanToRange_ReturnsNullIfSpanIsUndefined()
+        {
+            // Arrange
+            var sourceSpan = SourceSpan.Undefined;
+            var sourceText = SourceText.From(string.Empty);
+
+            // Act
+            var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
+
+            // Assert
+            Assert.Null(range);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsPublisherTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsPublisherTest.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Xunit;
+using Xunit.Sdk;
+using RazorDiagnosticFactory = Microsoft.AspNetCore.Razor.Language.RazorDiagnosticFactory;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorDiagnosticsPublisherTest : TestBase
+    {
+        public RazorDiagnosticsPublisherTest()
+        {
+            var testProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            var hostProject = new HostProject("/C:/project/project.csproj", RazorConfiguration.Default);
+            testProjectManager.HostProjectAdded(hostProject);
+            var sourceText = SourceText.From(string.Empty);
+            var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
+            var openedHostDocument = new HostDocument("/C:/project/open_document.cshtml", "/C:/project/open_document.cshtml");
+            testProjectManager.DocumentAdded(hostProject, openedHostDocument, TextLoader.From(textAndVersion));
+            testProjectManager.DocumentOpened(hostProject.FilePath, openedHostDocument.FilePath, sourceText);
+            var closedHostDocument = new HostDocument("/C:/project/closed_document.cshtml", "/C:/project/closed_document.cshtml");
+            testProjectManager.DocumentAdded(hostProject, closedHostDocument, TextLoader.From(textAndVersion));
+
+            OpenedDocument = testProjectManager.Projects[0].GetDocument(openedHostDocument.FilePath);
+            ClosedDocument = testProjectManager.Projects[0].GetDocument(closedHostDocument.FilePath);
+            ProjectManager = testProjectManager;
+        }
+
+        private ProjectSnapshotManager ProjectManager { get; }
+
+        private DocumentSnapshot ClosedDocument { get; }
+
+        private DocumentSnapshot OpenedDocument { get; }
+
+        private RazorDiagnostic[] EmptyDiagnostics => Array.Empty<RazorDiagnostic>();
+
+        private RazorDiagnostic[] SingleDiagnosticCollection => new RazorDiagnostic[]
+        {
+            RazorDiagnosticFactory.CreateDirective_BlockDirectiveCannotBeImported("test")
+        };
+
+        [Fact]
+        public void PublishDiagnostics_NewDocumentDiagnosticsGetPublished()
+        {
+            // Arrange
+            var processedOpenDocument = TestDocumentSnapshot.Create(OpenedDocument.FilePath);
+            var codeDocument = CreateCodeDocument(SingleDiagnosticCollection);
+            processedOpenDocument.With(codeDocument);
+            var languageServerDocument = new Mock<ILanguageServerDocument>();
+            languageServerDocument.Setup(lsd => lsd.SendNotification(It.IsAny<string>(), It.IsAny<PublishDiagnosticsParams>()))
+                .Callback<string, PublishDiagnosticsParams>((method, diagnosticParams) =>
+                {
+                    Assert.Equal(processedOpenDocument.FilePath.TrimStart('/'), diagnosticParams.Uri.AbsolutePath);
+                    var diagnostic = Assert.Single(diagnosticParams.Diagnostics);
+                    var razorDiagnostic = SingleDiagnosticCollection[0];
+                    processedOpenDocument.TryGetText(out var sourceText);
+                    var expectedDiagnostic = RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText);
+                    Assert.Equal(expectedDiagnostic.Message, diagnostic.Message);
+                    Assert.Equal(expectedDiagnostic.Severity, diagnostic.Severity);
+                    Assert.Equal(expectedDiagnostic.Range, diagnostic.Range);
+                }).Verifiable();
+            var languageServer = new Mock<ILanguageServer>();
+            languageServer.Setup(server => server.Document).Returns(languageServerDocument.Object);
+            using (var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, languageServer.Object, LoggerFactory))
+            {
+                publisher.Initialize(ProjectManager);
+
+                // Act
+                publisher.PublishDiagnostics(processedOpenDocument);
+
+                // Assert
+                languageServerDocument.VerifyAll();
+            }
+        }
+
+        [Fact]
+        public void PublishDiagnostics_NewDiagnosticsGetPublished()
+        {
+            // Arrange
+            var processedOpenDocument = TestDocumentSnapshot.Create(OpenedDocument.FilePath);
+            var codeDocument = CreateCodeDocument(SingleDiagnosticCollection);
+            processedOpenDocument.With(codeDocument);
+            var languageServerDocument = new Mock<ILanguageServerDocument>();
+            languageServerDocument.Setup(lsd => lsd.SendNotification(It.IsAny<string>(), It.IsAny<PublishDiagnosticsParams>()))
+                .Callback<string, PublishDiagnosticsParams>((method, diagnosticParams) =>
+                {
+                    Assert.Equal(processedOpenDocument.FilePath.TrimStart('/'), diagnosticParams.Uri.AbsolutePath);
+                    var diagnostic = Assert.Single(diagnosticParams.Diagnostics);
+                    var razorDiagnostic = SingleDiagnosticCollection[0];
+                    processedOpenDocument.TryGetText(out var sourceText);
+                    var expectedDiagnostic = RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText);
+                    Assert.Equal(expectedDiagnostic.Message, diagnostic.Message);
+                    Assert.Equal(expectedDiagnostic.Severity, diagnostic.Severity);
+                    Assert.Equal(expectedDiagnostic.Range, diagnostic.Range);
+                }).Verifiable();
+            var languageServer = new Mock<ILanguageServer>();
+            languageServer.Setup(server => server.Document).Returns(languageServerDocument.Object);
+            using (var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, languageServer.Object, LoggerFactory))
+            {
+                publisher._publishedDiagnostics[processedOpenDocument.FilePath] = EmptyDiagnostics;
+                publisher.Initialize(ProjectManager);
+
+                // Act
+                publisher.PublishDiagnostics(processedOpenDocument);
+
+                // Assert
+                languageServerDocument.VerifyAll();
+            }
+        }
+
+        [Fact]
+        public void PublishDiagnostics_NoopsIfDiagnosticsAreSameAsPreviousPublish()
+        {
+            // Arrange
+            var languageServer = new Mock<ILanguageServer>();
+            languageServer.Setup(server => server.Document).Throws<XunitException>();
+            var processedOpenDocument = TestDocumentSnapshot.Create(OpenedDocument.FilePath);
+            var codeDocument = CreateCodeDocument(SingleDiagnosticCollection);
+            processedOpenDocument.With(codeDocument);
+            using (var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, languageServer.Object, LoggerFactory))
+            {
+                publisher._publishedDiagnostics[processedOpenDocument.FilePath] = SingleDiagnosticCollection;
+                publisher.Initialize(ProjectManager);
+
+                // Act & Assert
+                publisher.PublishDiagnostics(processedOpenDocument);
+            }
+        }
+
+        [Fact]
+        public void ClearClosedDocuments_ClearsDiagnosticsForClosedDocument()
+        {
+            // Arrange
+            var languageServerDocument = new Mock<ILanguageServerDocument>();
+            languageServerDocument.Setup(lsd => lsd.SendNotification(It.IsAny<string>(), It.IsAny<PublishDiagnosticsParams>()))
+                .Callback<string, PublishDiagnosticsParams>((method, diagnosticParams) =>
+                {
+                    Assert.Equal(ClosedDocument.FilePath.TrimStart('/'), diagnosticParams.Uri.AbsolutePath);
+                    Assert.Empty(diagnosticParams.Diagnostics);
+                }).Verifiable();
+            var languageServer = new Mock<ILanguageServer>();
+            languageServer.Setup(server => server.Document).Returns(languageServerDocument.Object);
+            using (var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, languageServer.Object, LoggerFactory))
+            {
+                publisher._publishedDiagnostics[ClosedDocument.FilePath] = SingleDiagnosticCollection;
+                publisher.Initialize(ProjectManager);
+
+                // Act
+                publisher.ClearClosedDocuments();
+
+                // Assert
+                languageServerDocument.VerifyAll();
+            }
+        }
+
+        [Fact]
+        public void ClearClosedDocuments_NoopsIfDocumentIsStillOpen()
+        {
+            // Arrange
+            var languageServer = new Mock<ILanguageServer>();
+            languageServer.Setup(server => server.Document).Throws<XunitException>();
+            using (var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, languageServer.Object, LoggerFactory))
+            {
+                publisher._publishedDiagnostics[OpenedDocument.FilePath] = SingleDiagnosticCollection;
+                publisher.Initialize(ProjectManager);
+
+                // Act & Assert
+                publisher.ClearClosedDocuments();
+            }
+        }
+
+        [Fact]
+        public void ClearClosedDocuments_NoopsIfDocumentIsClosedButNoDiagnostics()
+        {
+            // Arrange
+            var languageServer = new Mock<ILanguageServer>();
+            languageServer.Setup(server => server.Document).Throws<XunitException>();
+            using (var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, languageServer.Object, LoggerFactory))
+            {
+                publisher._publishedDiagnostics[ClosedDocument.FilePath] = EmptyDiagnostics;
+                publisher.Initialize(ProjectManager);
+
+                // Act & Assert
+                publisher.ClearClosedDocuments();
+            }
+        }
+
+        [Fact]
+        public void ClearClosedDocuments_RestartsTimerIfDocumentsStillOpen()
+        {
+            // Arrange
+            var languageServer = new Mock<ILanguageServer>();
+            languageServer.Setup(server => server.Document).Throws<XunitException>();
+            using (var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, languageServer.Object, LoggerFactory))
+            {
+                publisher._publishedDiagnostics[ClosedDocument.FilePath] = EmptyDiagnostics;
+                publisher._publishedDiagnostics[OpenedDocument.FilePath] = EmptyDiagnostics;
+                publisher.Initialize(ProjectManager);
+
+                // Act
+                publisher.ClearClosedDocuments();
+
+                // Assert
+                Assert.NotNull(publisher._documentClosedTimer);
+            }
+        }
+
+        private static RazorCodeDocument CreateCodeDocument(params RazorDiagnostic[] diagnostics)
+        {
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+            var razorCSharpDocument = RazorCSharpDocument.Create(string.Empty, RazorCodeGenerationOptions.CreateDefault(), diagnostics);
+            codeDocument.SetCSharpDocument(razorCSharpDocument);
+
+            return codeDocument;
+        }
+
+        private class TestRazorDiagnosticsPublisher : RazorDiagnosticsPublisher, IDisposable
+        {
+            public TestRazorDiagnosticsPublisher(
+                ForegroundDispatcher foregroundDispatcher,
+                ILanguageServer languageServer,
+                ILoggerFactory loggerFactory) : base(foregroundDispatcher, languageServer, loggerFactory)
+            {
+            }
+
+            public void Dispose()
+            {
+                _workTimer?.Dispose();
+                _documentClosedTimer?.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- We now listen for when a document has been processed by the `BackgroundDocumentGenerator` and on a cadence refresh diagnostics when they change.
- The `LanguageClient` already expects diagnostics to be flowed to the client and handles the publish diagnostics notifications appropriately.
- Because we can't proactively tell when a document has been closed we poll the snapshot manager on a 5 second interval re-checking all of our active documents.
- Add a RazorDiagnostic converter because we need to go from `RazorDiagnostic` to an LSP diagnostic. However, we only ever convert to an LSP diagnostic when we've found new diagnostics to publish.
- Added tests to validate the `RazorDiagnosticConverter` and `RazorDiagnosticPublisher` work as expected.

![image](https://i.imgur.com/VelwfK4.gif)

#30