### PR TITLE
Add support for RootNamespace

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,15 +3,15 @@
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.7.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview4.19158.1</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview4.19158.1</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview4.19158.1</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview4.19158.1</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview4.19170.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>3.0.0-preview4.19155.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandle.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandle.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
         public FullProjectSnapshotHandle(
             string filePath,
             RazorConfiguration configuration,
+            string rootNamespace,
             ProjectWorkspaceState projectWorkspaceState)
         {
             if (filePath == null)
@@ -24,12 +25,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
 
             FilePath = filePath;
             Configuration = configuration;
+            RootNamespace = rootNamespace;
             ProjectWorkspaceState = projectWorkspaceState;
         }
 
         public string FilePath { get; }
 
         public RazorConfiguration Configuration { get; }
+
+        public string RootNamespace { get; }
 
         public ProjectWorkspaceState ProjectWorkspaceState { get; }
     }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandleJsonConverter.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandleJsonConverter.cs
@@ -28,9 +28,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
             var obj = JObject.Load(reader);
             var filePath = obj[nameof(FullProjectSnapshotHandle.FilePath)].Value<string>();
             var configuration = obj[nameof(FullProjectSnapshotHandle.Configuration)].ToObject<RazorConfiguration>(serializer);
+            var rootNamespace = obj[nameof(FullProjectSnapshotHandle.RootNamespace)].ToObject<string>(serializer);
             var projectWorkspaceState = obj[nameof(FullProjectSnapshotHandle.ProjectWorkspaceState)].ToObject<ProjectWorkspaceState>(serializer);
 
-            return new FullProjectSnapshotHandle(filePath, configuration, projectWorkspaceState);
+            return new FullProjectSnapshotHandle(filePath, configuration, rootNamespace, projectWorkspaceState);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -63,6 +64,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
                 writer.WritePropertyName(nameof(FullProjectSnapshotHandle.ProjectWorkspaceState));
                 serializer.Serialize(writer, handle.ProjectWorkspaceState);
             }
+
+            writer.WritePropertyName(nameof(FullProjectSnapshotHandle.RootNamespace));
+            writer.WriteValue(handle.RootNamespace);
 
             writer.WriteEndObject();
         }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/ProjectSnapshotJsonConverter.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/ProjectSnapshotJsonConverter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var project = (ProjectSnapshot)value;
-            var handle = new FullProjectSnapshotHandle(project.FilePath, project.Configuration, project.ProjectWorkspaceState);
+            var handle = new FullProjectSnapshotHandle(project.FilePath, project.Configuration, project.RootNamespace, project.ProjectWorkspaceState);
 
             FullProjectSnapshotHandleJsonConverter.Instance.WriteJson(writer, handle, serializer);
         }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultProjectResolver.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultProjectResolver.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             _projectSnapshotManagerAccessor = projectSnapshotManagerAccessor;
 
             var miscellaneousProjectPath = Path.Combine(TempDirectory.Instance.DirectoryPath, "__MISC_RAZOR_PROJECT__");
-            _miscellaneousHostProject = new HostProject(miscellaneousProjectPath, RazorDefaults.Configuration);
+            _miscellaneousHostProject = new HostProject(miscellaneousProjectPath, RazorDefaults.Configuration, RazorDefaults.RootNamespace);
         }
 
         public override bool TryResolvePotentialProject(string documentFilePath, out ProjectSnapshot projectSnapshot)

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -25,6 +25,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
         public abstract void RemoveProject(string filePath);
 
-        public abstract void UpdateProject(string filePath, RazorConfiguration configuration, ProjectWorkspaceState projectWorkspaceState);
+        public abstract void UpdateProject(string filePath, RazorConfiguration configuration, string rootNamespace, ProjectWorkspaceState projectWorkspaceState);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorUpdateProjectParams.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorUpdateProjectParams.cs
@@ -12,8 +12,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
     {
         public string FilePath { get; set; }
 
-        public ProjectWorkspaceState ProjectWorkspaceState { get; set; }
-
         public RazorConfiguration Configuration { get; set; }
+
+        public string RootNamespace { get; set; }
+
+        public ProjectWorkspaceState ProjectWorkspaceState { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDefaults.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDefaults.cs
@@ -16,5 +16,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             });
 
         public static RazorConfiguration Configuration { get; } = FallbackRazorConfiguration.MVC_2_1;
