### PR TITLE
Fix Html completion timeout on freshly opened documents.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
             "outFiles": [
                 "${workspaceFolder}/client/out/test/**/*.js"
             ],
-            "preLaunchTask": "client-npm-watch"
+            "preLaunchTask": "client-npm-compile"
         },
         {
             "type": "node",

--- a/client/test/Completions.test.ts
+++ b/client/test/Completions.test.ts
@@ -38,6 +38,25 @@ describe('Completions', () => {
         await pollUntil(() => vscode.window.visibleTextEditors.length === 0, 1000);
     });
 
+    it('Can get HTML completions on document open', async () => {
+        // This test relies on the Index.cshtml document containing at least 1 HTML tag in it.
+        // For the purposes of this test it locates that tag and tries to get the Html completion
+        // list from it.
+
+        const content = doc.getText();
+        const tagNameIndex = content.indexOf('<') + 1;
+        const docPosition = doc.positionAt(tagNameIndex);
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            docPosition);
+        const matchingCompletions = completions!.items
+            .filter(item => (typeof item.insertText === 'string') && item.insertText === 'iframe')
+            .map(item => item.insertText as string);
+
+        assert.deepEqual(matchingCompletions, ['iframe']);
+    });
+
     it('Can complete C# code blocks', async () => {
         const lastLine = new vscode.Position(doc.lineCount - 1, 0);
         await editor.edit(edit => edit.insert(lastLine, '@{}'));

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -131,6 +131,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
     private openDocument(uri: vscode.Uri) {
         const document = this._getDocument(uri);
 
+        this.updateHtmlBuffer(document);
         this.notifyDocumentChange(document, RazorDocumentChangeKind.opened);
     }
 
@@ -214,7 +215,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
     private notifyDocumentChange(document: IRazorDocument, kind: RazorDocumentChangeKind) {
         if (this.logger.verboseEnabled) {
             this.logger.logVerbose(
-                `Notifying docoument '${getUriPath(document.uri)}' changed '${RazorDocumentChangeKind[kind]}'`);
+                `Notifying document '${getUriPath(document.uri)}' changed '${RazorDocumentChangeKind[kind]}'`);
         }
 
         const args: IRazorDocumentChangeEvent = {


### PR DESCRIPTION
- Prior to this we wouldn't be updating the html buffer with the documents content when the doc was opened. This means that if a completion request via ctrl + j was invoked before typing it would never work.
- Added a functional test to validate behavior.