### PR TITLE
Update ComponentRefreshTrigger to not force update OmniSharp with non-compile items.

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ComponentRefreshTriggerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ComponentRefreshTriggerTest.cs
@@ -17,6 +17,37 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public ProjectInstance ProjectInstance { get; } = new ProjectInstance(ProjectRootElement.Create());
 
         [Fact]
+        public void IsCompileItem_CompileItem_ReturnsTrue()
+        {
+            // Arrange
+            var relativeFilePath = "/path/to/obj/Debug/file.razor.g.cs";
+            var projectRootElement = ProjectRootElement.Create("/path/to/project.csproj");
+            projectRootElement.AddItem("Compile", relativeFilePath);
+            var projectInstance = new ProjectInstance(projectRootElement);
+
+            // Act
+            var result = ComponentRefreshTrigger.IsCompileItem(relativeFilePath, projectInstance);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsCompileItem_NotCompileItem_ReturnsFalse()
+        {
+            // Arrange
+            var relativeFilePath = "/path/to/obj/Debug/file.razor.g.cs";
+            var projectRootElement = ProjectRootElement.Create("/path/to/project.csproj");
+            var projectInstance = new ProjectInstance(projectRootElement);
+
+            // Act
+            var result = ComponentRefreshTrigger.IsCompileItem(relativeFilePath, projectInstance);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
         public async Task RazorDocumentChangedAsync_Changed_PerformsProjectEvaluation()
         {
             // Arrange


### PR DESCRIPTION
- Prior to this when you would do a `dotnet build` at the command line while VSCode was open it would trigger document output changed events for the actual pre-compiled views (not just the declaration files). Problem with this is that the pre-compiled views shouldn't be considered as part of the compile output for the primary project, otherwise you get ambiguous reference issues.
- Added tests to verify IsCompileItem functionality.

/cc @danroth27 this was causing the issue 😉 