+
+        public static string RootNamespace { get; } = null;
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorProjectEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorProjectEndpoint.cs
@@ -99,6 +99,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 () => _projectService.UpdateProject(
                     request.FilePath,
                     request.Configuration,
+                    request.RootNamespace,
                     request.ProjectWorkspaceState ?? ProjectWorkspaceState.Default),
                 CancellationToken.None,
                 TaskCreationOptions.None,

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
@@ -13,6 +13,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             FilePath = filePath;
             PhysicalPath = physicalPath;
+
+            if (FilePath.StartsWith('/'))
+            {
+                RelativePhysicalPath = FilePath.Substring(1);
+            }
+            else
+            {
+                RelativePhysicalPath = FilePath;
+            }
         }
 
         public override string BasePath => "/";
@@ -20,6 +29,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public override string FilePath { get; }
 
         public override string PhysicalPath { get; }
+
+        public override string RelativePhysicalPath { get; }
 
         public override bool Exists
         {

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostProject.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostProject.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
     public sealed class OmniSharpHostProject
     {
-        public OmniSharpHostProject(string projectFilePath, RazorConfiguration razorConfiguration)
+        public OmniSharpHostProject(string projectFilePath, RazorConfiguration razorConfiguration, string rootNamespace)
         {
             if (projectFilePath == null)
             {
@@ -21,12 +21,14 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 throw new ArgumentNullException(nameof(razorConfiguration));
             }
 
-            InternalHostProject = new HostProject(projectFilePath, razorConfiguration);
+            InternalHostProject = new HostProject(projectFilePath, razorConfiguration, rootNamespace);
         }
 
         public string FilePath => InternalHostProject.FilePath;
 
         public RazorConfiguration Configuration => InternalHostProject.Configuration;
+
+        public string RootNamespace => InternalHostProject.RootNamespace;
 
         internal HostProject InternalHostProject { get; }
     }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/FallbackConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/FallbackConfigurationProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             }
 
             var razorConfiguration = FallbackRazorConfiguration.SelectConfiguration(version);
-            configuration = new ProjectConfiguration(razorConfiguration, Array.Empty<OmniSharpHostDocument>());
+            configuration = new ProjectConfiguration(razorConfiguration, Array.Empty<OmniSharpHostDocument>(), rootNamespace: null);
             return true;
         }
 

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         internal const string RazorGenerateWithTargetPathItemType = "RazorGenerateWithTargetPath";
         internal const string RazorComponentWithTargetPathItemType = "RazorComponentWithTargetPath";
         internal const string RazorTargetPathMetadataName = "TargetPath";
+        internal const string RootNamespaceProperty = "RootNamespace";
 
         private const string RazorLangVersionProperty = "RazorLangVersion";
         private const string RazorDefaultConfigurationProperty = "RazorDefaultConfiguration";
@@ -79,12 +80,25 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 return false;
             }
 
+            var rootNamespace = GetRootNamespace(projectInstance);
             var extensions = GetExtensions(configuredExtensionNames, projectInstance.Items);
             var razorConfiguration = new ProjectSystemRazorConfiguration(languageVersion, configurationItem.EvaluatedInclude, extensions);
             var hostDocuments = GetHostDocuments(projectInstance.Items);
 
-            configuration = new ProjectConfiguration(razorConfiguration, hostDocuments);
+            configuration = new ProjectConfiguration(razorConfiguration, hostDocuments, rootNamespace);
             return true;
+        }
+
+        // Internal for testing
+        internal static string GetRootNamespace(ProjectInstance projectInstance)
+        {
+            var rootNamespace = projectInstance.GetPropertyValue(RootNamespaceProperty);
+            if (string.IsNullOrEmpty(rootNamespace))
+            {
+                return null;
+            }
+
+            return rootNamespace;
         }
 
         // Internal for testing

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             }
 
             var projectSnapshot = _projectManager.GetLoadedProject(projectFilePath);
