### PR TITLE
Add TagHelper attribute completion descriptions.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/AttributeDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/AttributeDescriptionInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class AttributeDescriptionInfo
+    {
+        public static readonly AttributeDescriptionInfo Default = new AttributeDescriptionInfo(Array.Empty<TagHelperAttributeDescriptionInfo>());
+
+        public AttributeDescriptionInfo(IReadOnlyList<TagHelperAttributeDescriptionInfo> associatedAttributeDescriptions)
+        {
+            if (associatedAttributeDescriptions == null)
+            {
+                throw new ArgumentNullException(nameof(associatedAttributeDescriptions));
+            }
+
+            AssociatedAttributeDescriptions = associatedAttributeDescriptions;
+        }
+
+        public IReadOnlyList<TagHelperAttributeDescriptionInfo> AssociatedAttributeDescriptions { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/CompletionItemExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal static class CompletionItemExtensions
     {
         private const string TagHelperElementDataKey = "_TagHelperElementData_";
+        private const string TagHelperAttributeDataKey = "_TagHelperAttributes_";
 
         public static bool IsTagHelperElementCompletion(this CompletionItem completion)
         {
@@ -20,10 +21,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return false;
         }
 
-        public static void SetDescriptionData(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
+        public static bool IsTagHelperAttributeCompletion(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperAttributeDataKey))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static void SetDescriptionInfo(this CompletionItem completion, ElementDescriptionInfo elementDescriptionInfo)
         {
             var data = new JObject();
             data[TagHelperElementDataKey] = JObject.FromObject(elementDescriptionInfo);
+            completion.Data = data;
+        }
+
+        public static void SetDescriptionInfo(this CompletionItem completion, AttributeDescriptionInfo attributeDescriptionInfo)
+        {
+            var data = new JObject();
+            data[TagHelperAttributeDataKey] = JObject.FromObject(attributeDescriptionInfo);
             completion.Data = data;
         }
 
@@ -36,6 +54,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             return ElementDescriptionInfo.Default;
+        }
+
+        public static AttributeDescriptionInfo GetAttributeDescriptionInfo(this CompletionItem completion)
+        {
+            if (completion.Data is JObject data && data.ContainsKey(TagHelperAttributeDataKey))
+            {
+                var descriptionInfo = data[TagHelperAttributeDataKey].ToObject<AttributeDescriptionInfo>();
+                return descriptionInfo;
+            }
+
+            return AttributeDescriptionInfo.Default;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperCompletionService.cs
@@ -261,6 +261,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Kind = CompletionItemKind.TypeParameter,
                     CommitCharacters = AttributeCommitCharacters,
                 };
+                var attributeDescriptions = completion.Value.Select(boundAttribute => new TagHelperAttributeDescriptionInfo(
+                    boundAttribute.DisplayName,
+                    boundAttribute.GetPropertyName(),
+                    indexerCompletion ? boundAttribute.IndexerTypeName : boundAttribute.TypeName,
+                    boundAttribute.Documentation));
+                var attributeDescriptionInfo = new AttributeDescriptionInfo(attributeDescriptions.ToList());
+                razorCompletionItem.SetDescriptionInfo(attributeDescriptionInfo);
 
                 completionItems.Add(razorCompletionItem);
             }
@@ -301,7 +308,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
                 var tagHelperDescriptions = completion.Value.Select(tagHelper => new TagHelperDescriptionInfo(tagHelper.GetTypeName(), tagHelper.Documentation));
                 var elementDescription = new ElementDescriptionInfo(tagHelperDescriptions.ToList());
-                razorCompletionItem.SetDescriptionData(elementDescription);
+                razorCompletionItem.SetDescriptionInfo(elementDescription);
 
                 completionItems.Add(razorCompletionItem);
             }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultTagHelperDescriptionFactory.cs
@@ -13,6 +13,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         private static readonly Lazy<Regex> ExtractCrefRegex = new Lazy<Regex>(
             () => new Regex("<(see|seealso)[\\s]+cref=\"([^\">]+)\"[^>]*>", RegexOptions.Compiled, TimeSpan.FromSeconds(1)));
