### PR TITLE
Add TagHelper element completion.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,15 +2,15 @@
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.7.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview3.19109.1</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview3.19109.1</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview3.19109.1</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview4.19121.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview4.19121.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview4.19121.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview3.19109.1</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview4.19121.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/AttributeDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/AttributeDescriptionInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class AttributeDescriptionInfo
+    {
+        public static readonly AttributeDescriptionInfo Default = new AttributeDescriptionInfo(Array.Empty<TagHelperAttributeDescriptionInfo>());
+
+        public AttributeDescriptionInfo(IReadOnlyList<TagHelperAttributeDescriptionInfo> associatedAttributeDescriptions)
+        {
+            if (associatedAttributeDescriptions == null)
+            {
+                throw new ArgumentNullException(nameof(associatedAttributeDescriptions));
+            }
+
+            AssociatedAttributeDescriptions = associatedAttributeDescriptions;
+        }
+
+        public IReadOnlyList<TagHelperAttributeDescriptionInfo> AssociatedAttributeDescriptions { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class CompletionItemExtensions
+    {
+        private const string TagHelperElementDataKey = "_TagHelperElementData_";
+
+        public static bool IsTagHelperElementCompletion(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperElementDataKey))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static void SetDescriptionData(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
+        {
+            var data = new JObject();
+            data[TagHelperElementDataKey] = JObject.FromObject(elementDescriptionInfo);
+            completion.Data = data;
+        }
+
+        public static ElementDescriptionInfo GetElementDescriptionInfo(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperElementDataKey))
+            {
+                var descriptionInfo = data[TagHelperElementDataKey].ToObject<ElementDescriptionInfo>();
+                return descriptionInfo;
+            }
+
+            return ElementDescriptionInfo.Default;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal static class CompletionItemExtensions
     {
         private const string TagHelperElementDataKey = "_TagHelperElementData_";
+        private const string TagHelperAttributeDataKey = "_TagHelperAttributes_";
 
         public static bool IsTagHelperElementCompletion(this CompletionItem completion)
         {
@@ -20,10 +21,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return false;
         }
 
-        public static void SetDescriptionData(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
+        public static bool IsTagHelperAttributeCompletion(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperAttributeDataKey))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static void SetDescriptionInfo(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
         {
             var data = new JObject();
             data[TagHelperElementDataKey] = JObject.FromObject(elementDescriptionInfo);
+            completion.Data = data;
+        }
+
+        public static void SetDescriptionInfo(this CompletionItem completion, AttributeDescriptionInfo attributeDescriptionInfo)
+        {
+            var data = new JObject();
+            data[TagHelperAttributeDataKey] = JObject.FromObject(attributeDescriptionInfo);
             completion.Data = data;
         }
 
@@ -36,6 +54,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             return ElementDescriptionInfo.Default;
+        }
+
+        public static AttributeDescriptionInfo GetAttributeDescriptionInfo(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperAttributeDataKey))
+            {
+                var descriptionInfo = data[TagHelperAttributeDataKey].ToObject<AttributeDescriptionInfo>();
+                return descriptionInfo;
+            }
+
+            return AttributeDescriptionInfo.Default;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
@@ -306,6 +306,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Kind = CompletionItemKind.TypeParameter,
                     CommitCharacters = ElementCommitCharacters,
                 };
+                var tagHelperDescriptions = completion.Value.Select(tagHelper => new TagHelperDescriptionInfo(tagHelper.GetTypeName(), tagHelper.Documentation));
+                var elementDescription = new ElementDescriptionInfo(tagHelperDescriptions.ToList());
+                razorCompletionItem.SetDescriptionData(elementDescription);
 
                 completionItems.Add(razorCompletionItem);
             }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
@@ -268,6 +268,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Kind = CompletionItemKind.TypeParameter,
                     CommitCharacters = AttributeCommitCharacters,
                 };
+                var attributeDescriptions = completion.Value.Select(boundAttribute => new TagHelperAttributeDescriptionInfo(
+                    boundAttribute.DisplayName,
+                    boundAttribute.GetPropertyName(),
+                    indexerCompletion ? boundAttribute.IndexerTypeName : boundAttribute.TypeName,
+                    boundAttribute.Documentation));
+                var attributeDescriptionInfo = new AttributeDescriptionInfo(attributeDescriptions.ToList());
+                razorCompletionItem.SetDescriptionInfo(attributeDescriptionInfo);
 
                 completionItems.Add(razorCompletionItem);
             }
@@ -308,7 +315,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
                 var tagHelperDescriptions = completion.Value.Select(tagHelper => new TagHelperDescriptionInfo(tagHelper.GetTypeName(), tagHelper.Documentation));
                 var elementDescription = new ElementDescriptionInfo(tagHelperDescriptions.ToList());
-                razorCompletionItem.SetDescriptionData(elementDescription);
+                razorCompletionItem.SetDescriptionInfo(elementDescription);
 
                 completionItems.Add(razorCompletionItem);
             }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