-            var hostProject = new OmniSharpHostProject(projectFilePath, projectConfiguration.Configuration);
+            var hostProject = new OmniSharpHostProject(projectFilePath, projectConfiguration.Configuration, projectConfiguration.RootNamespace);
             if (projectSnapshot == null)
             {
                 // Project doesn't exist yet, create it and set it up with all of its host documents.

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/ProjectConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
     public sealed class ProjectConfiguration
     {
-        public ProjectConfiguration(RazorConfiguration configuration, IReadOnlyList<OmniSharpHostDocument> documents)
+        public ProjectConfiguration(RazorConfiguration configuration, IReadOnlyList<OmniSharpHostDocument> documents, string rootNamespace)
         {
             if (configuration == null)
             {
@@ -23,10 +23,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
             Configuration = configuration;
             Documents = documents;
+            RootNamespace = rootNamespace;
         }
 
         public RazorConfiguration Configuration { get; }
 
         public IReadOnlyList<OmniSharpHostDocument> Documents { get; }
+
+        public string RootNamespace { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/SystemWebConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/SystemWebConfigurationProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 return false;
             }
 
-            configuration = new ProjectConfiguration(UnsupportedRazorConfiguration.Instance, Array.Empty<OmniSharpHostDocument>());
+            configuration = new ProjectConfiguration(UnsupportedRazorConfiguration.Instance, Array.Empty<OmniSharpHostDocument>(), rootNamespace: null);
             return true;
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorProjectConfiguration.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorProjectConfiguration.ts
@@ -10,7 +10,8 @@ export interface IRazorProjectConfiguration {
     readonly uri: vscode.Uri;
     readonly projectPath: string;
     readonly projectUri: vscode.Uri;
-    readonly projectWorkspaceState: any;
     readonly configuration: any;
+    readonly rootNamespace: string;
+    readonly projectWorkspaceState: any;
     readonly lastUpdated: Date;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
@@ -5,6 +5,7 @@
 
 export interface UpdateProjectRequest {
     readonly filePath: string;
-    readonly projectWorkspaceState?: any;
     readonly configuration?: any;
+    readonly rootNamespace?: string;
+    readonly projectWorkspaceState?: any;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -63,6 +63,7 @@ export class RazorLanguageServiceClient {
             filePath: project.uri.fsPath,
             projectWorkspaceState: project.configuration ? project.configuration.projectWorkspaceState : null,
             configuration: project.configuration ? project.configuration.configuration : undefined,
+            rootNamespace: project.configuration ? project.configuration.rootNamespace : undefined,
         };
         await this.serverClient.sendRequest<UpdateProjectRequest>('projects/updateProject', request);
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
@@ -168,6 +168,7 @@ export class RazorProjectManager {
                 projectPath: projectFilePath,
                 projectUri,
                 configuration: projectHandle.Configuration,
+                rootNamespace: projectHandle.RootNamespace,
                 projectWorkspaceState: projectHandle.ProjectWorkspaceState,
                 lastUpdated,
             };

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
@@ -41,7 +41,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void FullProjectSnapshotHandle_CanRoundTrip()
         {
             // Arrange
-            var handle = new FullProjectSnapshotHandle("/path/to/project.csproj", Configuration, ProjectWorkspaceState);
+            var handle = new FullProjectSnapshotHandle(
+                "/path/to/project.csproj", 
+                Configuration, 
+                rootNamespace: "TestProject", 
+                ProjectWorkspaceState);
             var serializedHandle = JsonConvert.SerializeObject(handle, Converters);
 
             // Act
@@ -50,6 +54,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             // Assert
             Assert.Equal(handle.FilePath, deserializedHandle.FilePath);
             Assert.Equal(handle.Configuration, deserializedHandle.Configuration);
+            Assert.Equal(handle.RootNamespace, deserializedHandle.RootNamespace);
             Assert.Equal(handle.ProjectWorkspaceState, deserializedHandle.ProjectWorkspaceState);
         }
 

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/BackgroundDocumentGeneratorTest.cs
@@ -30,11 +30,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 new HostDocument("c:\\Test1\\Components\\Counter.cshtml", "Components\\Counter.cshtml"),
             };
 
-            HostProject1 = new HostProject("c:\\Test1\\Test1.csproj", RazorConfiguration.Default);
-            HostProject2 = new HostProject("c:\\Test2\\Test2.csproj", RazorConfiguration.Default);
-
-            var projectId1 = ProjectId.CreateNewId("Test1");
-            var projectId2 = ProjectId.CreateNewId("Test2");
+            HostProject1 = new HostProject("c:\\Test1\\Test1.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            HostProject2 = new HostProject("c:\\Test2\\Test2.csproj", RazorConfiguration.Default, "TestRootNamespace");
         }
 
         private IEnumerable<DocumentProcessedListener> Listeners => Enumerable.Empty<DocumentProcessedListener>();

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentFilePath = "/C:/path/to/file.cshtml";
             var projectFilePath = "/C:/path/to/project.csproj";
             var container = Store.Get(documentFilePath);
-            var project = new HostProject(projectFilePath, RazorConfiguration.Default);
+            var project = new HostProject(projectFilePath, RazorConfiguration.Default, "TestRootNamespace");
             ProjectManager.ProjectAdded(project);
             var document = new HostDocument(documentFilePath, "file.cshtml");
             ProjectManager.DocumentAdded(project, document, null);

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -19,7 +19,32 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     public class DefaultRazorProjectServiceTest : TestBase
     {
         [Fact]
-        public void UpdateProject_SameConfigurationNoops()
+        public void UpdateProject_SameConfigurationDifferentRootNamespace_UpdatesRootNamespace()
+        {
+            // Arrange
+            var projectFilePath = "/C:/path/to/project.csproj";
+            var ownerProject = TestProjectSnapshot.Create(projectFilePath);
+            var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
+            var expectedRootNamespace = "NewRootNamespace";
+            projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
+                .Returns(ownerProject);
+            projectSnapshotManager.Setup(manager => manager.ProjectWorkspaceStateChanged(It.IsAny<string>(), It.IsAny<ProjectWorkspaceState>()));
+            projectSnapshotManager.Setup(manager => manager.ProjectConfigurationChanged(It.IsAny<HostProject>()))
+                .Callback<HostProject>((hostProject) =>
+                {
+                    Assert.Equal(expectedRootNamespace, hostProject.RootNamespace);
+                });
+            var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
+
+            // Act
+            projectService.UpdateProject(projectFilePath, ownerProject.Configuration, expectedRootNamespace, ProjectWorkspaceState.Default);
+
+            // Assert
+            projectSnapshotManager.VerifyAll();
+        }
+
+        [Fact]
+        public void UpdateProject_SameConfigurationAndRootNamespaceNoops()
         {
             // Arrange
             var projectFilePath = "/C:/path/to/project.csproj";
@@ -33,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
 
             // Act & Assert
-            projectService.UpdateProject(projectFilePath, ownerProject.Configuration, ProjectWorkspaceState.Default);
+            projectService.UpdateProject(projectFilePath, ownerProject.Configuration, "TestRootNamespace", ProjectWorkspaceState.Default);
         }
 
         [Fact]
@@ -55,7 +80,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
 
             // Act
-            projectService.UpdateProject(projectFilePath, configuration: null, ProjectWorkspaceState.Default);
+            projectService.UpdateProject(projectFilePath, configuration: null, "TestRootNamespace", ProjectWorkspaceState.Default);
 
             // Assert
             projectSnapshotManager.VerifyAll();
@@ -80,7 +105,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
 
             // Act
-            projectService.UpdateProject(projectFilePath, FallbackRazorConfiguration.MVC_1_1, ProjectWorkspaceState.Default);
+            projectService.UpdateProject(projectFilePath, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", ProjectWorkspaceState.Default);
 
             // Assert
             projectSnapshotManager.VerifyAll();
@@ -99,7 +124,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectSnapshotManager.Object);
 
             // Act & Assert
-            projectService.UpdateProject(projectFilePath, FallbackRazorConfiguration.MVC_1_1, ProjectWorkspaceState.Default);
+            projectService.UpdateProject(projectFilePath, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", ProjectWorkspaceState.Default);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsPublisherTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsPublisherTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public RazorDiagnosticsPublisherTest()
         {
             var testProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
-            var hostProject = new HostProject("/C:/project/project.csproj", RazorConfiguration.Default);
+            var hostProject = new HostProject("/C:/project/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             testProjectManager.ProjectAdded(hostProject);
             var sourceText = SourceText.From(string.Empty);
             var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ComponentRefreshTriggerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ComponentRefreshTriggerTest.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
     public class ComponentRefreshTriggerTest : OmniSharpTestBase
     {
-        public ProjectInstanceEvaluator ProjectInstanceEvaluator { get; } = Mock.Of<ProjectInstanceEvaluator>();
+        private ProjectInstanceEvaluator ProjectInstanceEvaluator { get; } = Mock.Of<ProjectInstanceEvaluator>();
 
-        public ProjectInstance ProjectInstance { get; } = new ProjectInstance(ProjectRootElement.Create());
+        private ProjectInstance ProjectInstance { get; } = new ProjectInstance(ProjectRootElement.Create());
 
         [Fact]
         public void IsCompileItem_CompileItem_ReturnsTrue()
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             refreshTrigger.Initialize(projectManager);
             await RunOnForegroundAsync(() =>
             {
-                var hostProject = new OmniSharpHostProject(projectInstance.ProjectFileLocation.File, RazorConfiguration.Default);
+                var hostProject = new OmniSharpHostProject(projectInstance.ProjectFileLocation.File, RazorConfiguration.Default, "TestRootNamespace");
                 projectManager.ProjectAdded(hostProject);
                 var hostDocument = new OmniSharpHostDocument("file.cshtml", "file.cshtml", FileKinds.Component);
                 projectManager.DocumentAdded(hostProject, hostDocument);
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
             await RunOnForegroundAsync(() =>
             {
-                var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+                var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
                 projectManager.ProjectAdded(hostProject);
                 var hostDocument = new OmniSharpHostDocument("file.cshtml", "file.cshtml", FileKinds.Legacy);
                 projectManager.DocumentAdded(hostProject, hostDocument);
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var projectManager = CreateProjectSnapshotManager();
             var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
             refreshTrigger.Initialize(projectManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             await RunOnForegroundAsync(() => projectManager.ProjectAdded(hostProject));
 
             // Act
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var projectManager = CreateProjectSnapshotManager();
             var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
             refreshTrigger.Initialize(projectManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             var hostDocument = new OmniSharpHostDocument("file.cshtml", "file.cshtml", FileKinds.Legacy);
             await RunOnForegroundAsync(() =>
             {
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var projectManager = CreateProjectSnapshotManager();
             var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
             refreshTrigger.Initialize(projectManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             var hostDocument = new OmniSharpHostDocument("file.cshtml", "file.cshtml", FileKinds.Component);
             await RunOnForegroundAsync(() =>
             {

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/DefaultProjectChangePublisherTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/DefaultProjectChangePublisherTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                     Assert.Equal(expectedPublishFilePath, publishFilePath);
                 });
             publisher.Initialize(snapshotManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             publisher.SetPublishFilePath(hostProject.FilePath, expectedPublishFilePath);
 
             // Act
@@ -91,11 +91,11 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                     Assert.Equal(expectedPublishFilePath, publishFilePath);
                 });
             publisher.Initialize(snapshotManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             publisher.SetPublishFilePath(hostProject.FilePath, expectedPublishFilePath);
             await RunOnForegroundAsync(() => snapshotManager.ProjectAdded(hostProject));
             var newConfiguration = RazorConfiguration.Create(RazorLanguageVersion.Experimental, "Custom", Enumerable.Empty<RazorExtension>());
-            var newHostProject = new OmniSharpHostProject(hostProject.FilePath, newConfiguration);
+            var newHostProject = new OmniSharpHostProject(hostProject.FilePath, newConfiguration, "TestRootNamespace");
 
             // Act
             await RunOnForegroundAsync(() => snapshotManager.ProjectConfigurationChanged(newHostProject));
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var publisher = new TestProjectChangePublisher(LoggerFactory);
             publisher.Initialize(snapshotManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             await RunOnForegroundAsync(() => snapshotManager.ProjectAdded(hostProject));
 
             // Act & Assert
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                     Assert.Equal(expectedPublishFilePath, publishFilePath);
                 });
             publisher.Initialize(snapshotManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             publisher.SetPublishFilePath(hostProject.FilePath, expectedPublishFilePath);
             await RunOnForegroundAsync(() => snapshotManager.ProjectAdded(hostProject));
 

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 LoggerFactory);
             var projectManager = CreateProjectSnapshotManager();
             msbuildProjectManager.Initialize(projectManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", CustomConfiguration);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", CustomConfiguration, "TestRootNamespace");
             var projectSnapshot = await RunOnForegroundAsync(() =>
             {
                 projectManager.ProjectAdded(hostProject);
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 LoggerFactory);
             var projectManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             msbuildProjectManager.Initialize(projectManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", CustomConfiguration);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", CustomConfiguration, "TestRootNamespace");
             var projectSnapshot = await RunOnForegroundAsync(() =>
             {
                 projectManager.ProjectAdded(hostProject);
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 LoggerFactory);
             var projectManager = CreateProjectSnapshotManager();
             msbuildProjectManager.Initialize(projectManager);
-            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", CustomConfiguration);
+            var hostProject = new OmniSharpHostProject("/path/to/project.csproj", CustomConfiguration, "TestRootNamespace");
             var projectSnapshot = await RunOnForegroundAsync(() =>
             {
                 projectManager.ProjectAdded(hostProject);
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             projectRootElement.AddProperty(MSBuildProjectManager.IntermediateOutputPathPropertyName, intermediateOutputPath);
             var projectInstance = new ProjectInstance(projectRootElement);
             var hostDocument = new OmniSharpHostDocument("file.razor", "file.razor", FileKinds.Component);
-            var projectConfiguration = new ProjectConfiguration(CustomConfiguration, new[] { hostDocument });
+            var projectConfiguration = new ProjectConfiguration(CustomConfiguration, new[] { hostDocument }, "TestRootNamespace");
             var configurationProvider = new Mock<ProjectConfigurationProvider>();
             configurationProvider.Setup(provider => provider.TryResolveConfiguration(It.IsAny<ProjectConfigurationProviderContext>(), out projectConfiguration))
                 .Returns(true);
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
             projectInstance.AddItem(MSBuildProjectManager.ProjectCapabilityItemType, CoreProjectConfigurationProvider.DotNetCoreRazorCapability);
             var provider1 = new Mock<ProjectConfigurationProvider>();
-            var configuration = new ProjectConfiguration(RazorConfiguration.Default, Array.Empty<OmniSharpHostDocument>()); // Setting to non-null to ensure the listener doesn't return the config verbatim.
+            var configuration = new ProjectConfiguration(RazorConfiguration.Default, Array.Empty<OmniSharpHostDocument>(), "TestRootNamespace"); // Setting to non-null to ensure the listener doesn't return the config verbatim.
             provider1.Setup(p => p.TryResolveConfiguration(It.IsAny<ProjectConfigurationProviderContext>(), out configuration))
                 .Returns(false);
             var provider2 = new Mock<ProjectConfigurationProvider>();
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
             projectInstance.AddItem(MSBuildProjectManager.ProjectCapabilityItemType, CoreProjectConfigurationProvider.DotNetCoreRazorCapability);
             var provider = new Mock<ProjectConfigurationProvider>();
-            var configuration = new ProjectConfiguration(RazorConfiguration.Default, Array.Empty<OmniSharpHostDocument>()); // Setting to non-null to ensure the listener doesn't return the config verbatim.
+            var configuration = new ProjectConfiguration(RazorConfiguration.Default, Array.Empty<OmniSharpHostDocument>(), "TestRootNamespace"); // Setting to non-null to ensure the listener doesn't return the config verbatim.
             provider.Setup(p => p.TryResolveConfiguration(It.IsAny<ProjectConfigurationProviderContext>(), out configuration))
                 .Returns(false);
 
@@ -260,7 +260,6 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
         {
             // Arrange
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
-            var loggerFactory = Mock.Of<ILoggerFactory>();
 
             // Act
             var result = MSBuildProjectManager.TryResolveConfigurationOutputPath(projectInstance, out var path);

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/TestProjectSnapshot.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/TestProjectSnapshot.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 
             var hostServices = TestServices.Create(workspaceServices, languageServices);
             var workspace = TestWorkspace.Create(hostServices);
-            var hostProject = new HostProject(filePath, configuration);
+            var hostProject = new HostProject(filePath, configuration, "TestRootNamespace");
             var state = ProjectState.Create(workspace.Services, hostProject);
             foreach (var documentFilePath in documentFilePaths)
             {


### PR DESCRIPTION
- Updated Razor packages to pull in new RootNamespace changes.
- Updated HostProject creations/usages to now also pass RootNamespace.
- Added extra logging to the `UpdateProject` method on the project service to identify when a RootNamespace is updated for a project.
- Updated project handle serialization to also include RootNamespace.
- Added tests to cover new RootNamespace calculation scenarios

#308