### PR TITLE
Fix activation deadlock.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,8 +1,7 @@
 {
     "name": "razor-vscode",
-    "version": "0.0.1",
-    "lockfileVersion": 1,
     "requires": true,
+    "lockfileVersion": 1,
     "dependencies": {
         "@types/mocha": {
             "version": "2.2.42",

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
     "name": "razor-vscode",
     "displayName": "Razor",
     "description": "Razor tooling support for VS Code",
+    "version": "0.0.1",
     "defaults": {
         "razor": "0.0.1"
     },


### PR DESCRIPTION
- Found an issue where the `onReady` handler doesn't reject awaiters for the VSCode LanguageClient when retries are exhausted. Because the awaiters don't get rejected we fail activation (it hangs) at which point VSCode kills the Razor + C# extension.
- Typically the LanguageServer fails due to unsupported platforms and then it repeatedly fails until the hardcoded retry limit is exhausted.
- Due to the LanguageClient untestability wasn't able to add a test.
- Add a `version` to `package.json`so local debugging doesn't result in an error window.

#223