@@ -1,0 +1,304 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.VisualStudio.Editor.Razor;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using RazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.TagHelperCompletionService;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultTagHelperCompletionService : TagHelperCompletionService
+    {
+        private static readonly Container<string> ElementCommitCharacters = new Container<string>(" ", ">");
+        private static readonly HashSet<string> HtmlSchemaTagNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "DOCTYPE",
+            "a",
+            "abbr",
+            "acronym",
+            "address",
+            "applet",
+            "area",
+            "article",
+            "aside",
+            "audio",
+            "b",
+            "base",
+            "basefont",
+            "bdi",
+            "bdo",
+            "big",
+            "blockquote",
+            "body",
+            "br",
+            "button",
+            "canvas",
+            "caption",
+            "center",
+            "cite",
+            "code",
+            "col",
+            "colgroup",
+            "data",
+            "datalist",
+            "dd",
+            "del",
+            "details",
+            "dfn",
+            "dialog",
+            "dir",
+            "div",
+            "dl",
+            "dt",
+            "em",
+            "embed",
+            "fieldset",
+            "figcaption",
+            "figure",
+            "font",
+            "footer",
+            "form",
+            "frame",
+            "frameset",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "head",
+            "header",
+            "hr",
+            "html",
+            "i",
+            "iframe",
+            "img",
+            "input",
+            "ins",
+            "kbd",
+            "label",
+            "legend",
+            "li",
+            "link",
+            "main",
+            "map",
+            "mark",
+            "meta",
+            "meter",
+            "nav",
+            "noframes",
+            "noscript",
+            "object",
+            "ol",
+            "optgroup",
+            "option",
+            "output",
+            "p",
+            "param",
+            "picture",
+            "pre",
+            "progress",
+            "q",
+            "rp",
+            "rt",
+            "ruby",
+            "s",
+            "samp",
+            "script",
+            "section",
+            "select",
+            "small",
+            "source",
+            "span",
+            "strike",
+            "strong",
+            "style",
+            "sub",
+            "summary",
+            "sup",
+            "svg",
+            "table",
+            "tbody",
+            "td",
+            "template",
+            "textarea",
+            "tfoot",
+            "th",
+            "thead",
+            "time",
+            "title",
+            "tr",
+            "track",
+            "tt",
+            "u",
+            "ul",
+            "var",
+            "video",
+            "wbr",
+        };
+        private readonly RazorTagHelperCompletionService _razorTagHelperCompletionService;
+
+        public DefaultTagHelperCompletionService(RazorTagHelperCompletionService razorCompletionService)
+        {
+            if (razorCompletionService == null)
+            {
+                throw new ArgumentNullException(nameof(razorCompletionService));
+            }
+
+            _razorTagHelperCompletionService = razorCompletionService;
+        }
+
+        public override IReadOnlyList<CompletionItem> GetCompletionsAt(SourceSpan location, RazorCodeDocument codeDocument)
+        {
+            if (codeDocument == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var change = new SourceChange(location, "");
+            var owner = syntaxTree.Root.LocateOwner(change);
+
+            if (owner == null)
+            {
+                Debug.Fail("Owner should never be null.");
+                return Array.Empty<CompletionItem>();
+            }
+
+            var parent = owner.Parent;
+            if (TryGetElementInfo(parent, out var containingTagNameToken, out var attributes) &&
+                containingTagNameToken.Span.IntersectsWith(location.AbsoluteIndex))
+            {
+                var stringifiedAttributes = StringifyAttributes(attributes);
+                var elementCompletions = GetElementCompletions(parent, containingTagNameToken.Content, stringifiedAttributes, codeDocument);
+                return elementCompletions;
+            }
+
+            // Invalid location for TagHelper completions.
+            return Array.Empty<CompletionItem>();
+        }
+
+        private IReadOnlyList<CompletionItem> GetElementCompletions(
+            SyntaxNode containingTag,
+            string containingTagName,
+            IEnumerable<KeyValuePair<string, string>> attributes,
+            RazorCodeDocument codeDocument)
+        {
+            var ancestors = containingTag.Ancestors();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var (ancestorTagName, ancestorIsTagHelper) = GetNearestAncestorTagInfo(ancestors);
+            var elementCompletionContext = new ElementCompletionContext(
+                tagHelperDocumentContext,
+                existingCompletions: Enumerable.Empty<string>(),
+                containingTagName,
+                attributes,
+                ancestorTagName,
+                ancestorIsTagHelper,
+                HtmlSchemaTagNames.Contains);
+
+            var completionItems = new List<CompletionItem>();
+            var completionResult = _razorTagHelperCompletionService.GetElementCompletions(elementCompletionContext);
+            foreach (var completion in completionResult.Completions)
+            {
+                var razorCompletionItem = new CompletionItem()
+                {
+                    Label = completion.Key,
+                    InsertText = completion.Key,
+                    FilterText = completion.Key,
+                    SortText = completion.Key,
+                    Kind = CompletionItemKind.TypeParameter,
+                    CommitCharacters = ElementCommitCharacters,
+                };
+
+                completionItems.Add(razorCompletionItem);
+            }
+
+            return completionItems;
+        }
+
+        // Internal for testing
+        internal static IEnumerable<KeyValuePair<string, string>> StringifyAttributes(SyntaxList<RazorSyntaxNode> attributes)
+        {
+            var stringifiedAttributes = new List<KeyValuePair<string, string>>();
+
+            for (var i = 0; i < attributes.Count; i++)
+            {
+                var attribute = attributes[i];
+                if (attribute is MarkupTagHelperAttributeSyntax tagHelperAttribute)
+                {
+                    var name = tagHelperAttribute.Name.GetContent();
+                    var value = tagHelperAttribute.Value?.GetContent() ?? string.Empty;
+                    stringifiedAttributes.Add(new KeyValuePair<string, string>(name, value));
+                }
+                else if (attribute is MarkupMinimizedTagHelperAttributeSyntax minimizedTagHelperAttribute)
+                {
+                    var name = minimizedTagHelperAttribute.Name.GetContent();
+                    stringifiedAttributes.Add(new KeyValuePair<string, string>(name, string.Empty));
+                }
+                else if (attribute is MarkupAttributeBlockSyntax markupAttribute)
+                {
+                    var name = markupAttribute.Name.GetContent();
+                    var value = markupAttribute.Value?.GetContent() ?? string.Empty;
+                    stringifiedAttributes.Add(new KeyValuePair<string, string>(name, value));
+                }
+                else if (attribute is MarkupMinimizedAttributeBlockSyntax minimizedMarkupAttribute)
+                {
+                    var name = minimizedMarkupAttribute.Name.GetContent();
+                    stringifiedAttributes.Add(new KeyValuePair<string, string>(name, string.Empty));
+                }
+            }
+
+            return stringifiedAttributes;
+        }
+
+        // Internal for testing
+        internal static (string ancestorTagName, bool ancestorIsTagHelper) GetNearestAncestorTagInfo(IEnumerable<SyntaxNode> ancestors)
+        {
+            foreach (var ancestor in ancestors)
+            {
+                if (ancestor is MarkupElementSyntax element)
+                {
+                    // It's possible for start tag to be null in malformed cases.
+                    var name = element.StartTag?.Name?.Content ?? string.Empty;
+                    return (name, ancestorIsTagHelper: false);
+                }
+                else if (ancestor is MarkupTagHelperElementSyntax tagHelperElement)
+                {
+                    // It's possible for start tag to be null in malformed cases.
+                    var name = tagHelperElement.StartTag?.Name?.Content ?? string.Empty;
+                    return (name, ancestorIsTagHelper: true);
+                }
+            }
+
+            return (ancestorTagName: null, ancestorIsTagHelper: false);
+        }
+
+        private static bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes)
+        {
+            if (element is MarkupStartTagSyntax startTag)
+            {
+                containingTagNameToken = startTag.Name;
+                attributeNodes = startTag.Attributes;
+                return true;
+            }
+
+            if (element is MarkupTagHelperStartTagSyntax startTagHelper)
+            {
+                containingTagNameToken = startTagHelper.Name;
+                attributeNodes = startTagHelper.Attributes;
+                return true;
+            }
+
+            containingTagNameToken = null;
+            attributeNodes = default;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperDescriptionFactory.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultTagHelperDescriptionFactory : TagHelperDescriptionFactory
+    {
+        private static readonly Lazy<Regex> ExtractCrefRegex = new Lazy<Regex>(
+            () => new Regex("<(see|seealso)[\\s]+cref=\"([^\">]+)\"[^>]*>", RegexOptions.Compiled, TimeSpan.FromSeconds(1)));
+
+        public override bool TryCreateDescription(ElementDescriptionInfo elementDescriptionInfo, out string markdown)
+        {
+            var associatedTagHelperInfos = elementDescriptionInfo.AssociatedTagHelperDescriptions;
+            if (associatedTagHelperInfos.Count == 0)
+            {
+                markdown = null;
+                return false;
+            }
+
+            // This generates a markdown description that looks like the following:
+            // **SomeTagHelper**
+            //
+            // The Summary documentation text with `CrefTypeValues` in code.
+            //
+            // Additional description infos result in a triple `---` to separate the markdown entries.
+
+            var descriptionBuilder = new StringBuilder();
+            for (var i = 0; i < associatedTagHelperInfos.Count; i++)
+            {
+                var descriptionInfo = associatedTagHelperInfos[i];
+
+                if (descriptionBuilder.Length > 0)
+                {
+                    descriptionBuilder.AppendLine();
+                    descriptionBuilder.AppendLine("---");
+                }
+
+                descriptionBuilder.Append("**");
+                var tagHelperType = descriptionInfo.TagHelperTypeName;
+                var reducedTypeName = ReduceTypeName(tagHelperType);
+                descriptionBuilder.Append(reducedTypeName);
+                descriptionBuilder.AppendLine("**");
+                descriptionBuilder.AppendLine();
+
+                var documentation = descriptionInfo.Documentation;
+                if (!TryExtractSummary(documentation, out var summaryContent))
+                {
+                    continue;
+                }
+
+                var finalSummaryContent = CleanSummaryContent(summaryContent);
+                descriptionBuilder.AppendLine(finalSummaryContent);
+            }
+
+            markdown = descriptionBuilder.ToString();
+            return true;
+        }
+
+        // Internal for testing
+        internal static string CleanSummaryContent(string summaryContent)
+        {
+            // Cleans out all <see cref="..." /> and <seealso cref="..." /> elements. It's possible to
+            // have additional doc comment types in the summary but none that require cleaning. For instance
+            // if there's a <para> in the summary element when it's shown in the completion description window
+            // it'll be serialized as html (wont show).
+
+            var crefMatches = ExtractCrefRegex.Value.Matches(summaryContent).Reverse();
+            var summaryBuilder = new StringBuilder(summaryContent);
+
+            foreach (var cref in crefMatches)
+            {
+                if (cref.Success)
+                {
+                    var value = cref.Groups[2].Value;
+                    var reducedValue = ReduceCrefValue(value);
+                    reducedValue = reducedValue.Replace("{", "<").Replace("}", ">");
+                    summaryBuilder.Remove(cref.Index, cref.Length);
+                    summaryBuilder.Insert(cref.Index, $"`{reducedValue}`");
+                }
+            }
+            var lines = summaryBuilder.ToString().Split(new[] { '\n' }, StringSplitOptions.None).Select(line => line.Trim());
+            var finalSummaryContent = string.Join(Environment.NewLine, lines);
+            return finalSummaryContent;
+        }
+
+        // Internal for testing
+        internal static bool TryExtractSummary(string documentation, out string summary)
+        {
+            const string summaryStartTag = "<summary>";
+            const string summaryEndTag = "</summary>";
+
+            if (string.IsNullOrEmpty(documentation))
+            {
+                summary = null;
+                return false;
+            }
+
+            var summaryTagStart = documentation.IndexOf(summaryStartTag, StringComparison.OrdinalIgnoreCase);
+            if (summaryTagStart == -1)
+            {
+                summary = null;
+                return false;
+            }
+
+            var summaryTagEndStart = documentation.IndexOf(summaryEndTag, StringComparison.OrdinalIgnoreCase);
+            if (summaryTagEndStart == -1)
+            {
+                summary = null;
+                return false;
+            }
+
+            var summaryContentStart = summaryTagStart + summaryStartTag.Length;
+            var summaryContentLength = summaryTagEndStart - summaryContentStart;
+
+            summary = documentation.Substring(summaryContentStart, summaryContentLength);
+            return true;
+        }
+
+        // Internal for testing
+        internal static string ReduceCrefValue(string value)
+        {
+            // cref values come in the following formats:
+            // Type = "T:Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName"
+            // Property = "P:T:Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.AspAction"
+            // Member = "M:T:Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeMethod(System.Collections.Generic.List{System.String})"
+
+            if (value.Length < 2)
+            {
+                return string.Empty;
+            }
+
+            var type = value[0];
+            value = value.Substring(2);
+
+            switch (type)
+            {
+                case 'T':
+                    var reducedCrefType = ReduceTypeName(value);
+                    return reducedCrefType;
+                case 'P':
+                case 'M':
+                    // TypeName.MemberName
+                    var reducedCrefProperty = ReduceMemberName(value);
+                    return reducedCrefProperty;
+            }
+
+            return value;
+        }
+
+
+        // Internal for testing
+        internal static string ReduceTypeName(string content) => ReduceFullName(content, reduceWhenDotCount: 1);
+
+        // Internal for testing
+        internal static string ReduceMemberName(string content) => ReduceFullName(content, reduceWhenDotCount: 2);
+
+        private static string ReduceFullName(string content, int reduceWhenDotCount)
+        {
+            // Starts searching backwards and then substrings everything when it finds enough dots. i.e. 
+            // ReduceFullName("Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName", 1) == "SomeTypeName"
+            //
+            // ReduceFullName("Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.AspAction", 2) == "SomeTypeName.AspAction"
+            //
+            // This is also smart enough to ignore nested dots in type generics[<>], methods[()], cref generics[{}].
+
+            if (reduceWhenDotCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(reduceWhenDotCount));
+            }
+
+            var dotsSeen = 0;
+            var scope = 0;
+            for (var i = content.Length - 1; i >= 0; i--)
+            {
+                do
+                {
+                    if (content[i] == '}')
+                    {
+                        scope++;
+                    }
+                    else if (content[i] == '{')
+                    {
+                        scope--;
+                    }
+
+                    if (scope > 0)
+                    {
+                        i--;
+                    }
+                } while (scope != 0 && i >= 0);
+
+                if (i < 0)
+                {
+                    // Could not balance scope
+                    return content;
+                }
+
+                do
+                {
+                    if (content[i] == ')')
+                    {
+                        scope++;
+                    }
+                    else if (content[i] == '(')
+                    {
+                        scope--;
+                    }
+
+                    if (scope > 0)
+                    {
+                        i--;
+                    }
+                } while (scope != 0 && i >= 0);
+
+                if (i < 0)
+                {
+                    // Could not balance scope
+                    return content;
+                }
+
+                do
+                {
+                    if (content[i] == '>')
+                    {
+                        scope++;
+                    }
+                    else if (content[i] == '<')
+                    {
+                        scope--;
+                    }
+
+                    if (scope > 0)
+                    {
+                        i--;
+                    }
+                } while (scope != 0 && i >= 0);
+
+                if (i < 0)
+                {
+                    // Could not balance scope
+                    return content;
+                }
+
+                if (content[i] == '.')
+                {
+                    dotsSeen++;
+                }
+
+                if (dotsSeen == reduceWhenDotCount)
+                {
+                    var piece = content.Substring(i + 1);
+                    return piece;
+                }
+            }
+
+            // Could not reduce name
+            return content;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ElementDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ElementDescriptionInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class ElementDescriptionInfo
+    {
+        public static readonly ElementDescriptionInfo Default = new ElementDescriptionInfo(Array.Empty<TagHelperDescriptionInfo>());
+
+        public ElementDescriptionInfo(IReadOnlyList<TagHelperDescriptionInfo> associatedTagHelperDescriptions)
+        {
+            if (associatedTagHelperDescriptions == null)
+            {
+                throw new ArgumentNullException(nameof(associatedTagHelperDescriptions));
+            }
+
+            AssociatedTagHelperDescriptions = associatedTagHelperDescriptions;
+        }
+
+        public IReadOnlyList<TagHelperDescriptionInfo> AssociatedTagHelperDescriptions { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<TagHelperFactsService, DefaultTagHelperFactsService>();
                         services.AddSingleton<VisualStudio.Editor.Razor.TagHelperCompletionService, VisualStudio.Editor.Razor.DefaultTagHelperCompletionService>();
                         services.AddSingleton<TagHelperCompletionService, DefaultTagHelperCompletionService>();
+                        services.AddSingleton<TagHelperDescriptionFactory, DefaultTagHelperDescriptionFactory>();
 
                         var foregroundDispatcher = new VSCodeForegroundDispatcher();
                         services.AddSingleton<ForegroundDispatcher>(foregroundDispatcher);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Editor.Razor;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Server;
 
@@ -77,6 +78,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<DocumentProcessedListener, RazorDiagnosticsPublisher>();
                         services.AddSingleton<HostDocumentFactory, DefaultHostDocumentFactory>();
                         services.AddSingleton<ProjectSnapshotManagerAccessor, DefaultProjectSnapshotManagerAccessor>();
+                        services.AddSingleton<TagHelperFactsService, DefaultTagHelperFactsService>();
+                        services.AddSingleton<VisualStudio.Editor.Razor.TagHelperCompletionService, VisualStudio.Editor.Razor.DefaultTagHelperCompletionService>();
+                        services.AddSingleton<TagHelperCompletionService, DefaultTagHelperCompletionService>();
 
                         var foregroundDispatcher = new VSCodeForegroundDispatcher();
                         services.AddSingleton<ForegroundDispatcher>(foregroundDispatcher);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperAttributeDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperAttributeDescriptionInfo.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class TagHelperAttributeDescriptionInfo
+    {
+        public TagHelperAttributeDescriptionInfo(
+            string displayName,
+            string propertyName,
+            string returnTypeName,
+            string documentation)
+        {
+            if (displayName == null)
+            {
+                throw new ArgumentNullException(nameof(displayName));
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (returnTypeName == null)
+            {
+                throw new ArgumentNullException(nameof(returnTypeName));
+            }
+
+            DisplayName = displayName;
+            PropertyName = propertyName;
+            ReturnTypeName = returnTypeName;
+            Documentation = documentation;
+        }
+
+        public string DisplayName { get; }
+
+        public string PropertyName { get; }
+
+        public string ReturnTypeName { get; }
+
+        public string Documentation { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperCompletionService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperCompletionService.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class TagHelperCompletionService
+    {
+        public abstract IReadOnlyList<CompletionItem> GetCompletionsAt(SourceSpan location, RazorCodeDocument codeDocument);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class TagHelperDescriptionFactory
+    {
+        public abstract bool TryCreateDescription(ElementDescriptionInfo descriptionInfos, out string markdown);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
@@ -6,5 +6,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal abstract class TagHelperDescriptionFactory
     {
         public abstract bool TryCreateDescription(ElementDescriptionInfo descriptionInfos, out string markdown);
+
+        public abstract bool TryCreateDescription(AttributeDescriptionInfo descriptionInfos, out string markdown);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class TagHelperDescriptionInfo
+    {
+        public TagHelperDescriptionInfo(string tagHelperTypeName, string documentation)
+        {
+            if (tagHelperTypeName == null)
+            {
+                throw new ArgumentNullException(nameof(tagHelperTypeName));
+            }
+
+            TagHelperTypeName = tagHelperTypeName;
+            Documentation = documentation;
+        }
+
+        public string TagHelperTypeName { get; }
+
+        public string Documentation { get; }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperCompletionServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperCompletionServiceTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure;
 using Microsoft.VisualStudio.Editor.Razor;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using DefaultRazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.DefaultTagHelperCompletionService;
 using RazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.TagHelperCompletionService;
@@ -20,10 +21,34 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var builder1 = TagHelperDescriptorBuilder.Create("Test1TagHelper", "TestAssembly");
             builder1.TagMatchingRule(rule => rule.TagName = "test1");
             builder1.SetTypeName("Test1TagHelper");
+            builder1.BindAttribute(attribute =>
+            {
+                attribute.Name = "bool-val";
+                attribute.SetPropertyName("BoolVal");
+                attribute.TypeName = typeof(bool).FullName;
+            });
+            builder1.BindAttribute(attribute =>
+            {
+                attribute.Name = "int-val";
+                attribute.SetPropertyName("IntVal");
+                attribute.TypeName = typeof(int).FullName;
+            });
 
             var builder2 = TagHelperDescriptorBuilder.Create("Test2TagHelper", "TestAssembly");
             builder2.TagMatchingRule(rule => rule.TagName = "test2");
             builder2.SetTypeName("Test2TagHelper");
+            builder2.BindAttribute(attribute =>
+            {
+                attribute.Name = "bool-val";
+                attribute.SetPropertyName("BoolVal");
+                attribute.TypeName = typeof(bool).FullName;
+            });
+            builder2.BindAttribute(attribute =>
+            {
+                attribute.Name = "int-val";
+                attribute.SetPropertyName("IntVal");
+                attribute.TypeName = typeof(int).FullName;
+            });
 
             DefaultTagHelpers = new[] { builder1.Build(), builder2.Build() };
             var tagHelperFactsService = new DefaultTagHelperFactsService();
@@ -270,6 +295,235 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 completions,
                 completion => Assert.Equal("test1", completion.InsertText),
                 completion => Assert.Equal("test2", completion.InsertText));
+        }
+
+        [Fact]
+        public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletionsWithSnippet()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("bool-val", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
+                },
+                completion =>
+                {
+                    Assert.Equal("int-val=\"$1\"", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_AtAttributeEdge_BoolAttribute_ReturnsCompletionsWithoutSnippet()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("bool-val", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
+                },
+                completion =>
+                {
+                    Assert.Equal("int-val=\"$1\"", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_AtAttributeEdge_IndexerBoolAttribute_ReturnsCompletionsWithAndWithoutSnippet()
+        {
+            // Arrange
+            var tagHelper = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
+            tagHelper.TagMatchingRule(rule => rule.TagName = "test");
+            tagHelper.SetTypeName("TestTagHelper");
+            tagHelper.BindAttribute(attribute =>
+            {
+                attribute.Name = "bool-val";
+                attribute.SetPropertyName("BoolVal");
+                attribute.TypeName = ("System.Collections.Generic.IDictionary<System.String, System.Boolean>");
+                attribute.AsDictionary("bool-val-", typeof(bool).FullName);
+            });
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", tagHelper.Build());
+            var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("bool-val=\"$1\"", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                },
+                completion =>
+                {
+                    Assert.Equal("bool-val-", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_AtAttributeEdge_IndexerAttribute_ReturnsCompletionsWithSnippet()
+        {
+            // Arrange
+            var tagHelper = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
+            tagHelper.TagMatchingRule(rule => rule.TagName = "test");
+            tagHelper.SetTypeName("TestTagHelper");
+            tagHelper.BindAttribute(attribute =>
+            {
+                attribute.Name = "int-val";
+                attribute.SetPropertyName("IntVal");
+                attribute.TypeName = ("System.Collections.Generic.IDictionary<System.String, System.Int32>");
+                attribute.AsDictionary("int-val-", typeof(int).FullName);
+            });
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", tagHelper.Build());
+            var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("int-val=\"$1\"", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                },
+                completion =>
+                {
+                    Assert.Equal("int-val-$1=\"$2\"", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_MinimizedAttribute_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 unbound />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("bool-val", completion.FilterText),
+                completion => Assert.Equal("int-val", completion.FilterText));
+        }
+
+        [Fact]
+        public void GetCompletionAt_MinimizedTagHelperAttribute_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 bool-val />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("int-val", completion.FilterText));
+        }
+
+        [Fact]
+        public void GetCompletionAt_HtmlAttribute_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("bool-val", completion.FilterText),
+                completion => Assert.Equal("int-val", completion.FilterText));
+        }
+
+        [Fact]
+        public void GetCompletionAt_TagHelperAttribute_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int-val='123' />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("bool-val", completion.FilterText));
+        }
+
+        [Fact]
+        public void GetCompletionsAt_MalformedAttributeValue_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int-val='>", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("bool-val", completion.FilterText));
+        }
+
+        [Fact]
+        public void GetCompletionsAt_MalformedAttributeName_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int->", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("bool-val", completion.FilterText),
+                completion => Assert.Equal("int-val", completion.FilterText));
         }
 
         private static RazorCodeDocument CreateCodeDocument(string text, params TagHelperDescriptor[] tagHelpers)

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperCompletionServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperCompletionServiceTest.cs
@@ -1,0 +1,284 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Infrastructure;
+using Microsoft.VisualStudio.Editor.Razor;
+using Xunit;
+using DefaultRazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.DefaultTagHelperCompletionService;
+using RazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.TagHelperCompletionService;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class DefaultTagHelperCompletionServiceTest : TestBase
+    {
+        public DefaultTagHelperCompletionServiceTest()
+        {
+            var builder1 = TagHelperDescriptorBuilder.Create("Test1TagHelper", "TestAssembly");
+            builder1.TagMatchingRule(rule => rule.TagName = "test1");
+            builder1.SetTypeName("Test1TagHelper");
+
+            var builder2 = TagHelperDescriptorBuilder.Create("Test2TagHelper", "TestAssembly");
+            builder2.TagMatchingRule(rule => rule.TagName = "test2");
+            builder2.SetTypeName("Test2TagHelper");
+
+            DefaultTagHelpers = new[] { builder1.Build(), builder2.Build() };
+            var tagHelperFactsService = new DefaultTagHelperFactsService();
+            RazorTagHelperCompletionService = new DefaultRazorTagHelperCompletionService(tagHelperFactsService);
+        }
+
+        private TagHelperDescriptor[] DefaultTagHelpers { get; }
+
+        private RazorTagHelperCompletionService RazorTagHelperCompletionService { get; }
+
+        [Fact]
+        public void GetNearestAncestorTagInfo_MarkupElement()
+        {
+            // Arrange
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<p><strong></strong></p>");
+            var sourceSpan = new SourceSpan(33 + Environment.NewLine.Length, 0);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var owner = syntaxTree.Root.LocateOwner(new SourceChange(sourceSpan, string.Empty));
+            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
+
+            // Act
+            var (ancestorName, ancestorIsTagHelper) = DefaultTagHelperCompletionService.GetNearestAncestorTagInfo(element.Ancestors());
+
+            // Assert
+            Assert.Equal("p", ancestorName);
+            Assert.False(ancestorIsTagHelper);
+        }
+
+        [Fact]
+        public void GetNearestAncestorTagInfo_TagHelperElement()
+        {
+            // Arrange
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><test2></test2></test1>", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(37 + Environment.NewLine.Length, 0);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var owner = syntaxTree.Root.LocateOwner(new SourceChange(sourceSpan, string.Empty));
+            var element = owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
+
+            // Act
+            var (ancestorName, ancestorIsTagHelper) = DefaultTagHelperCompletionService.GetNearestAncestorTagInfo(element.Ancestors());
+
+            // Assert
+            Assert.Equal("test1", ancestorName);
+            Assert.True(ancestorIsTagHelper);
+        }
+
+        [Fact]
+        public void StringifyAttributes_TagHelperAttribute()
+        {
+            // Arrange
+            var tagHelper = TagHelperDescriptorBuilder.Create("WithBoundAttribute", "TestAssembly");
+            tagHelper.TagMatchingRule(rule => rule.TagName = "test");
+            tagHelper.BindAttribute(attribute =>
+            {
+                attribute.Name = "bound";
+                attribute.SetPropertyName("Bound");
+                attribute.TypeName = typeof(bool).FullName;
+            });
+            tagHelper.SetTypeName("WithBoundAttribute");
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test bound='true' />", tagHelper.Build());
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
+            var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
+            var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+
+            // Act
+            var attributes = DefaultTagHelperCompletionService.StringifyAttributes(startTag.Attributes);
+
+            // Assert
+            Assert.Collection(
+                attributes,
+                attribute =>
+                {
+                    Assert.Equal("bound", attribute.Key);
+                    Assert.Equal("true", attribute.Value);
+                });
+        }
+
+        [Fact]
+        public void StringifyAttributes_MinimizedTagHelperAttribute()
+        {
+            // Arrange
+            var tagHelper = TagHelperDescriptorBuilder.Create("WithBoundAttribute", "TestAssembly");
+            tagHelper.TagMatchingRule(rule => rule.TagName = "test");
+            tagHelper.BindAttribute(attribute =>
+            {
+                attribute.Name = "bound";
+                attribute.SetPropertyName("Bound");
+                attribute.TypeName = typeof(bool).FullName;
+            });
+            tagHelper.SetTypeName("WithBoundAttribute");
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test bound />", tagHelper.Build());
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
+            var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
+            var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+
+            // Act
+            var attributes = DefaultTagHelperCompletionService.StringifyAttributes(startTag.Attributes);
+
+            // Assert
+            Assert.Collection(
+                attributes,
+                attribute =>
+                {
+                    Assert.Equal("bound", attribute.Key);
+                    Assert.Equal(string.Empty, attribute.Value);
+                });
+        }
+
+        [Fact]
+        public void StringifyAttributes_UnboundAttribute()
+        {
+            // Arrange
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound='hello world' />", DefaultTagHelpers);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
+            var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
+            var startTag = (MarkupStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+
+            // Act
+            var attributes = DefaultTagHelperCompletionService.StringifyAttributes(startTag.Attributes);
+
+            // Assert
+            Assert.Collection(
+                attributes,
+                attribute =>
+                {
+                    Assert.Equal("unbound", attribute.Key);
+                    Assert.Equal("hello world", attribute.Value);
+                });
+        }
+
+        [Fact]
+        public void StringifyAttributes_UnboundMinimizedAttribute()
+        {
+            // Arrange
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound />", DefaultTagHelpers);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
+            var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
+            var startTag = (MarkupStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+
+            // Act
+            var attributes = DefaultTagHelperCompletionService.StringifyAttributes(startTag.Attributes);
+
+            // Assert
+            Assert.Collection(
+                attributes,
+                attribute =>
+                {
+                    Assert.Equal("unbound", attribute.Key);
+                    Assert.Equal(string.Empty, attribute.Value);
+                });
+        }
+
+        [Fact]
+        public void StringifyAttributes_IgnoresMiscContent()
+        {
+            // Arrange
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound @DateTime.Now />", DefaultTagHelpers);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
+            var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
+            var startTag = (MarkupStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+
+            // Act
+            var attributes = DefaultTagHelperCompletionService.StringifyAttributes(startTag.Attributes);
+
+            // Assert
+            Assert.Collection(
+                attributes,
+                attribute =>
+                {
+                    Assert.Equal("unbound", attribute.Key);
+                    Assert.Equal(string.Empty, attribute.Value);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_AtEmptyTagName_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("test1", completion.InsertText),
+                completion => Assert.Equal("test2", completion.InsertText));
+        }
+
+        [Fact]
+        public void GetCompletionAt_OutsideOfTagName_DoesNotReturnCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(33 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionAt_AtHtmlElementNameEdge_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(32 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("test1", completion.InsertText),
+                completion => Assert.Equal("test2", completion.InsertText));
+        }
+
+        [Fact]
+        public void GetCompletionAt_AtTagHelperElementNameEdge_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("test1", completion.InsertText),
+                completion => Assert.Equal("test2", completion.InsertText));
+        }
+
+        private static RazorCodeDocument CreateCodeDocument(string text, params TagHelperDescriptor[] tagHelpers)
+        {
+            tagHelpers = tagHelpers ?? Array.Empty<TagHelperDescriptor>();
+            var sourceDocument = TestRazorSourceDocument.Create(text);
+            var projectEngine = RazorProjectEngine.Create(builder => { });
+            var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, "mvc", Array.Empty<RazorSourceDocument>(), tagHelpers);
+            return codeDocument;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperDescriptionFactoryTest.cs
@@ -1,0 +1,382 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class DefaultTagHelperDescriptionFactoryTest
+    {
+        [Fact]
+        public void ReduceTypeName_Plain()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("SomeTypeName", reduced);
+        }
+
+        [Fact]
+        public void ReduceTypeName_Generics()
+        {
+            // Arrange
+            var content = "System.Collections.Generic.List<System.String>";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("List<System.String>", reduced);
+        }
+
+        [Fact]
+        public void ReduceTypeName_CrefGenerics()
+        {
+            // Arrange
+            var content = "System.Collections.Generic.List{System.String}";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("List{System.String}", reduced);
+        }
+
+        [Fact]
+        public void ReduceTypeName_NestedGenerics()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType<Foo.Bar<Baz.Phi>>";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("SomeType<Foo.Bar<Baz.Phi>>", reduced);
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar<Baz.Phi>>")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar{Baz.Phi}}")]
+        public void ReduceTypeName_UnbalancedDocs_NotRecoverable_ReturnsOriginalContent(string content)
+        {
+            // Arrange
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal(content, reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_Plain()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType.SomeProperty";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType.SomeProperty", reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_Generics()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType<Foo.Bar>.SomeProperty<Foo.Bar>";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType<Foo.Bar>.SomeProperty<Foo.Bar>", reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_CrefGenerics()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType{Foo.Bar}.SomeProperty{Foo.Bar}";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType{Foo.Bar}.SomeProperty{Foo.Bar}", reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_NestedGenericsMethodsTypes()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType<Foo.Bar<Baz,Fi>>.SomeMethod(Foo.Bar<System.String>,Baz<Something>.Fi)";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType<Foo.Bar<Baz,Fi>>.SomeMethod(Foo.Bar<System.String>,Baz<Something>.Fi)", reduced);
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar<Baz.Phi>>")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar{Baz.Phi}}")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar(Baz.Phi))")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo{.>")]
+        public void ReduceMemberName_UnbalancedDocs_NotRecoverable_ReturnsOriginalContent(string content)
+        {
+            // Arrange
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal(content, reduced);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_InvalidShortValue_ReturnsEmptyString()
+        {
+            // Arrange
+            var content = "T:";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal(string.Empty, value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_InvalidUnknownIdentifierValue_ReturnsEmptyString()
+        {
+            // Arrange
+            var content = "X:";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal(string.Empty, value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_Type()
+        {
+            // Arrange
+            var content = "T:Microsoft.AspNetCore.SometTagHelpers.SomeType";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal("SomeType", value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_Property()
+        {
+            // Arrange
+            var content = "P:Microsoft.AspNetCore.SometTagHelpers.SomeType.SomeProperty";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal("SomeType.SomeProperty", value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_Member()
+        {
+            // Arrange
+            var content = "P:Microsoft.AspNetCore.SometTagHelpers.SomeType.SomeMember";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal("SomeType.SomeMember", value);
+        }
+
+        [Fact]
+        public void TryExtractSummary_ExtractsSummary_ReturnsTrue()
+        {
+            // Arrange
+            var expectedSummary = " Hello World ";
+            var documentation = $@"
+Prefixed invalid content
+
+
+<summary>{expectedSummary}</summary>
+
+Suffixed invalid content";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedSummary, summary);
+        }
+
+        [Fact]
+        public void TryExtractSummary_NoStartSummary_ReturnsFalse()
+        {
+            // Arrange
+            var documentation = @"
+Prefixed invalid content
+
+
+</summary>
+
+Suffixed invalid content";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(summary);
+        }
+
+        [Fact]
+        public void TryExtractSummary_NoEndSummary_ReturnsFalse()
+        {
+            // Arrange
+            var documentation = @"
+Prefixed invalid content
+
+
+<summary>
+
+Suffixed invalid content";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(summary);
+        }
+
+        [Fact]
+        public void CleanSummaryContent_ReplacesSeeCrefs()
+        {
+            // Arrange
+            var summary = "Accepts <see cref=\"T:System.Collections.List{System.String}\" />s";
+
+            // Act
+            var cleanedSummary = DefaultTagHelperDescriptionFactory.CleanSummaryContent(summary);
+
+            // Assert
+            Assert.Equal("Accepts `List<System.String>`s", cleanedSummary);
+        }
+
+        [Fact]
+        public void CleanSummaryContent_ReplacesSeeAlsoCrefs()
+        {
+            // Arrange
+            var summary = "Accepts <seealso cref=\"T:System.Collections.List{System.String}\" />s";
+
+            // Act
+            var cleanedSummary = DefaultTagHelperDescriptionFactory.CleanSummaryContent(summary);
+
+            // Assert
+            Assert.Equal("Accepts `List<System.String>`s", cleanedSummary);
+        }
+
+        [Fact]
+        public void CleanSummaryContent_TrimsSurroundingWhitespace()
+        {
+            // Arrange
+            var summary = @"
+            Hello
+
+    World
+";
+
+            // Act
+            var cleanedSummary = DefaultTagHelperDescriptionFactory.CleanSummaryContent(summary);
+
+            // Assert
+            Assert.Equal(@"
+Hello
+
+World
+", cleanedSummary);
+        }
+
+        [Fact]
+        public void TryCreateDescription_NoAssociatedTagHelperDescriptions_ReturnsFalse()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var elementDescription = ElementDescriptionInfo.Default;
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(elementDescription, out var markdown);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(markdown);
+        }
+
+        [Fact]
+        public void TryCreateDescription_SingleAssociatedTagHelper_ReturnsTrue()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var associatedTagHelperInfos = new[]
+            {
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+            };
+            var elementDescription = new ElementDescriptionInfo(associatedTagHelperInfos);
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(elementDescription, out var markdown);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(@"**SomeTagHelper**
+
+Uses `List<System.String>`s
+", markdown);
+        }
+
+        [Fact]
+        public void TryCreateDescription_MultipleAssociatedTagHelpers_ReturnsTrue()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var associatedTagHelperInfos = new[]
+            {
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.OtherTagHelper", "<summary>Also uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+            };
+            var elementDescription = new ElementDescriptionInfo(associatedTagHelperInfos);
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(elementDescription, out var markdown);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(@"**SomeTagHelper**
+
+Uses `List<System.String>`s
+
+---
+**OtherTagHelper**
+
+Also uses `List<System.String>`s
+", markdown);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private DocumentResolver EmptyDocumentResolver { get; }
 
         [Fact]
-        public async Task Handle_TagHelperCompletion_ReturnsCompletionItemWithDocumentation()
+        public async Task Handle_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
@@ -46,7 +46,26 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Returns(true);
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
             var completionItem = new CompletionItem();
-            completionItem.SetDescriptionData(ElementDescriptionInfo.Default);
+            completionItem.SetDescriptionInfo(ElementDescriptionInfo.Default);
+
+            // Act
+            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_TagHelperAttributeCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
+            var markdown = "Some Markdown";
+            descriptionFactory.Setup(factory => factory.TryCreateDescription(It.IsAny<AttributeDescriptionInfo>(), out markdown))
+                .Returns(true);
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
+            var completionItem = new CompletionItem();
+            completionItem.SetDescriptionInfo(AttributeDescriptionInfo.Default);
 
             // Act
             var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
@@ -79,7 +98,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, TagHelperDescriptionFactory, LoggerFactory);
             var completionItem = new CompletionItem();
-            completionItem.SetDescriptionData(ElementDescriptionInfo.Default);
+            completionItem.SetDescriptionInfo(ElementDescriptionInfo.Default);
+
+            // Act
+            var result = completionEndpoint.CanResolve(completionItem);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CanResolve_TagHelperAttributeCompletion_ReturnsTrue()
+        {
+            // Arrange
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, TagHelperDescriptionFactory, LoggerFactory);
+            var completionItem = new CompletionItem();
+            completionItem.SetDescriptionInfo(AttributeDescriptionInfo.Default);
 
             // Act
             var result = completionEndpoint.CanResolve(completionItem);


### PR DESCRIPTION
- This does not include any description/documentation support (will be in a coming PR).
- Added exhaustive tests to ensure the completion works as expected.
- Integrated TagHelper completion into the language server's completion endpoint so when VSCode prompts for completions we do a fork to see if there are any TagHelper completions available for the location.

![image](https://i.imgur.com/C4FGdK6.gif)

#93