### PR TITLE
Add TagHelper element completion descriptions.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/AttributeDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/AttributeDescriptionInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class AttributeDescriptionInfo
+    {
+        public static readonly AttributeDescriptionInfo Default = new AttributeDescriptionInfo(Array.Empty<TagHelperAttributeDescriptionInfo>());
+
+        public AttributeDescriptionInfo(IReadOnlyList<TagHelperAttributeDescriptionInfo> associatedAttributeDescriptions)
+        {
+            if (associatedAttributeDescriptions == null)
+            {
+                throw new ArgumentNullException(nameof(associatedAttributeDescriptions));
+            }
+
+            AssociatedAttributeDescriptions = associatedAttributeDescriptions;
+        }
+
+        public IReadOnlyList<TagHelperAttributeDescriptionInfo> AssociatedAttributeDescriptions { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class CompletionItemExtensions
+    {
+        private const string TagHelperElementDataKey = "_TagHelperElementData_";
+
+        public static bool IsTagHelperElementCompletion(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperElementDataKey))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static void SetDescriptionData(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
+        {
+            var data = new JObject();
+            data[TagHelperElementDataKey] = JObject.FromObject(elementDescriptionInfo);
+            completion.Data = data;
+        }
+
+        public static ElementDescriptionInfo GetElementDescriptionInfo(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperElementDataKey))
+            {
+                var descriptionInfo = data[TagHelperElementDataKey].ToObject<ElementDescriptionInfo>();
+                return descriptionInfo;
+            }
+
+            return ElementDescriptionInfo.Default;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal static class CompletionItemExtensions
     {
         private const string TagHelperElementDataKey = "_TagHelperElementData_";
+        private const string TagHelperAttributeDataKey = "_TagHelperAttributes_";
 
         public static bool IsTagHelperElementCompletion(this CompletionItem completion)
         {
@@ -20,10 +21,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return false;
         }
 
-        public static void SetDescriptionData(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
+        public static bool IsTagHelperAttributeCompletion(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperAttributeDataKey))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static void SetDescriptionInfo(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
         {
             var data = new JObject();
             data[TagHelperElementDataKey] = JObject.FromObject(elementDescriptionInfo);
+            completion.Data = data;
+        }
+
+        public static void SetDescriptionInfo(this CompletionItem completion, AttributeDescriptionInfo attributeDescriptionInfo)
+        {
+            var data = new JObject();
+            data[TagHelperAttributeDataKey] = JObject.FromObject(attributeDescriptionInfo);
             completion.Data = data;
         }
 
@@ -36,6 +54,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             return ElementDescriptionInfo.Default;
+        }
+
+        public static AttributeDescriptionInfo GetAttributeDescriptionInfo(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperAttributeDataKey))
+            {
+                var descriptionInfo = data[TagHelperAttributeDataKey].ToObject<AttributeDescriptionInfo>();
+                return descriptionInfo;
+            }
+
+            return AttributeDescriptionInfo.Default;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
@@ -261,6 +261,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Kind = CompletionItemKind.TypeParameter,
                     CommitCharacters = AttributeCommitCharacters,
                 };
+                var attributeDescriptions = completion.Value.Select(boundAttribute => new TagHelperAttributeDescriptionInfo(
+                    boundAttribute.DisplayName,
+                    boundAttribute.GetPropertyName(),
+                    indexerCompletion ? boundAttribute.IndexerTypeName : boundAttribute.TypeName,
+                    boundAttribute.Documentation));
+                var attributeDescriptionInfo = new AttributeDescriptionInfo(attributeDescriptions.ToList());
+                razorCompletionItem.SetDescriptionInfo(attributeDescriptionInfo);
 
                 completionItems.Add(razorCompletionItem);
             }
@@ -301,7 +308,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
                 var tagHelperDescriptions = completion.Value.Select(tagHelper => new TagHelperDescriptionInfo(tagHelper.GetTypeName(), tagHelper.Documentation));
                 var elementDescription = new ElementDescriptionInfo(tagHelperDescriptions.ToList());
-                razorCompletionItem.SetDescriptionData(elementDescription);
+                razorCompletionItem.SetDescriptionInfo(elementDescription);
 
                 completionItems.Add(razorCompletionItem);
             }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
