### PR TITLE
Allow errors at end of document.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
@@ -53,13 +53,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return null;
             }
 
-            var startPosition = sourceText.Lines.GetLinePosition(sourceSpan.AbsoluteIndex);
+            var spanStartIndex = NormalizeIndex(sourceSpan.AbsoluteIndex);
+            var startPosition = sourceText.Lines.GetLinePosition(spanStartIndex);
             var start = new Position()
             {
                 Line = startPosition.Line,
                 Character = startPosition.Character,
             };
-            var endPosition = sourceText.Lines.GetLinePosition(sourceSpan.AbsoluteIndex + sourceSpan.Length);
+
+            var spanEndIndex = NormalizeIndex(sourceSpan.AbsoluteIndex + sourceSpan.Length);
+            var endPosition = sourceText.Lines.GetLinePosition(spanEndIndex);
             var end = new Position()
             {
                 Line = endPosition.Line,
@@ -72,6 +75,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             };
 
             return range;
+
+            int NormalizeIndex(int index)
+            {
+                if (index >= sourceText.Length)
+                {
+                    // Span start index is past the end of the document. Roslyn and VSCode don't support 
+                    // virtual positions that don't exist on the document; normalize to the last character.
+                    index = sourceText.Length - 1;
+                }
+
+                return index;
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticConverterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticConverterTest.cs
@@ -58,6 +58,40 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
+        public void ConvertSpanToRange_StartsOutsideOfDocument_NormalizesToEnd()
+        {
+            // Arrange
+            var sourceText = SourceText.From("Hello World");
+            var sourceSpan = new SourceSpan(sourceText.Length + 5, 0, sourceText.Length + 5, 4);
+            var expectedRange = new Range(
+                new Position(0, 10),
+                new Position(0, 10));
+
+            // Act
+            var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
+
+            // Assert
+            Assert.Equal(expectedRange, range);
+        }
+
+        [Fact]
+        public void ConvertSpanToRange_EndsOutsideOfDocument_NormalizesToEnd()
+        {
+            // Arrange
+            var sourceText = SourceText.From("Hello World");
+            var sourceSpan = new SourceSpan(6, 0, 6, 15);
+            var expectedRange = new Range(
+                new Position(0, 6),
+                new Position(0, 10));
+
+            // Act
+            var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
+
+            // Assert
+            Assert.Equal(expectedRange, range);
+        }
+
+        [Fact]
         public void ConvertSpanToRange_ReturnsNullIfSpanIsUndefined()
         {
             // Arrange


### PR DESCRIPTION
- Prior to this doing `@{` at the end of the document would generate a 1 character length long error after the `{` (past the end of the document). This would cause Roslyn to explode on diagnostics publishing. Now we normalize starts and ends of errors to at the very most be the last character of the document.
- Added tests to verify errors that start and end outside of the document bounds get properly normalized.

#287