+        private static readonly IReadOnlyDictionary<string, string> PrimitiveDisplayTypeNameLookups = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [typeof(byte).FullName] = "byte",
+            [typeof(sbyte).FullName] = "sbyte",
+            [typeof(int).FullName] = "int",
+            [typeof(uint).FullName] = "uint",
+            [typeof(short).FullName] = "short",
+            [typeof(ushort).FullName] = "ushort",
+            [typeof(long).FullName] = "long",
+            [typeof(ulong).FullName] = "ulong",
+            [typeof(float).FullName] = "float",
+            [typeof(double).FullName] = "double",
+            [typeof(char).FullName] = "char",
+            [typeof(bool).FullName] = "bool",
+            [typeof(object).FullName] = "object",
+            [typeof(string).FullName] = "string",
+            [typeof(decimal).FullName] = "decimal",
+        };
 
         public override bool TryCreateDescription(ElementDescriptionInfo elementDescriptionInfo, out string markdown)
         {
@@ -38,6 +56,61 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 var tagHelperType = descriptionInfo.TagHelperTypeName;
                 var reducedTypeName = ReduceTypeName(tagHelperType);
                 descriptionBuilder.Append(reducedTypeName);
+                descriptionBuilder.AppendLine("**");
+                descriptionBuilder.AppendLine();
+
+                var documentation = descriptionInfo.Documentation;
+                if (!TryExtractSummary(documentation, out var summaryContent))
+                {
+                    continue;
+                }
+
+                var finalSummaryContent = CleanSummaryContent(summaryContent);
+                descriptionBuilder.AppendLine(finalSummaryContent);
+            }
+
+            markdown = descriptionBuilder.ToString();
+            return true;
+        }
+
+        public override bool TryCreateDescription(AttributeDescriptionInfo attributeDescriptionInfo, out string markdown)
+        {
+            var associatedAttributeInfos = attributeDescriptionInfo.AssociatedAttributeDescriptions;
+            if (associatedAttributeInfos.Count == 0)
+            {
+                markdown = null;
+                return false;
+            }
+
+            // This generates a markdown description that looks like the following:
+            // **ReturnTypeName** SomeTypeName.**SomeProperty**
+            //
+            // The Summary documentation text with `CrefTypeValues` in code.
+            //
+            // Additional description infos result in a triple `---` to separate the markdown entries.
+
+
+                              var descriptionBuilder = new StringBuilder();
+            for (var i = 0; i < associatedAttributeInfos.Count; i++)
+            {
+                var descriptionInfo = associatedAttributeInfos[i];
+
+                if (descriptionBuilder.Length > 0)
+                {
+                    descriptionBuilder.AppendLine();
+                    descriptionBuilder.AppendLine("---");
+                }
+
+                descriptionBuilder.Append("**");
+                var returnTypeName = GetSimpleName(descriptionInfo.ReturnTypeName);
+                var reducedReturnTypeName = ReduceTypeName(returnTypeName);
+                descriptionBuilder.Append(reducedReturnTypeName);
+                descriptionBuilder.Append("** ");
+                var tagHelperTypeName = ResolveTagHelperTypeName(descriptionInfo);
+                var reducedTagHelperTypeName = ReduceTypeName(tagHelperTypeName);
+                descriptionBuilder.Append(reducedTagHelperTypeName);
+                descriptionBuilder.Append(".**");
+                descriptionBuilder.Append(descriptionInfo.PropertyName);
                 descriptionBuilder.AppendLine("**");
                 descriptionBuilder.AppendLine();
 
@@ -146,6 +219,43 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return value;
         }
 
+        // Internal for testing
+        internal static string GetSimpleName(string typeName)
+        {
+            if (PrimitiveDisplayTypeNameLookups.TryGetValue(typeName, out var simpleName))
+            {
+                return simpleName;
+            }
+
+            return typeName;
+        }
+
+        // Internal for testing
+        internal static string ResolveTagHelperTypeName(TagHelperAttributeDescriptionInfo info)
+        {
+            // A BoundAttributeDescriptor does not have a direct reference to its parent TagHelper.
+            // However, when it was constructed the parent TagHelper's type name was embedded into
+            // its DisplayName. In VSCode we can't use the DisplayName verbatim for descriptions
+            // because the DisplayName is typically too long to display properly. Therefore we need
+            // to break it apart and then reconstruct it in a reduced format.
+            // i.e. this is the format the display name comes in:
+            // ReturnTypeName SomeTypeName.SomePropertyName
+
+            // We must simplify the return type name before using it to determine the type name prefix
+            // because that is how the display name was originally built (a little hacky).
+            var simpleReturnType = GetSimpleName(info.ReturnTypeName);
+
+            // "ReturnTypeName "
+            var typeNamePrefixLength = simpleReturnType.Length + 1 /* space */;
+
+            // ".SomePropertyName"
+            var typeNameSuffixLength = /* . */ 1 + info.PropertyName.Length;
+
+            // "SomeTypeName"
+            var typeNameLength = info.DisplayName.Length - typeNamePrefixLength - typeNameSuffixLength;
+            var tagHelperTypeName = info.DisplayName.Substring(typeNamePrefixLength, typeNameLength);
+            return tagHelperTypeName;
+        }
 
         // Internal for testing
         internal static string ReduceTypeName(string content) => ReduceFullName(content, reduceWhenDotCount: 1);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperAttributeDescriptionInfo.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperAttributeDescriptionInfo.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class TagHelperAttributeDescriptionInfo
+    {
+        public TagHelperAttributeDescriptionInfo(
+            string displayName,
+            string propertyName,
+            string returnTypeName,
+            string documentation)
+        {
+            if (displayName == null)
+            {
+                throw new ArgumentNullException(nameof(displayName));
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (returnTypeName == null)
+            {
+                throw new ArgumentNullException(nameof(returnTypeName));
+            }
+
+            DisplayName = displayName;
+            PropertyName = propertyName;
+            ReturnTypeName = returnTypeName;
+            Documentation = documentation;
+        }
+
+        public string DisplayName { get; }
+
+        public string PropertyName { get; }
+
+        public string ReturnTypeName { get; }
+
+        public string Documentation { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptionFactory.cs
@@ -6,5 +6,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal abstract class TagHelperDescriptionFactory
     {
         public abstract bool TryCreateDescription(ElementDescriptionInfo descriptionInfos, out string markdown);
+
+        public abstract bool TryCreateDescription(AttributeDescriptionInfo descriptionInfos, out string markdown);
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultTagHelperDescriptionFactoryTest.cs
@@ -8,6 +8,68 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     public class DefaultTagHelperDescriptionFactoryTest
     {
         [Fact]
+        public void ResolveTagHelperTypeName_ExtractsTypeName_SimpleReturnType()
+        {
+            // Arrange
+            var info = new TagHelperAttributeDescriptionInfo(
+                displayName: "string SomeTypeName.SomePropertyName",
+                propertyName: "SomePropertyName",
+                returnTypeName: "System.String",
+                documentation: string.Empty);
+
+            // Act
+            var typeName = DefaultTagHelperDescriptionFactory.ResolveTagHelperTypeName(info);
+
+            // Assert
+            Assert.Equal("SomeTypeName", typeName);
+        }
+
+        [Fact]
+        public void ResolveTagHelperTypeName_ExtractsTypeName_ComplexReturnType()
+        {
+            // Arrange
+            var info = new TagHelperAttributeDescriptionInfo(
+                displayName: "SomeReturnTypeName SomeTypeName.SomePropertyName",
+                propertyName: "SomePropertyName",
+                returnTypeName: "SomeReturnTypeName",
+                documentation: string.Empty);
+
+            // Act
+            var typeName = DefaultTagHelperDescriptionFactory.ResolveTagHelperTypeName(info);
+
+            // Assert
+            Assert.Equal("SomeTypeName", typeName);
+        }
+
+        [Fact]
+        public void GetSimpleName_NoopsForNonPrimitiveType()
+        {
+            // Arrange
+            var typeName = "Microsoft.AspNetCore.SomeType";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.GetSimpleName(typeName);
+
+            // Assert
+            Assert.Equal(typeName, result);
+        }
+
+        [Theory]
+        [InlineData("System.Int32", "int")]
+        [InlineData("System.Boolean", "bool")]
+        [InlineData("System.String", "string")]
+        public void GetSimpleName_SimplifiesPrimitiveTypes(string typeName, string expectedTypeName)
+        {
+            // Arrange
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.GetSimpleName(typeName);
+
+            // Assert
+            Assert.Equal(expectedTypeName, result);
+        }
+
+        [Fact]
         public void ReduceTypeName_Plain()
         {
             // Arrange
@@ -329,7 +391,7 @@ World
         }
 
         [Fact]
-        public void TryCreateDescription_SingleAssociatedTagHelper_ReturnsTrue()
+        public void TryCreateDescription_Element_SingleAssociatedTagHelper_ReturnsTrue()
         {
             // Arrange
             var descriptionFactory = new DefaultTagHelperDescriptionFactory();
@@ -351,7 +413,7 @@ Uses `List<System.String>`s
         }
 
         [Fact]
-        public void TryCreateDescription_MultipleAssociatedTagHelpers_ReturnsTrue()
+        public void TryCreateDescription_Element_MultipleAssociatedTagHelpers_ReturnsTrue()
         {
             // Arrange
             var descriptionFactory = new DefaultTagHelperDescriptionFactory();
@@ -375,6 +437,68 @@ Uses `List<System.String>`s
 **OtherTagHelper**
 
 Also uses `List<System.String>`s
+", markdown);
+        }
+
+        [Fact]
+        public void TryCreateDescription_Attribute_SingleAssociatedAttribute_ReturnsTrue()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var associatedAttributeDescriptions = new[]
+            {
+                new TagHelperAttributeDescriptionInfo(
+                    displayName: "string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty",
+                    propertyName: "SomeProperty",
+                    returnTypeName: "System.String",
+                    documentation: "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>")
+            };
+            var attributeDescription = new AttributeDescriptionInfo(associatedAttributeDescriptions);
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(attributeDescription, out var markdown);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(@"**string** SomeTypeName.**SomeProperty**
+
+Uses `List<System.String>`s
+", markdown);
+        }
+
+        [Fact]
+        public void TryCreateDescription_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
+        {
+            // Arrange
+            var descriptionFactory = new DefaultTagHelperDescriptionFactory();
+            var associatedAttributeDescriptions = new[]
+            {
+                new TagHelperAttributeDescriptionInfo(
+                    displayName: "string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty",
+                    propertyName: "SomeProperty",
+                    returnTypeName: "System.String",
+                    documentation: "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+                new TagHelperAttributeDescriptionInfo(
+                    displayName: "System.Boolean? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty",
+                    propertyName: "AnotherProperty",
+                    returnTypeName: "System.Boolean?",
+                    documentation: "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+            };
+            var attributeDescription = new AttributeDescriptionInfo(associatedAttributeDescriptions);
+
+            // Act
+            var result = descriptionFactory.TryCreateDescription(attributeDescription, out var markdown);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(@"**string** SomeTypeName.**SomeProperty**
+
+Uses `List<System.String>`s
+
+---
+**Boolean?** AnotherTypeName.**AnotherProperty**
+
+Uses `List<System.String>`s
 ", markdown);
         }
     }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorCompletionEndpointTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private DocumentResolver EmptyDocumentResolver { get; }
 
         [Fact]
-        public async Task Handle_TagHelperCompletion_ReturnsCompletionItemWithDocumentation()
+        public async Task Handle_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
@@ -46,7 +46,26 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Returns(true);
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
             var completionItem = new CompletionItem();
-            completionItem.SetDescriptionData(ElementDescriptionInfo.Default);
+            completionItem.SetDescriptionInfo(ElementDescriptionInfo.Default);
+
+            // Act
+            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_TagHelperAttributeCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
+            var markdown = "Some Markdown";
+            descriptionFactory.Setup(factory => factory.TryCreateDescription(It.IsAny<AttributeDescriptionInfo>(), out markdown))
+                .Returns(true);
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
+            var completionItem = new CompletionItem();
+            completionItem.SetDescriptionInfo(AttributeDescriptionInfo.Default);
 
             // Act
             var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
@@ -79,7 +98,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, TagHelperDescriptionFactory, LoggerFactory);
             var completionItem = new CompletionItem();
-            completionItem.SetDescriptionData(ElementDescriptionInfo.Default);
+            completionItem.SetDescriptionInfo(ElementDescriptionInfo.Default);
+
+            // Act
+            var result = completionEndpoint.CanResolve(completionItem);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CanResolve_TagHelperAttributeCompletion_ReturnsTrue()
+        {
+            // Arrange
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, TagHelperDescriptionFactory, LoggerFactory);
+            var completionItem = new CompletionItem();
+            completionItem.SetDescriptionInfo(AttributeDescriptionInfo.Default);
 
             // Act
             var result = completionEndpoint.CanResolve(completionItem);


### PR DESCRIPTION
- Added tests to ensure the completion descriptions populate correctly. Did only a few integration level tests for the completion description to make things easier to maintain. Didn't want to add a ton of work every time we decided to change what the completion descriptions looked like.
- Expanded the completion item extensions to allow setting/retrieving of attribute descriptions
- Had to add a little hack to extract an attributes parent TagHelper type name by looking at its display name. There isn't another way around this given the current set of APIs exposed by core Razor.

![image](https://i.imgur.com/XbvhrZn.gif)

#18