@@ -299,6 +299,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Kind = CompletionItemKind.TypeParameter,
                     CommitCharacters = ElementCommitCharacters,
                 };
+                var tagHelperDescriptions = completion.Value.Select(tagHelper => new TagHelperDescriptionInfo(tagHelper.GetTypeName(), tagHelper.Documentation));
+                var elementDescription = new ElementDescriptionInfo(tagHelperDescriptions.ToList());
+                razorCompletionItem.SetDescriptionData(elementDescription);
 
                 completionItems.Add(razorCompletionItem);
             }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperDescriptionFactory.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultTagHelperDescriptionFactory : TagHelperDescriptionFactory
+    {
+        private static readonly Lazy<Regex> ExtractCrefRegex = new Lazy<Regex>(
+            () => new Regex("<(see|seealso)[\\s]+cref=\"([^\">]+)\"[^>]*>", RegexOptions.Compiled, TimeSpan.FromSeconds(1)));
+
+        public override bool TryCreateDescription(ElementDescriptionInfo elementDescriptionInfo, out string markdown)
+        {
+            var associatedTagHelperInfos = elementDescriptionInfo.AssociatedTagHelperDescriptions;
+            if (associatedTagHelperInfos.Count == 0)
+            {
+                markdown = null;
+                return false;
+            }
+
+            // This generates a markdown description that looks like the following:
+            // **SomeTagHelper**
+            //
+            // The Summary documentation text with `CrefTypeValues` in code.
+            //
+            // Additional description infos result in a triple `---` to separate the markdown entries.
+
+            var descriptionBuilder = new StringBuilder();
+            for (var i = 0; i < associatedTagHelperInfos.Count; i++)
+            {
+                var descriptionInfo = associatedTagHelperInfos[i];
+
+                if (descriptionBuilder.Length > 0)
+                {
+                    descriptionBuilder.AppendLine();
+                    descriptionBuilder.AppendLine("---");
+                }
+
+                descriptionBuilder.Append("**");
+                var tagHelperType = descriptionInfo.TagHelperTypeName;
+                var reducedTypeName = ReduceTypeName(tagHelperType);
+                descriptionBuilder.Append(reducedTypeName);
+                descriptionBuilder.AppendLine("**");
+                descriptionBuilder.AppendLine();
+
+                var documentation = descriptionInfo.Documentation;
+                if (!TryExtractSummary(documentation, out var summaryContent))
+                {
+                    continue;
+                }
+
+                var finalSummaryContent = CleanSummaryContent(summaryContent);
+                descriptionBuilder.AppendLine(finalSummaryContent);
+            }
+
+            markdown = descriptionBuilder.ToString();
+            return true;
+        }
+
+        // Internal for testing
+        internal static string CleanSummaryContent(string summaryContent)
+        {
+            // Cleans out all <see cref="..." /> and <seealso cref="..." /> elements. It's possible to
+            // have additional doc comment types in the summary but none that require cleaning. For instance
+            // if there's a <para> in the summary element when it's shown in the completion description window
+            // it'll be serialized as html (wont show).
+
+            var crefMatches = ExtractCrefRegex.Value.Matches(summaryContent).Reverse();
+            var summaryBuilder = new StringBuilder(summaryContent);
+
+            foreach (var cref in crefMatches)
+            {
+                if (cref.Success)
+                {
+                    var value = cref.Groups[2].Value;
+                    var reducedValue = ReduceCrefValue(value);
+                    reducedValue = reducedValue.Replace("{", "<").Replace("}", ">");
+                    summaryBuilder.Remove(cref.Index, cref.Length);
+                    summaryBuilder.Insert(cref.Index, $"`{reducedValue}`");
+                }
+            }
+            var lines = summaryBuilder.ToString().Split(new[] { '\n' }, StringSplitOptions.None).Select(line => line.Trim());
+            var finalSummaryContent = string.Join(Environment.NewLine, lines);
+            return finalSummaryContent;
+        }
+
+        // Internal for testing
+        internal static bool TryExtractSummary(string documentation, out string summary)
+        {
+            const string summaryStartTag = "<summary>";
+            const string summaryEndTag = "</summary>";
+
+            if (string.IsNullOrEmpty(documentation))
+            {
+                summary = null;
+                return false;
+            }
+
+            var summaryTagStart = documentation.IndexOf(summaryStartTag, StringComparison.OrdinalIgnoreCase);
+            if (summaryTagStart == -1)
+            {
+                summary = null;
+                return false;
+            }
+
+            var summaryTagEndStart = documentation.IndexOf(summaryEndTag, StringComparison.OrdinalIgnoreCase);
+            if (summaryTagEndStart == -1)
+            {
+                summary = null;
+                return false;
+            }
+
+            var summaryContentStart = summaryTagStart + summaryStartTag.Length;
+            var summaryContentLength = summaryTagEndStart - summaryContentStart;
+
+            summary = documentation.Substring(summaryContentStart, summaryContentLength);
+            return true;
+        }
+
+        // Internal for testing
+        internal static string ReduceCrefValue(string value)
+        {
+            // cref values come in the following formats:
+            // Type = "T:Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName"
+            // Property = "P:T:Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.AspAction"
+            // Member = "M:T:Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeMethod(System.Collections.Generic.List{System.String})"
+
+            if (value.Length < 2)
+            {
+                return string.Empty;
+            }
+
+            var type = value[0];
+            value = value.Substring(2);
+
+            switch (type)
+            {
+                case 'T':
+                    var reducedCrefType = ReduceTypeName(value);
+                    return reducedCrefType;
+                case 'P':
+                case 'M':
+                    // TypeName.MemberName
+                    var reducedCrefProperty = ReduceMemberName(value);
+                    return reducedCrefProperty;
+            }
+
+            return value;
+        }
+
+
+        // Internal for testing
+        internal static string ReduceTypeName(string content) => ReduceFullName(content, reduceWhenDotCount: 1);
+
+        // Internal for testing
+        internal static string ReduceMemberName(string content) => ReduceFullName(content, reduceWhenDotCount: 2);
+
+        private static string ReduceFullName(string content, int reduceWhenDotCount)
+        {
+            // Starts searching backwards and then substrings everything when it finds enough dots. i.e. 
+            // ReduceFullName("Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName", 1) == "SomeTypeName"
+            //
+            // ReduceFullName("Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.AspAction", 2) == "SomeTypeName.AspAction"
+            //
+            // This is also smart enough to ignore nested dots in type generics[<>], methods[()], cref generics[{}].
+
+            if (reduceWhenDotCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(reduceWhenDotCount));
+            }
+
+            var dotsSeen = 0;
+            var scope = 0;
+            for (var i = content.Length - 1; i >= 0; i--)
+            {
+                do
+                {
+                    if (content[i] == '}')
+                    {
+                        scope++;
+                    }
+                    else if (content[i] == '{')
+                    {
+                        scope--;
+                    }
+
+                    if (scope > 0)
+                    {
+                        i--;
+                    }
+                } while (scope != 0 && i >= 0);
+
+                if (i < 0)
+                {
+                    // Could not balance scope
+                    return content;
+                }
+
+                do
+                {
+                    if (content[i] == ')')
+                    {
+                        scope++;
+                    }
+                    else if (content[i] == '(')
+                    {
+                        scope--;
+                    }
+
+                    if (scope > 0)
+                    {
+                        i--;
+                    }
+                } while (scope != 0 && i >= 0);
+
+                if (i < 0)
+                {
+                    // Could not balance scope
+                    return content;
+                }
+
+                do
+                {
+                    if (content[i] == '>')
+                    {
+                        scope++;
+                    }
+                    else if (content[i] == '<')
+                    {
+                        scope--;
+                    }
+
+                    if (scope > 0)
+                    {
+                        i--;
+                    }
+                } while (scope != 0 && i >= 0);
+
+                if (i < 0)
+                {
+                    // Could not balance scope
+                    return content;
+                }
+
+                if (content[i] == '.')
+                {
+                    dotsSeen++;
+                }
+
+                if (dotsSeen == reduceWhenDotCount)
+                {
+                    var piece = content.Substring(i + 1);
+                    return piece;
+                }
+            }
+
+            // Could not reduce name
+            return content;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ElementDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ElementDescriptionInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class ElementDescriptionInfo
+    {
+        public static readonly ElementDescriptionInfo Default = new ElementDescriptionInfo(Array.Empty<TagHelperDescriptionInfo>());
+
+        public ElementDescriptionInfo(IReadOnlyList<TagHelperDescriptionInfo> associatedTagHelperDescriptions)
+        {
+            if (associatedTagHelperDescriptions == null)
+            {
+                throw new ArgumentNullException(nameof(associatedTagHelperDescriptions));
+            }
+
+            AssociatedTagHelperDescriptions = associatedTagHelperDescriptions;
+        }
+
+        public IReadOnlyList<TagHelperDescriptionInfo> AssociatedTagHelperDescriptions { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<TagHelperFactsService, DefaultTagHelperFactsService>();
                         services.AddSingleton<VisualStudio.Editor.Razor.TagHelperCompletionService, VisualStudio.Editor.Razor.DefaultTagHelperCompletionService>();
                         services.AddSingleton<TagHelperCompletionService, DefaultTagHelperCompletionService>();
+                        services.AddSingleton<TagHelperDescriptionFactory, DefaultTagHelperDescriptionFactory>();
 
                         var foregroundDispatcher = new VSCodeForegroundDispatcher();
                         services.AddSingleton<ForegroundDispatcher>(foregroundDispatcher);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperAttributeDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperAttributeDescriptionInfo.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class TagHelperAttributeDescriptionInfo
+    {
+        public TagHelperAttributeDescriptionInfo(
+            string displayName,
+            string propertyName,
+            string returnTypeName,
+            string documentation)
+        {
+            if (displayName == null)
+            {
+                throw new ArgumentNullException(nameof(displayName));
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (returnTypeName == null)
+            {
+                throw new ArgumentNullException(nameof(returnTypeName));
+            }
+
+            DisplayName = displayName;
+            PropertyName = propertyName;
+            ReturnTypeName = returnTypeName;
+            Documentation = documentation;
+        }
+
+        public string DisplayName { get; }
+
+        public string PropertyName { get; }
+
+        public string ReturnTypeName { get; }
+
+        public string Documentation { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class TagHelperDescriptionFactory
+    {
+        public abstract bool TryCreateDescription(ElementDescriptionInfo descriptionInfos, out string markdown);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
@@ -6,5 +6,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal abstract class TagHelperDescriptionFactory
     {
         public abstract bool TryCreateDescription(ElementDescriptionInfo descriptionInfos, out string markdown);
+
+        public abstract bool TryCreateDescription(AttributeDescriptionInfo descriptionInfos, out string markdown);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class TagHelperDescriptionInfo
+    {
+        public TagHelperDescriptionInfo(string tagHelperTypeName, string documentation)
+        {
+            if (tagHelperTypeName == null)
+            {
+                throw new ArgumentNullException(nameof(tagHelperTypeName));
+            }
+
+            TagHelperTypeName = tagHelperTypeName;
+            Documentation = documentation;
+        }
+
+        public string TagHelperTypeName { get; }
+
+        public string Documentation { get; }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperDescriptionFactoryTest.cs
@@ -1,0 +1,382 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class DefaultTagHelperDescriptionFactoryTest
+    {
+        [Fact]
+        public void ReduceTypeName_Plain()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("SomeTypeName", reduced);
+        }
+
+        [Fact]
+        public void ReduceTypeName_Generics()
+        {
+            // Arrange
+            var content = "System.Collections.Generic.List<System.String>";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("List<System.String>", reduced);
+        }
+
+        [Fact]
+        public void ReduceTypeName_CrefGenerics()
+        {
+            // Arrange
+            var content = "System.Collections.Generic.List{System.String}";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("List{System.String}", reduced);
+        }
+
+        [Fact]
+        public void ReduceTypeName_NestedGenerics()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType<Foo.Bar<Baz.Phi>>";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal("SomeType<Foo.Bar<Baz.Phi>>", reduced);
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar<Baz.Phi>>")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar{Baz.Phi}}")]
+        public void ReduceTypeName_UnbalancedDocs_NotRecoverable_ReturnsOriginalContent(string content)
+        {
+            // Arrange
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceTypeName(content);
+
+            // Assert
+            Assert.Equal(content, reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_Plain()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType.SomeProperty";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType.SomeProperty", reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_Generics()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType<Foo.Bar>.SomeProperty<Foo.Bar>";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType<Foo.Bar>.SomeProperty<Foo.Bar>", reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_CrefGenerics()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType{Foo.Bar}.SomeProperty{Foo.Bar}";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType{Foo.Bar}.SomeProperty{Foo.Bar}", reduced);
+        }
+
+        [Fact]
+        public void ReduceMemberName_NestedGenericsMethodsTypes()
+        {
+            // Arrange
+            var content = "Microsoft.AspNetCore.SometTagHelpers.SomeType<Foo.Bar<Baz,Fi>>.SomeMethod(Foo.Bar<System.String>,Baz<Something>.Fi)";
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal("SomeType<Foo.Bar<Baz,Fi>>.SomeMethod(Foo.Bar<System.String>,Baz<Something>.Fi)", reduced);
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar<Baz.Phi>>")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar{Baz.Phi}}")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo.Bar(Baz.Phi))")]
+        [InlineData("Microsoft.AspNetCore.SometTagHelpers.SomeType.Foo{.>")]
+        public void ReduceMemberName_UnbalancedDocs_NotRecoverable_ReturnsOriginalContent(string content)
+        {
+            // Arrange
+
+            // Act
+            var reduced = DefaultTagHelperDescriptionFactory.ReduceMemberName(content);
+
+            // Assert
+            Assert.Equal(content, reduced);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_InvalidShortValue_ReturnsEmptyString()
+        {
+            // Arrange
+            var content = "T:";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal(string.Empty, value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_InvalidUnknownIdentifierValue_ReturnsEmptyString()
+        {
+            // Arrange
+            var content = "X:";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal(string.Empty, value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_Type()
+        {
+            // Arrange
+            var content = "T:Microsoft.AspNetCore.SometTagHelpers.SomeType";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal("SomeType", value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_Property()
+        {
+            // Arrange
+            var content = "P:Microsoft.AspNetCore.SometTagHelpers.SomeType.SomeProperty";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal("SomeType.SomeProperty", value);
+        }
+
+        [Fact]
+        public void ReduceCrefValue_Member()
+        {
+            // Arrange
+            var content = "P:Microsoft.AspNetCore.SometTagHelpers.SomeType.SomeMember";
+
+            // Act
+            var value = DefaultTagHelperDescriptionFactory.ReduceCrefValue(content);
+
+            // Assert
+            Assert.Equal("SomeType.SomeMember", value);
+        }
+
+        [Fact]
+        public void TryExtractSummary_ExtractsSummary_ReturnsTrue()
+        {
+            // Arrange
+            var expectedSummary = " Hello World ";
+            var documentation = $@"
+Prefixed invalid content
+
+
+<summary>{expectedSummary}</summary>
+
+Suffixed invalid content";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedSummary, summary);
+        }
+
+        [Fact]
+        public void TryExtractSummary_NoStartSummary_ReturnsFalse()
+        {
+            // Arrange
+            var documentation = @"
+Prefixed invalid content
+
+
+</summary>
+
+Suffixed invalid content";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(summary);
+        }
+
+        [Fact]
+        public void TryExtractSummary_NoEndSummary_ReturnsFalse()
+        {
+            // Arrange
+            var documentation = @"
+Prefixed invalid content
+
+
+<summary>
+
+Suffixed invalid content";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(summary);
+        }
+
+        [Fact]
+        public void CleanSummaryContent_ReplacesSeeCrefs()
+        {
+            // Arrange
+            var summary = "Accepts <see cref=\"T:System.Collections.List{System.String}\" />s";
+
+            // Act
+            var cleanedSummary = DefaultTagHelperDescriptionFactory.CleanSummaryContent(summary);
+
+            // Assert
+            Assert.Equal("Accepts `List<System.String>`s", cleanedSummary);
+        }
+
+        [Fact]
+        public void CleanSummaryContent_ReplacesSeeAlsoCrefs()
+        {
+            // Arrange
+            var summary = "Accepts <seealso cref=\"T:System.Collections.List{System.String}\" />s";
+
+            // Act
+            var cleanedSummary = DefaultTagHelperDescriptionFactory.CleanSummaryContent(summary);
+
+            // Assert
+            Assert.Equal("Accepts `List<System.String>`s", cleanedSummary);
+        }
+
+        [Fact]
+        public void CleanSummaryContent_TrimsSurroundingWhitespace()
+        {
+            // Arrange
+            var summary = @"
+            Hello
+
+    World
+";
+
+            // Act
+            var cleanedSummary = DefaultTagHelperDescriptionFactory.CleanSummaryContent(summary);
+
+            // Assert
+            Assert.Equal(@"
+Hello
+
+World
+", cleanedSummary);
+        }
+
+        [Fact]
+        public void TryCreateDescription_NoAssociatedTagHelperDescriptions_ReturnsFalse()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var elementDescription = ElementDescriptionInfo.Default;
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(elementDescription, out var markdown);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(markdown);
+        }
+
+        [Fact]
+        public void TryCreateDescription_SingleAssociatedTagHelper_ReturnsTrue()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var associatedTagHelperInfos = new[]
+            {
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+            };
+            var elementDescription = new ElementDescriptionInfo(associatedTagHelperInfos);
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(elementDescription, out var markdown);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(@"**SomeTagHelper**
+
+Uses `List<System.String>`s
+", markdown);
+        }
+
+        [Fact]
+        public void TryCreateDescription_MultipleAssociatedTagHelpers_ReturnsTrue()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var associatedTagHelperInfos = new[]
+            {
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.OtherTagHelper", "<summary>Also uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+            };
+            var elementDescription = new ElementDescriptionInfo(associatedTagHelperInfos);
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(elementDescription, out var markdown);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(@"**SomeTagHelper**
+
+Uses `List<System.String>`s
+
+---
+**OtherTagHelper**
+
+Also uses `List<System.String>`s
+", markdown);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private DocumentResolver EmptyDocumentResolver { get; }
 
         [Fact]
-        public async Task Handle_TagHelperCompletion_ReturnsCompletionItemWithDocumentation()
+        public async Task Handle_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
@@ -46,7 +46,26 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Returns(true);
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
             var completionItem = new CompletionItem();
-            completionItem.SetDescriptionData(ElementDescriptionInfo.Default);
+            completionItem.SetDescriptionInfo(ElementDescriptionInfo.Default);
+
+            // Act
+            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_TagHelperAttributeCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
+            var markdown = "Some Markdown";
+            descriptionFactory.Setup(factory => factory.TryCreateDescription(It.IsAny<AttributeDescriptionInfo>(), out markdown))
+                .Returns(true);
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
+            var completionItem = new CompletionItem();
+            completionItem.SetDescriptionInfo(AttributeDescriptionInfo.Default);
 
             // Act
             var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
@@ -79,7 +98,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, TagHelperDescriptionFactory, LoggerFactory);
             var completionItem = new CompletionItem();
-            completionItem.SetDescriptionData(ElementDescriptionInfo.Default);
+            completionItem.SetDescriptionInfo(ElementDescriptionInfo.Default);
+
+            // Act
+            var result = completionEndpoint.CanResolve(completionItem);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CanResolve_TagHelperAttributeCompletion_ReturnsTrue()
+        {
+            // Arrange
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, TagHelperDescriptionFactory, LoggerFactory);
+            var completionItem = new CompletionItem();
+            completionItem.SetDescriptionInfo(AttributeDescriptionInfo.Default);
 
             // Act
             var result = completionEndpoint.CanResolve(completionItem);


### PR DESCRIPTION
- Completion documentation is expected to be fully populated once a user selects a completion item in the drop down list. At this point VSCode performs a completion item resolve request to the language server in order to populate any documentation. This is essential because populating the documentation usually requires a significant amount of work and is not something we want users waiting for. Therefore, in these changes we store just enough information on the completion item to re-hydrate a markdown based documentation for when one of our TagHelper completions is resolved.
- Given VSCodes limited viewport bandwidth our description factory has to do a lot of work to slim down type names in crefs and TagHelper typenames. Otherwise you end up with a description that never fits the box.
- Added exhaustive tests to ensure the completion descriptions populate correctly. Did only a few integration level tests for the completion description to make things easier to maintain. Didn't want to add a ton of work every time we decided to change what the completion descriptions looked like.
- Updated the completion endpoint to also be a resolve handler. Resolve handlers are responsible for populating documentation when a user selects a completion item.
- Added completion item extensions. We need to interact with completion items in two different services in order to store/retrieve description data, wanted to unify the way that was done with the extensions.

![image](https://i.imgur.com/sEtQ3HL.gif)

#18