### PR TITLE
Use built-in VSCode clipboard API.

### DIFF
--- a/client/Client.csproj
+++ b/client/Client.csproj
@@ -19,7 +19,7 @@
     <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
     <Exec Command="node -v" />
     <Exec Command="npm -v" />
-    <Exec Command="npm ci" />
+    <Exec Command="npm install" />
   </Target>
 
   <Target Name="RunNpmCompile" AfterTargets="Build" DependsOnTargets="EnsureNpmRestored">

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,31 +16,23 @@
             "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
             "dev": true
         },
+        "agent-base": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+            "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
+        },
         "ajv": {
-            "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-            "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
-            }
-        },
-        "ansi-cyan": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-            "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-            "requires": {
-                "ansi-wrap": "0.1.0"
-            }
-        },
-        "ansi-red": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-            "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-            "requires": {
-                "ansi-wrap": "0.1.0"
             }
         },
         "ansi-regex": {
@@ -55,19 +47,6 @@
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
             "dev": true
         },
-        "ansi-wrap": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
-        },
-        "append-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-            "requires": {
-                "buffer-equal": "^1.0.0"
-            }
-        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -77,52 +56,11 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "arr-diff": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-            "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-            "requires": {
-                "arr-flatten": "^1.0.1",
-                "array-slice": "^0.2.3"
-            }
-        },
-        "arr-flatten": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-        },
-        "arr-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
-        },
-        "array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-        },
-        "array-slice": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
-        },
-        "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "requires": {
-                "array-uniq": "^1.0.1"
-            }
-        },
-        "array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
         },
         "asn1": {
             "version": "0.2.4",
@@ -197,14 +135,6 @@
                 "tweetnacl": "^0.14.3"
             }
         },
-        "block-stream": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-            "requires": {
-                "inherits": "~2.0.0"
-            }
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -218,16 +148,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
-        },
-        "buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-        },
-        "buffer-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -282,31 +202,6 @@
                 }
             }
         },
-        "clone": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-            "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
-        },
-        "clone-buffer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
-        },
-        "clone-stats": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-        },
-        "cloneable-readable": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-            "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-            "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
-            }
-        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -339,14 +234,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "convert-source-map": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-            "requires": {
-                "safe-buffer": "~5.1.1"
-            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -392,22 +279,6 @@
                 "ms": "2.0.0"
             }
         },
-        "deep-assign": {
-            "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
-            "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-            "requires": {
-                "is-obj": "^1.0.0"
-            }
-        },
-        "define-properties": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "requires": {
-                "object-keys": "^1.0.12"
-            }
-        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -418,22 +289,6 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
             "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
         },
-        "duplexer": {
-            "version": "0.1.1",
-            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-        },
-        "duplexify": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-            "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
-            "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-            }
-        },
         "ecc-jsbn": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -443,12 +298,17 @@
                 "safer-buffer": "^2.1.0"
             }
         },
-        "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+        "es6-promise": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+            "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "requires": {
-                "once": "^1.4.0"
+                "es6-promise": "^4.0.3"
             }
         },
         "escape-string-regexp": {
@@ -468,32 +328,10 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
-        "event-stream": {
-            "version": "3.3.4",
-            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-            "requires": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
-                "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
-            }
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "extend-shallow": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-            "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-            "requires": {
-                "kind-of": "^1.1.0"
-            }
         },
         "extsprintf": {
             "version": "1.3.0",
@@ -510,23 +348,6 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
-        "fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-            "requires": {
-                "pend": "~1.2.0"
-            }
-        },
-        "flush-write-stream": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-            "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
-            }
-        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -542,40 +363,10 @@
                 "mime-types": "^2.1.12"
             }
         },
-        "from": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-        },
-        "fs-mkdirp-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-            "requires": {
-                "graceful-fs": "^4.1.11",
-                "through2": "^2.0.3"
-            }
-        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "fstream": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            }
-        },
-        "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "getpass": {
             "version": "0.1.7",
@@ -598,212 +389,10 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-parent": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
-            }
-        },
-        "glob-stream": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-            "requires": {
-                "extend": "^3.0.0",
-                "glob": "^7.1.1",
-                "glob-parent": "^3.1.0",
-                "is-negated-glob": "^1.0.0",
-                "ordered-read-streams": "^1.0.0",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.1.5",
-                "remove-trailing-separator": "^1.0.1",
-                "to-absolute-glob": "^2.0.0",
-                "unique-stream": "^2.0.2"
-            }
-        },
-        "graceful-fs": {
-            "version": "4.1.15",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-        },
         "growl": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
             "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
-        },
-        "gulp-chmod": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
-            "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
-            "requires": {
-                "deep-assign": "^1.0.0",
-                "stat-mode": "^0.2.0",
-                "through2": "^2.0.0"
-            }
-        },
-        "gulp-filter": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
-            "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
-            "requires": {
-                "multimatch": "^2.0.0",
-                "plugin-error": "^0.1.2",
-                "streamfilter": "^1.0.5"
-            }
-        },
-        "gulp-gunzip": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
-            "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
-            "requires": {
-                "through2": "~0.6.5",
-                "vinyl": "~0.4.6"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
-            }
-        },
-        "gulp-remote-src-vscode": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
-            "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
-            "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "^1.1.2",
-                "request": "^2.79.0",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.1"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-                },
-                "vinyl": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-                    "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "gulp-untar": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
-            "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
-            "requires": {
-                "event-stream": "~3.3.4",
-                "streamifier": "~0.1.1",
-                "tar": "^2.2.1",
-                "through2": "~2.0.3",
-                "vinyl": "^1.2.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-vinyl-zip": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
-            "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
-            "requires": {
-                "event-stream": "3.3.4",
-                "queue": "^4.2.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.2",
-                "vinyl-fs": "^3.0.3",
-                "yauzl": "^2.2.1",
-                "yazl": "^2.2.1"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-                },
-                "vinyl": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-                    "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
-                    }
-                }
-            }
         },
         "har-schema": {
             "version": "2.0.0",
@@ -817,14 +406,6 @@
             "requires": {
                 "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
-            }
-        },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "requires": {
-                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -841,15 +422,19 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
-        "has-symbols": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
-        },
         "he": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+        },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "requires": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            }
         },
         "http-signature": {
             "version": "1.2.0",
@@ -859,6 +444,15 @@
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
                 "sshpk": "^1.7.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "requires": {
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
             }
         },
         "inflight": {
@@ -875,88 +469,16 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
-        "is": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
-            "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
-        },
-        "is-absolute": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
-            }
-        },
-        "is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-glob": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-            "requires": {
-                "is-extglob": "^2.1.0"
-            }
-        },
-        "is-negated-glob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
-        },
-        "is-obj": {
-            "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-        },
-        "is-relative": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "requires": {
-                "is-unc-path": "^1.0.0"
-            }
-        },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
-        "is-unc-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "requires": {
-                "unc-path-regex": "^0.1.2"
-            }
-        },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-        },
-        "is-valid-glob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
-        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-        },
-        "isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -1000,11 +522,6 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
-        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -1021,2221 +538,30 @@
                 "verror": "1.10.0"
             }
         },
-        "kind-of": {
-            "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-            "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
-        },
-        "lazystream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-            "requires": {
-                "readable-stream": "^2.0.5"
-            }
-        },
-        "lead": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
-            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-            "requires": {
-                "flush-write-stream": "^1.0.2"
-            }
-        },
         "make-error": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
             "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
             "dev": true
         },
-        "map-stream": {
-            "version": "0.1.0",
-            "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-        },
         "microsoft.aspnetcore.razor.vscode": {
             "version": "file:../src/Microsoft.AspNetCore.Razor.VSCode",
             "requires": {
-                "clipboardy": "1.2.3",
-                "vscode-html-languageservice": "^2.1.7",
-                "vscode-languageclient": "^5.1.0"
-            },
-            "dependencies": {
-                "@types/clipboardy": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "@types/node": {
-                    "version": "10.9.4",
-                    "bundled": true
-                },
-                "ajv": {
-                    "version": "6.6.1",
-                    "bundled": true,
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "ansi-cyan": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-wrap": "0.1.0"
-                    }
-                },
-                "ansi-red": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-wrap": "0.1.0"
-                    }
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "bundled": true
-                },
-                "ansi-wrap": {
-                    "version": "0.1.0",
-                    "bundled": true
-                },
-                "append-buffer": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "buffer-equal": "^1.0.0"
-                    }
-                },
-                "arch": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "argparse": {
-                    "version": "1.0.10",
-                    "bundled": true,
-                    "requires": {
-                        "sprintf-js": "~1.0.2"
-                    }
-                },
-                "arr-diff": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1",
-                        "array-slice": "^0.2.3"
-                    }
-                },
-                "arr-flatten": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "arr-union": {
-                    "version": "2.1.0",
-                    "bundled": true
-                },
-                "array-differ": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "array-slice": {
-                    "version": "0.2.3",
-                    "bundled": true
-                },
-                "array-union": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "array-uniq": "^1.0.1"
-                    }
-                },
-                "array-uniq": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "bundled": true
-                },
-                "arrify": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "asn1": {
-                    "version": "0.2.4",
-                    "bundled": true,
-                    "requires": {
-                        "safer-buffer": "~2.1.0"
-                    }
-                },
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "asynckit": {
-                    "version": "0.4.0",
-                    "bundled": true
-                },
-                "aws-sign2": {
-                    "version": "0.7.0",
-                    "bundled": true
-                },
-                "aws4": {
-                    "version": "1.8.0",
-                    "bundled": true
-                },
-                "babel-code-frame": {
-                    "version": "6.26.0",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "1.1.3",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "^2.2.1",
-                                "escape-string-regexp": "^1.0.2",
-                                "has-ansi": "^2.0.0",
-                                "strip-ansi": "^3.0.0",
-                                "supports-color": "^2.0.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "bcrypt-pbkdf": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "tweetnacl": "^0.14.3"
-                    }
-                },
-                "block-stream": {
-                    "version": "0.0.9",
-                    "bundled": true,
-                    "requires": {
-                        "inherits": "~2.0.0"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "bundled": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "browser-stdout": {
-                    "version": "1.3.0",
-                    "bundled": true
-                },
-                "buffer-crc32": {
-                    "version": "0.2.13",
-                    "bundled": true
-                },
-                "buffer-equal": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "buffer-from": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "builtin-modules": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "caseless": {
-                    "version": "0.12.0",
-                    "bundled": true
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "^1.9.0"
-                            }
-                        },
-                        "has-flag": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "^3.0.0"
-                            }
-                        }
-                    }
-                },
-                "clipboardy": {
-                    "version": "1.2.3",
-                    "bundled": true,
-                    "requires": {
-                        "arch": "^2.1.0",
-                        "execa": "^0.8.0"
-                    }
-                },
-                "clone": {
-                    "version": "0.2.0",
-                    "bundled": true
-                },
-                "clone-buffer": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "clone-stats": {
-                    "version": "0.0.1",
-                    "bundled": true
-                },
-                "cloneable-readable": {
-                    "version": "1.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "inherits": "^2.0.1",
-                        "process-nextick-args": "^2.0.0",
-                        "readable-stream": "^2.3.5"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "bundled": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "bundled": true
-                },
-                "combined-stream": {
-                    "version": "1.0.7",
-                    "bundled": true,
-                    "requires": {
-                        "delayed-stream": "~1.0.0"
-                    }
-                },
-                "commander": {
-                    "version": "2.11.0",
-                    "bundled": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true
-                },
-                "convert-source-map": {
-                    "version": "1.6.0",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.1"
-                    }
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "cross-spawn": {
-                    "version": "5.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "dashdash": {
-                    "version": "1.14.1",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "^1.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "deep-assign": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-obj": "^1.0.0"
-                    }
-                },
-                "define-properties": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "object-keys": "^1.0.12"
-                    }
-                },
-                "delayed-stream": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "diff": {
-                    "version": "3.3.1",
-                    "bundled": true
-                },
-                "duplexer": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "duplexify": {
-                    "version": "3.6.1",
-                    "bundled": true,
-                    "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
-                    }
-                },
-                "ecc-jsbn": {
-                    "version": "0.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "jsbn": "~0.1.0",
-                        "safer-buffer": "^2.1.0"
-                    }
-                },
-                "end-of-stream": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "requires": {
-                        "once": "^1.4.0"
-                    }
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "bundled": true
-                },
-                "esprima": {
-                    "version": "4.0.1",
-                    "bundled": true
-                },
-                "esutils": {
-                    "version": "2.0.2",
-                    "bundled": true
-                },
-                "event-stream": {
-                    "version": "3.3.4",
-                    "bundled": true,
-                    "requires": {
-                        "duplexer": "~0.1.1",
-                        "from": "~0",
-                        "map-stream": "~0.1.0",
-                        "pause-stream": "0.0.11",
-                        "split": "0.3",
-                        "stream-combiner": "~0.0.4",
-                        "through": "~2.3.1"
-                    }
-                },
-                "execa": {
-                    "version": "0.8.0",
-                    "bundled": true,
-                    "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "expand-range": {
-                    "version": "1.8.2",
-                    "bundled": true,
-                    "requires": {
-                        "fill-range": "^2.1.0"
-                    }
-                },
-                "extend": {
-                    "version": "3.0.2",
-                    "bundled": true
-                },
-                "extend-shallow": {
-                    "version": "1.1.4",
-                    "bundled": true,
-                    "requires": {
-                        "kind-of": "^1.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "bundled": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "is-extglob": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "extsprintf": {
-                    "version": "1.3.0",
-                    "bundled": true
-                },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "fast-json-stable-stringify": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "fd-slicer": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "pend": "~1.2.0"
-                    }
-                },
-                "filename-regex": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "fill-range": {
-                    "version": "2.2.4",
-                    "bundled": true,
-                    "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "first-chunk-stream": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "flush-write-stream": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
-                    }
-                },
-                "for-in": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "for-own": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "for-in": "^1.0.1"
-                    }
-                },
-                "forever-agent": {
-                    "version": "0.6.1",
-                    "bundled": true
-                },
-                "form-data": {
-                    "version": "2.3.3",
-                    "bundled": true,
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "from": {
-                    "version": "0.1.7",
-                    "bundled": true
-                },
-                "fs-mkdirp-stream": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "through2": "^2.0.3"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "fstream": {
-                    "version": "1.0.11",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "inherits": "~2.0.0",
-                        "mkdirp": ">=0.5 0",
-                        "rimraf": "2"
-                    }
-                },
-                "function-bind": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "get-stream": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "getpass": {
-                    "version": "0.1.7",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "glob-base": {
-                    "version": "0.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "glob-parent": "^2.0.0",
-                        "is-glob": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "glob-parent": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "is-glob": "^2.0.0"
-                            }
-                        },
-                        "is-extglob": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "is-glob": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-extglob": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "glob-parent": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
-                    }
-                },
-                "glob-stream": {
-                    "version": "5.3.5",
-                    "bundled": true,
-                    "requires": {
-                        "extend": "^3.0.0",
-                        "glob": "^5.0.3",
-                        "glob-parent": "^3.0.0",
-                        "micromatch": "^2.3.7",
-                        "ordered-read-streams": "^0.3.0",
-                        "through2": "^0.6.0",
-                        "to-absolute-glob": "^0.1.1",
-                        "unique-stream": "^2.0.2"
-                    },
-                    "dependencies": {
-                        "glob": {
-                            "version": "5.0.15",
-                            "bundled": true,
-                            "requires": {
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "2 || 3",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        },
-                        "isarray": {
-                            "version": "0.0.1",
-                            "bundled": true
-                        },
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "bundled": true,
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
-                                "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "bundled": true
-                        },
-                        "through2": {
-                            "version": "0.6.5",
-                            "bundled": true,
-                            "requires": {
-                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                                "xtend": ">=4.0.0 <4.1.0-0"
-                            }
-                        }
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.1.15",
-                    "bundled": true
-                },
-                "growl": {
-                    "version": "1.10.3",
-                    "bundled": true
-                },
-                "gulp-chmod": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "deep-assign": "^1.0.0",
-                        "stat-mode": "^0.2.0",
-                        "through2": "^2.0.0"
-                    }
-                },
-                "gulp-filter": {
-                    "version": "5.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "multimatch": "^2.0.0",
-                        "plugin-error": "^0.1.2",
-                        "streamfilter": "^1.0.5"
-                    }
-                },
-                "gulp-gunzip": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "through2": "~0.6.5",
-                        "vinyl": "~0.4.6"
-                    },
-                    "dependencies": {
-                        "isarray": {
-                            "version": "0.0.1",
-                            "bundled": true
-                        },
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "bundled": true,
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
-                                "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "bundled": true
-                        },
-                        "through2": {
-                            "version": "0.6.5",
-                            "bundled": true,
-                            "requires": {
-                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                                "xtend": ">=4.0.0 <4.1.0-0"
-                            }
-                        }
-                    }
-                },
-                "gulp-remote-src-vscode": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "event-stream": "3.3.4",
-                        "node.extend": "^1.1.2",
-                        "request": "^2.79.0",
-                        "through2": "^2.0.3",
-                        "vinyl": "^2.0.1"
-                    },
-                    "dependencies": {
-                        "clone": {
-                            "version": "2.1.2",
-                            "bundled": true
-                        },
-                        "clone-stats": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "vinyl": {
-                            "version": "2.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "clone": "^2.1.1",
-                                "clone-buffer": "^1.0.0",
-                                "clone-stats": "^1.0.0",
-                                "cloneable-readable": "^1.0.0",
-                                "remove-trailing-separator": "^1.0.1",
-                                "replace-ext": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "gulp-sourcemaps": {
-                    "version": "1.6.0",
-                    "bundled": true,
-                    "requires": {
-                        "convert-source-map": "^1.1.1",
-                        "graceful-fs": "^4.1.2",
-                        "strip-bom": "^2.0.0",
-                        "through2": "^2.0.0",
-                        "vinyl": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "clone": {
-                            "version": "1.0.4",
-                            "bundled": true
-                        },
-                        "replace-ext": {
-                            "version": "0.0.1",
-                            "bundled": true
-                        },
-                        "vinyl": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "clone": "^1.0.0",
-                                "clone-stats": "^0.0.1",
-                                "replace-ext": "0.0.1"
-                            }
-                        }
-                    }
-                },
-                "gulp-symdest": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "event-stream": "3.3.4",
-                        "mkdirp": "^0.5.1",
-                        "queue": "^3.1.0",
-                        "vinyl-fs": "^2.4.3"
-                    },
-                    "dependencies": {
-                        "clone": {
-                            "version": "1.0.4",
-                            "bundled": true
-                        },
-                        "replace-ext": {
-                            "version": "0.0.1",
-                            "bundled": true
-                        },
-                        "vinyl": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "clone": "^1.0.0",
-                                "clone-stats": "^0.0.1",
-                                "replace-ext": "0.0.1"
-                            }
-                        },
-                        "vinyl-fs": {
-                            "version": "2.4.4",
-                            "bundled": true,
-                            "requires": {
-                                "duplexify": "^3.2.0",
-                                "glob-stream": "^5.3.2",
-                                "graceful-fs": "^4.0.0",
-                                "gulp-sourcemaps": "1.6.0",
-                                "is-valid-glob": "^0.3.0",
-                                "lazystream": "^1.0.0",
-                                "lodash.isequal": "^4.0.0",
-                                "merge-stream": "^1.0.0",
-                                "mkdirp": "^0.5.0",
-                                "object-assign": "^4.0.0",
-                                "readable-stream": "^2.0.4",
-                                "strip-bom": "^2.0.0",
-                                "strip-bom-stream": "^1.0.0",
-                                "through2": "^2.0.0",
-                                "through2-filter": "^2.0.0",
-                                "vali-date": "^1.0.0",
-                                "vinyl": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "gulp-untar": {
-                    "version": "0.0.7",
-                    "bundled": true,
-                    "requires": {
-                        "event-stream": "~3.3.4",
-                        "streamifier": "~0.1.1",
-                        "tar": "^2.2.1",
-                        "through2": "~2.0.3",
-                        "vinyl": "^1.2.0"
-                    },
-                    "dependencies": {
-                        "clone": {
-                            "version": "1.0.4",
-                            "bundled": true
-                        },
-                        "replace-ext": {
-                            "version": "0.0.1",
-                            "bundled": true
-                        },
-                        "vinyl": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "clone": "^1.0.0",
-                                "clone-stats": "^0.0.1",
-                                "replace-ext": "0.0.1"
-                            }
-                        }
-                    }
-                },
-                "gulp-vinyl-zip": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "event-stream": "3.3.4",
-                        "queue": "^4.2.1",
-                        "through2": "^2.0.3",
-                        "vinyl": "^2.0.2",
-                        "vinyl-fs": "^3.0.3",
-                        "yauzl": "^2.2.1",
-                        "yazl": "^2.2.1"
-                    },
-                    "dependencies": {
-                        "clone": {
-                            "version": "2.1.2",
-                            "bundled": true
-                        },
-                        "clone-stats": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "queue": {
-                            "version": "4.5.1",
-                            "bundled": true,
-                            "requires": {
-                                "inherits": "~2.0.0"
-                            }
-                        },
-                        "vinyl": {
-                            "version": "2.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "clone": "^2.1.1",
-                                "clone-buffer": "^1.0.0",
-                                "clone-stats": "^1.0.0",
-                                "cloneable-readable": "^1.0.0",
-                                "remove-trailing-separator": "^1.0.1",
-                                "replace-ext": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "har-schema": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "har-validator": {
-                    "version": "5.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "ajv": "^6.5.5",
-                        "har-schema": "^2.0.0"
-                    }
-                },
-                "has": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "function-bind": "^1.1.1"
-                    }
-                },
-                "has-ansi": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "has-symbols": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "he": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "http-signature": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "^1.0.0",
-                        "jsprim": "^1.2.2",
-                        "sshpk": "^1.7.0"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true
-                },
-                "is": {
-                    "version": "3.2.1",
-                    "bundled": true
-                },
-                "is-absolute": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-relative": "^1.0.0",
-                        "is-windows": "^1.0.1"
-                    }
-                },
-                "is-buffer": {
-                    "version": "1.1.6",
-                    "bundled": true
-                },
-                "is-dotfile": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "is-equal-shallow": {
-                    "version": "0.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "is-primitive": "^2.0.0"
-                    }
-                },
-                "is-extendable": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "is-extglob": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "is-glob": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                },
-                "is-negated-glob": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-obj": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "is-posix-bracket": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "is-primitive": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "is-relative": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-unc-path": "^1.0.0"
-                    }
-                },
-                "is-stream": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "is-typedarray": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "is-unc-path": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "unc-path-regex": "^0.1.2"
-                    }
-                },
-                "is-utf8": {
-                    "version": "0.2.1",
-                    "bundled": true
-                },
-                "is-valid-glob": {
-                    "version": "0.3.0",
-                    "bundled": true
-                },
-                "is-windows": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "isexe": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "isstream": {
-                    "version": "0.1.2",
-                    "bundled": true
-                },
-                "js-tokens": {
-                    "version": "3.0.2",
-                    "bundled": true
-                },
-                "js-yaml": {
-                    "version": "3.12.0",
-                    "bundled": true,
-                    "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
-                    }
-                },
-                "jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "json-schema": {
-                    "version": "0.2.3",
-                    "bundled": true
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "bundled": true
-                },
-                "json-stable-stringify": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "jsonify": "~0.0.0"
-                    }
-                },
-                "json-stringify-safe": {
-                    "version": "5.0.1",
-                    "bundled": true
-                },
-                "jsonify": {
-                    "version": "0.0.0",
-                    "bundled": true
-                },
-                "jsprim": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.3.0",
-                        "json-schema": "0.2.3",
-                        "verror": "1.10.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "lazystream": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "readable-stream": "^2.0.5"
-                    }
-                },
-                "lead": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "flush-write-stream": "^1.0.2"
-                    }
-                },
-                "lodash.isequal": {
-                    "version": "4.5.0",
-                    "bundled": true
-                },
-                "lru-cache": {
-                    "version": "4.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
-                    }
-                },
-                "map-stream": {
-                    "version": "0.1.0",
-                    "bundled": true
-                },
-                "math-random": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "merge-stream": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "readable-stream": "^2.0.1"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "bundled": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    },
-                    "dependencies": {
-                        "arr-diff": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "arr-flatten": "^1.0.1"
-                            }
-                        },
-                        "is-extglob": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "is-glob": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-extglob": "^1.0.0"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "mime-db": {
-                    "version": "1.37.0",
-                    "bundled": true
-                },
-                "mime-types": {
-                    "version": "2.1.21",
-                    "bundled": true,
-                    "requires": {
-                        "mime-db": "~1.37.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "mocha": {
-                    "version": "4.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "browser-stdout": "1.3.0",
-                        "commander": "2.11.0",
-                        "debug": "3.1.0",
-                        "diff": "3.3.1",
-                        "escape-string-regexp": "1.0.5",
-                        "glob": "7.1.2",
-                        "growl": "1.10.3",
-                        "he": "1.1.1",
-                        "mkdirp": "0.5.1",
-                        "supports-color": "4.4.0"
-                    },
-                    "dependencies": {
-                        "glob": {
-                            "version": "7.1.2",
-                            "bundled": true,
-                            "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "multimatch": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "array-differ": "^1.0.0",
-                        "array-union": "^1.0.1",
-                        "arrify": "^1.0.0",
-                        "minimatch": "^3.0.0"
-                    }
-                },
-                "node.extend": {
-                    "version": "1.1.8",
-                    "bundled": true,
-                    "requires": {
-                        "has": "^1.0.3",
-                        "is": "^3.2.1"
-                    }
-                },
-                "normalize-path": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "remove-trailing-separator": "^1.0.1"
-                    }
-                },
-                "now-and-later": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "once": "^1.3.2"
-                    }
-                },
-                "npm-run-path": {
-                    "version": "2.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "path-key": "^2.0.0"
-                    }
-                },
-                "oauth-sign": {
-                    "version": "0.9.0",
-                    "bundled": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true
-                },
-                "object-keys": {
-                    "version": "1.0.12",
-                    "bundled": true
-                },
-                "object.assign": {
-                    "version": "4.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "define-properties": "^1.1.2",
-                        "function-bind": "^1.1.1",
-                        "has-symbols": "^1.0.0",
-                        "object-keys": "^1.0.11"
-                    }
-                },
-                "object.omit": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "for-own": "^0.1.4",
-                        "is-extendable": "^0.1.1"
-                    }
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "ordered-read-streams": {
-                    "version": "0.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-stream": "^1.0.1",
-                        "readable-stream": "^2.0.1"
-                    }
-                },
-                "p-finally": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "parse-glob": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "glob-base": "^0.3.0",
-                        "is-dotfile": "^1.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "is-extglob": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "is-glob": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-extglob": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "path-dirname": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "path-key": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "path-parse": {
-                    "version": "1.0.6",
-                    "bundled": true
-                },
-                "pause-stream": {
-                    "version": "0.0.11",
-                    "bundled": true,
-                    "requires": {
-                        "through": "~2.3"
-                    }
-                },
-                "pend": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "performance-now": {
-                    "version": "2.1.0",
-                    "bundled": true
-                },
-                "plugin-error": {
-                    "version": "0.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-cyan": "^0.1.1",
-                        "ansi-red": "^0.1.1",
-                        "arr-diff": "^1.0.1",
-                        "arr-union": "^2.0.1",
-                        "extend-shallow": "^1.1.2"
-                    }
-                },
-                "preserve": {
-                    "version": "0.2.0",
-                    "bundled": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "pseudomap": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "psl": {
-                    "version": "1.1.29",
-                    "bundled": true
-                },
-                "pump": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
-                },
-                "pumpify": {
-                    "version": "1.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "duplexify": "^3.6.0",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
-                    }
-                },
-                "punycode": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "qs": {
-                    "version": "6.5.2",
-                    "bundled": true
-                },
-                "querystringify": {
-                    "version": "2.1.0",
-                    "bundled": true
-                },
-                "queue": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "inherits": "~2.0.0"
-                    }
-                },
-                "randomatic": {
-                    "version": "3.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "is-number": "^4.0.0",
-                        "kind-of": "^6.0.0",
-                        "math-random": "^1.0.1"
-                    },
-                    "dependencies": {
-                        "is-number": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "regex-cache": {
-                    "version": "0.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "is-equal-shallow": "^0.1.3"
-                    }
-                },
-                "remove-bom-buffer": {
-                    "version": "3.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5",
-                        "is-utf8": "^0.2.1"
-                    }
-                },
-                "remove-bom-stream": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "remove-bom-buffer": "^3.0.0",
-                        "safe-buffer": "^5.1.0",
-                        "through2": "^2.0.3"
-                    }
-                },
-                "remove-trailing-separator": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "repeat-element": {
-                    "version": "1.1.3",
-                    "bundled": true
-                },
-                "repeat-string": {
-                    "version": "1.6.1",
-                    "bundled": true
-                },
-                "replace-ext": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "request": {
-                    "version": "2.88.0",
-                    "bundled": true,
-                    "requires": {
-                        "aws-sign2": "~0.7.0",
-                        "aws4": "^1.8.0",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.6",
-                        "extend": "~3.0.2",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.3.2",
-                        "har-validator": "~5.1.0",
-                        "http-signature": "~1.2.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.19",
-                        "oauth-sign": "~0.9.0",
-                        "performance-now": "^2.1.0",
-                        "qs": "~6.5.2",
-                        "safe-buffer": "^5.1.2",
-                        "tough-cookie": "~2.4.3",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.3.2"
-                    }
-                },
-                "requires-port": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "resolve": {
-                    "version": "1.8.1",
-                    "bundled": true,
-                    "requires": {
-                        "path-parse": "^1.0.5"
-                    }
-                },
-                "resolve-options": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "value-or-function": "^3.0.0"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.2",
-                    "bundled": true,
-                    "requires": {
-                        "glob": "^7.0.5"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "semver": {
-                    "version": "5.5.1",
-                    "bundled": true
-                },
-                "shebang-command": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "shebang-regex": "^1.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "bundled": true
-                },
-                "source-map-support": {
-                    "version": "0.5.9",
-                    "bundled": true,
-                    "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
-                    }
-                },
-                "split": {
-                    "version": "0.3.3",
-                    "bundled": true,
-                    "requires": {
-                        "through": "2"
-                    }
-                },
-                "sprintf-js": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "sshpk": {
-                    "version": "1.15.2",
-                    "bundled": true,
-                    "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "safer-buffer": "^2.0.2",
-                        "tweetnacl": "~0.14.0"
-                    }
-                },
-                "stat-mode": {
-                    "version": "0.2.2",
-                    "bundled": true
-                },
-                "stream-combiner": {
-                    "version": "0.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "duplexer": "~0.1.1"
-                    }
-                },
-                "stream-shift": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "streamfilter": {
-                    "version": "1.0.7",
-                    "bundled": true,
-                    "requires": {
-                        "readable-stream": "^2.0.2"
-                    }
-                },
-                "streamifier": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
-                },
-                "strip-bom-stream": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "strip-bom": "^2.0.0"
-                    }
-                },
-                "strip-eof": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "supports-color": {
-                    "version": "4.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "has-flag": "^2.0.0"
-                    }
-                },
-                "tar": {
-                    "version": "2.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "block-stream": "*",
-                        "fstream": "^1.0.2",
-                        "inherits": "2"
-                    }
-                },
-                "through": {
-                    "version": "2.3.8",
-                    "bundled": true
-                },
-                "through2": {
-                    "version": "2.0.5",
-                    "bundled": true,
-                    "requires": {
-                        "readable-stream": "~2.3.6",
-                        "xtend": "~4.0.1"
-                    }
-                },
-                "through2-filter": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "through2": "~2.0.0",
-                        "xtend": "~4.0.0"
-                    }
-                },
-                "to-absolute-glob": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "to-through": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "through2": "^2.0.3"
-                    }
-                },
-                "tough-cookie": {
-                    "version": "2.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
-                    },
-                    "dependencies": {
-                        "punycode": {
-                            "version": "1.4.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "tslib": {
-                    "version": "1.9.3",
-                    "bundled": true
-                },
-                "tslint": {
-                    "version": "5.11.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-code-frame": "^6.22.0",
-                        "builtin-modules": "^1.1.1",
-                        "chalk": "^2.3.0",
-                        "commander": "^2.12.1",
-                        "diff": "^3.2.0",
-                        "glob": "^7.1.1",
-                        "js-yaml": "^3.7.0",
-                        "minimatch": "^3.0.4",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.3.0",
-                        "tslib": "^1.8.0",
-                        "tsutils": "^2.27.2"
-                    },
-                    "dependencies": {
-                        "commander": {
-                            "version": "2.18.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "tsutils": {
-                    "version": "2.29.0",
-                    "bundled": true,
-                    "requires": {
-                        "tslib": "^1.8.1"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "^5.0.1"
-                    }
-                },
-                "tweetnacl": {
-                    "version": "0.14.5",
-                    "bundled": true
-                },
-                "typescript": {
-                    "version": "3.0.3",
-                    "bundled": true
-                },
-                "unc-path-regex": {
-                    "version": "0.1.2",
-                    "bundled": true
-                },
-                "unique-stream": {
-                    "version": "2.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "json-stable-stringify": "^1.0.0",
-                        "through2-filter": "^2.0.0"
-                    }
-                },
-                "uri-js": {
-                    "version": "4.2.2",
-                    "bundled": true,
-                    "requires": {
-                        "punycode": "^2.1.0"
-                    }
-                },
-                "url-parse": {
-                    "version": "1.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "querystringify": "^2.0.0",
-                        "requires-port": "^1.0.0"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "uuid": {
-                    "version": "3.3.2",
-                    "bundled": true
-                },
-                "vali-date": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "value-or-function": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "verror": {
-                    "version": "1.10.0",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "^1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "bundled": true,
-                    "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
-                    }
-                },
-                "vinyl-fs": {
-                    "version": "3.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "fs-mkdirp-stream": "^1.0.0",
-                        "glob-stream": "^6.1.0",
-                        "graceful-fs": "^4.0.0",
-                        "is-valid-glob": "^1.0.0",
-                        "lazystream": "^1.0.0",
-                        "lead": "^1.0.0",
-                        "object.assign": "^4.0.4",
-                        "pumpify": "^1.3.5",
-                        "readable-stream": "^2.3.3",
-                        "remove-bom-buffer": "^3.0.0",
-                        "remove-bom-stream": "^1.2.0",
-                        "resolve-options": "^1.1.0",
-                        "through2": "^2.0.0",
-                        "to-through": "^2.0.0",
-                        "value-or-function": "^3.0.0",
-                        "vinyl": "^2.0.0",
-                        "vinyl-sourcemap": "^1.1.0"
-                    },
-                    "dependencies": {
-                        "clone": {
-                            "version": "2.1.2",
-                            "bundled": true
-                        },
-                        "clone-stats": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "glob-stream": {
-                            "version": "6.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "extend": "^3.0.0",
-                                "glob": "^7.1.1",
-                                "glob-parent": "^3.1.0",
-                                "is-negated-glob": "^1.0.0",
-                                "ordered-read-streams": "^1.0.0",
-                                "pumpify": "^1.3.5",
-                                "readable-stream": "^2.1.5",
-                                "remove-trailing-separator": "^1.0.1",
-                                "to-absolute-glob": "^2.0.0",
-                                "unique-stream": "^2.0.2"
-                            }
-                        },
-                        "is-valid-glob": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "ordered-read-streams": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "readable-stream": "^2.0.1"
-                            }
-                        },
-                        "to-absolute-glob": {
-                            "version": "2.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-absolute": "^1.0.0",
-                                "is-negated-glob": "^1.0.0"
-                            }
-                        },
-                        "vinyl": {
-                            "version": "2.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "clone": "^2.1.1",
-                                "clone-buffer": "^1.0.0",
-                                "clone-stats": "^1.0.0",
-                                "cloneable-readable": "^1.0.0",
-                                "remove-trailing-separator": "^1.0.1",
-                                "replace-ext": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "vinyl-source-stream": {
-                    "version": "1.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "through2": "^2.0.3",
-                        "vinyl": "^0.4.3"
-                    }
-                },
-                "vinyl-sourcemap": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "append-buffer": "^1.0.2",
-                        "convert-source-map": "^1.5.0",
-                        "graceful-fs": "^4.1.6",
-                        "normalize-path": "^2.1.1",
-                        "now-and-later": "^2.0.0",
-                        "remove-bom-buffer": "^3.0.0",
-                        "vinyl": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "clone": {
-                            "version": "2.1.2",
-                            "bundled": true
-                        },
-                        "clone-stats": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "vinyl": {
-                            "version": "2.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "clone": "^2.1.1",
-                                "clone-buffer": "^1.0.0",
-                                "clone-stats": "^1.0.0",
-                                "cloneable-readable": "^1.0.0",
-                                "remove-trailing-separator": "^1.0.1",
-                                "replace-ext": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "vscode": {
-                    "version": "1.1.25",
-                    "bundled": true,
-                    "requires": {
-                        "glob": "^7.1.2",
-                        "gulp-chmod": "^2.0.0",
-                        "gulp-filter": "^5.0.1",
-                        "gulp-gunzip": "1.0.0",
-                        "gulp-remote-src-vscode": "^0.5.1",
-                        "gulp-symdest": "^1.1.1",
-                        "gulp-untar": "^0.0.7",
-                        "gulp-vinyl-zip": "^2.1.2",
-                        "mocha": "^4.0.1",
-                        "request": "^2.88.0",
-                        "semver": "^5.4.1",
-                        "source-map-support": "^0.5.0",
-                        "url-parse": "^1.4.3",
-                        "vinyl-fs": "^3.0.3",
-                        "vinyl-source-stream": "^1.1.0"
-                    }
-                },
-                "vscode-html-languageservice": {
-                    "version": "2.1.7",
-                    "bundled": true,
-                    "requires": {
-                        "vscode-languageserver-types": "^3.12.0",
-                        "vscode-nls": "^3.2.5",
-                        "vscode-uri": "^1.0.6"
-                    }
-                },
-                "vscode-jsonrpc": {
-                    "version": "4.0.0",
-                    "bundled": true
-                },
-                "vscode-languageclient": {
-                    "version": "5.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "semver": "^5.5.0",
-                        "vscode-languageserver-protocol": "3.13.0"
-                    }
-                },
-                "vscode-languageserver-protocol": {
-                    "version": "3.13.0",
-                    "bundled": true,
-                    "requires": {
-                        "vscode-jsonrpc": "^4.0.0",
-                        "vscode-languageserver-types": "3.13.0"
-                    }
-                },
-                "vscode-languageserver-types": {
-                    "version": "3.13.0",
-                    "bundled": true
-                },
-                "vscode-nls": {
-                    "version": "3.2.5",
-                    "bundled": true
-                },
-                "vscode-uri": {
-                    "version": "1.0.6",
-                    "bundled": true
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "bundled": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "xtend": {
-                    "version": "4.0.1",
-                    "bundled": true
-                },
-                "yallist": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "yauzl": {
-                    "version": "2.10.0",
-                    "bundled": true,
-                    "requires": {
-                        "buffer-crc32": "~0.2.3",
-                        "fd-slicer": "~1.1.0"
-                    }
-                },
-                "yazl": {
-                    "version": "2.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "buffer-crc32": "~0.2.3"
-                    }
-                }
+                "vscode-html-languageservice": "2.1.7",
+                "vscode-languageclient": "5.2.1"
             }
         },
         "mime-db": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+            "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
         },
         "mime-types": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "version": "2.1.22",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+            "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "~1.38.0"
             }
         },
         "minimatch": {
@@ -3296,68 +622,16 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
-        "multimatch": {
-            "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-            "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-            "requires": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
-            }
-        },
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
-        "node.extend": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
-            "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
-            "requires": {
-                "has": "^1.0.3",
-                "is": "^3.2.1"
-            }
-        },
-        "normalize-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "requires": {
-                "remove-trailing-separator": "^1.0.1"
-            }
-        },
-        "now-and-later": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
-            "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
-            "requires": {
-                "once": "^1.3.2"
-            }
-        },
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "object-keys": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
-        },
-        "object.assign": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-            "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
-            }
         },
         "once": {
             "version": "1.4.0",
@@ -3366,19 +640,6 @@
             "requires": {
                 "wrappy": "1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-            "requires": {
-                "readable-stream": "^2.0.1"
-            }
-        },
-        "path-dirname": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -3397,64 +658,15 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
-        "pause-stream": {
-            "version": "0.0.11",
-            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-            "requires": {
-                "through": "~2.3"
-            }
-        },
-        "pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
-        "plugin-error": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-            "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-            "requires": {
-                "ansi-cyan": "^0.1.1",
-                "ansi-red": "^0.1.1",
-                "arr-diff": "^1.0.1",
-                "arr-union": "^2.0.1",
-                "extend-shallow": "^1.1.2"
-            }
-        },
-        "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        },
         "psl": {
             "version": "1.1.31",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
-        },
-        "pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "pumpify": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-            "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -3467,60 +679,9 @@
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "querystringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-            "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
-        },
-        "queue": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
-            "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
-            "requires": {
-                "inherits": "~2.0.0"
-            }
-        },
-        "readable-stream": {
-            "version": "2.3.6",
-            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-            "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "remove-bom-buffer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
-            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-            "requires": {
-                "is-buffer": "^1.1.5",
-                "is-utf8": "^0.2.1"
-            }
-        },
-        "remove-bom-stream": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
-            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-            "requires": {
-                "remove-bom-buffer": "^3.0.0",
-                "safe-buffer": "^5.1.0",
-                "through2": "^2.0.3"
-            }
-        },
-        "remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-        },
-        "replace-ext": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
         },
         "request": {
             "version": "2.88.0",
@@ -3561,22 +722,6 @@
             "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
-            }
-        },
-        "resolve-options": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
-            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-            "requires": {
-                "value-or-function": "^3.0.0"
-            }
-        },
-        "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "requires": {
-                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -3623,14 +768,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "split": {
-            "version": "0.3.3",
-            "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
-            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-            "requires": {
-                "through": "2"
-            }
-        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3638,9 +775,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
-            "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -3651,45 +788,6 @@
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
-            }
-        },
-        "stat-mode": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
-        },
-        "stream-combiner": {
-            "version": "0.0.4",
-            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-            "requires": {
-                "duplexer": "~0.1.1"
-            }
-        },
-        "stream-shift": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-        },
-        "streamfilter": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
-            "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
-            "requires": {
-                "readable-stream": "^2.0.2"
-            }
-        },
-        "streamifier": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "requires": {
-                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -3707,56 +805,6 @@
             "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
             "requires": {
                 "has-flag": "^2.0.0"
-            }
-        },
-        "tar": {
-            "version": "2.2.1",
-            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-            }
-        },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-        },
-        "through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-            "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
-            }
-        },
-        "through2-filter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-            "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
-            }
-        },
-        "to-absolute-glob": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-            "requires": {
-                "is-absolute": "^1.0.0",
-                "is-negated-glob": "^1.0.0"
-            }
-        },
-        "to-through": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
-            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-            "requires": {
-                "through2": "^2.0.3"
             }
         },
         "tough-cookie": {
@@ -3861,20 +909,6 @@
             "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
             "dev": true
         },
-        "unc-path-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
-        },
-        "unique-stream": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
-            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-            "requires": {
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "through2-filter": "^3.0.0"
-            }
-        },
         "uri-js": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -3892,20 +926,10 @@
                 "requires-port": "^1.0.0"
             }
         },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
         "uuid": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        },
-        "value-or-function": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
         },
         "verror": {
             "version": "1.10.0",
@@ -3917,131 +941,27 @@
                 "extsprintf": "^1.2.0"
             }
         },
-        "vinyl": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-            "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-            "requires": {
-                "clone": "^0.2.0",
-                "clone-stats": "^0.0.1"
-            }
-        },
-        "vinyl-fs": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-            "requires": {
-                "fs-mkdirp-stream": "^1.0.0",
-                "glob-stream": "^6.1.0",
-                "graceful-fs": "^4.0.0",
-                "is-valid-glob": "^1.0.0",
-                "lazystream": "^1.0.0",
-                "lead": "^1.0.0",
-                "object.assign": "^4.0.4",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.3.3",
-                "remove-bom-buffer": "^3.0.0",
-                "remove-bom-stream": "^1.2.0",
-                "resolve-options": "^1.1.0",
-                "through2": "^2.0.0",
-                "to-through": "^2.0.0",
-                "value-or-function": "^3.0.0",
-                "vinyl": "^2.0.0",
-                "vinyl-sourcemap": "^1.1.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-                },
-                "vinyl": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-                    "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "vinyl-source-stream": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
-            "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
-            "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^0.4.3"
-            }
-        },
-        "vinyl-sourcemap": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-            "requires": {
-                "append-buffer": "^1.0.2",
-                "convert-source-map": "^1.5.0",
-                "graceful-fs": "^4.1.6",
-                "normalize-path": "^2.1.1",
-                "now-and-later": "^2.0.0",
-                "remove-bom-buffer": "^3.0.0",
-                "vinyl": "^2.0.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-                },
-                "vinyl": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-                    "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
-                    }
-                }
-            }
-        },
         "vscode": {
-            "version": "1.1.26",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.26.tgz",
-            "integrity": "sha512-z1Nf5J38gjUFbuDCbJHPN6OJ//5EG+e/yHlh6ERxj/U9B2Qc3aiHaFr38/fee/GGnxvRw/XegLMOG+UJwKi/Qg==",
+            "version": "1.1.33",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.33.tgz",
+            "integrity": "sha512-sXedp2oF6y4ZvqrrFiZpeMzaCLSWV+PpYkIxjG/iYquNZ9KrLL2LujltGxPLvzn49xu2sZkyC+avVNFgcJD1Iw==",
             "requires": {
                 "glob": "^7.1.2",
-                "gulp-chmod": "^2.0.0",
-                "gulp-filter": "^5.0.1",
-                "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.1",
-                "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.2",
                 "mocha": "^4.0.1",
                 "request": "^2.88.0",
                 "semver": "^5.4.1",
                 "source-map-support": "^0.5.0",
-                "url-parse": "^1.4.3",
-                "vinyl-fs": "^3.0.3",
-                "vinyl-source-stream": "^1.1.0"
+                "url-parse": "^1.4.4",
+                "vscode-test": "^0.1.4"
+            }
+        },
+        "vscode-test": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.1.5.tgz",
+            "integrity": "sha512-s+lbF1Dtasc0yXVB9iQTexBe2JK6HJAUJe3fWezHKIjq+xRw5ZwCMEMBaonFIPy7s95qg2HPTRDR5W4h4kbxGw==",
+            "requires": {
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1"
             }
         },
         "which": {
@@ -4057,28 +977,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        },
-        "yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-            "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
-            }
-        },
-        "yazl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-            "requires": {
-                "buffer-crc32": "~0.2.3"
-            }
         },
         "yn": {
             "version": "2.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         },
         "@types/node": {
             "version": "9.4.7",
-            "resolved": "http://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
             "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
             "dev": true
         },
@@ -103,7 +103,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -116,7 +116,7 @@
                 },
                 "supports-color": {
                     "version": "2.0.0",
-                    "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 }
@@ -166,9 +166,9 @@
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
@@ -498,9 +498,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+            "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -574,12 +574,12 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "requires": {
                 "minimist": "0.0.8"
@@ -643,7 +643,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
@@ -716,12 +716,21 @@
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "resolve": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
-            "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
             "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
             }
         },
         "safe-buffer": {
@@ -735,9 +744,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         },
         "shebang-command": {
             "version": "1.2.0",
@@ -760,9 +769,9 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+            "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -770,7 +779,7 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
@@ -792,7 +801,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -841,7 +850,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -854,9 +863,9 @@
             "dev": true
         },
         "tslint": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.0.tgz",
-            "integrity": "sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==",
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+            "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
             "dev": true,
             "requires": {
                 "babel-code-frame": "^6.22.0",
@@ -867,10 +876,11 @@
                 "glob": "^7.1.1",
                 "js-yaml": "^3.7.0",
                 "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
                 "resolve": "^1.3.2",
                 "semver": "^5.3.0",
                 "tslib": "^1.8.0",
-                "tsutils": "^2.27.2"
+                "tsutils": "^2.29.0"
             },
             "dependencies": {
                 "commander": {
@@ -904,9 +914,9 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "typescript": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-            "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+            "version": "3.3.4000",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+            "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
             "dev": true
         },
         "uri-js": {

--- a/client/package.json
+++ b/client/package.json
@@ -139,7 +139,8 @@
         "cross-env": "^5.2.0",
         "ts-node": "^7.0.1",
         "tslint": "^5.11.0",
-        "typescript": "2.6.1"
+        "typescript": "3.3.4000",
+        "rimraf": "2.6.3"
     },
     "dependencies": {
         "microsoft.aspnetcore.razor.vscode": "file:../src/Microsoft.AspNetCore.Razor.VSCode",

--- a/client/package.json
+++ b/client/package.json
@@ -2,12 +2,13 @@
     "name": "razor-vscode",
     "displayName": "Razor",
     "description": "Razor tooling support for VS Code",
+    "version": "0.0.1",
     "defaults": {
         "razor": "0.0.1"
     },
     "publisher": "ms-vscode",
     "engines": {
-        "vscode": "^1.25.0"
+        "vscode": "^1.31.0"
     },
     "categories": [
         "Other"
@@ -142,6 +143,6 @@
     },
     "dependencies": {
         "microsoft.aspnetcore.razor.vscode": "file:../src/Microsoft.AspNetCore.Razor.VSCode",
-        "vscode": "^1.1.22"
+        "vscode": "1.1.33"
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/package-lock.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-      "integrity": "sha1-D0yy3Hwd5glgVTV/cBeQQ8M+mJc=",
+      "version": "10.14.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==",
       "dev": true
     },
     "agent-base": {
@@ -98,7 +98,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -108,12 +108,6 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -135,7 +129,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -167,9 +161,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -185,12 +179,6 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -228,9 +216,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
     "concat-map": {
@@ -270,9 +258,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -377,7 +365,7 @@
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -420,9 +408,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "he": {
@@ -497,9 +485,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -560,7 +548,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -599,6 +587,18 @@
         "supports-color": "4.4.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+          "dev": true
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -611,6 +611,21 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -713,12 +728,21 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
@@ -734,9 +758,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -787,13 +811,10 @@
       }
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^2.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -820,9 +841,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+      "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -833,18 +854,11 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.18.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
-          "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
-          "dev": true
-        }
+        "tsutils": "^2.29.0"
       }
     },
     "tsutils": {
@@ -872,9 +886,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "version": "3.3.4000",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
     },
     "uri-js": {

--- a/src/Microsoft.AspNetCore.Razor.VSCode/package-lock.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/package-lock.json
@@ -4,46 +4,31 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/clipboardy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/clipboardy/-/clipboardy-1.1.0.tgz",
-      "integrity": "sha512-KOxf4ah9diZWmREM5jCupx2+pZaBPwKk5d5jeNK2+TY6IgEO35uhG55NnDT4cdXeRX8irDSHQPtdRrr0JOTQIw==",
-      "dev": true
-    },
     "@types/node": {
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
       "integrity": "sha1-D0yy3Hwd5glgVTV/cBeQQ8M+mJc=",
       "dev": true
     },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "ansi-cyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-      "dev": true,
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-red": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-      "dev": true,
-      "requires": {
-        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-regex": {
@@ -58,26 +43,6 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-      "dev": true
-    },
-    "append-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-      "dev": true,
-      "requires": {
-        "buffer-equal": "^1.0.0"
-      }
-    },
-    "arch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -86,67 +51,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "arr-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-      "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "^1.0.1",
-        "array-slice": "^0.2.3"
-      }
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
-    },
-    "arr-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
-      "dev": true
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
-    },
-    "array-slice": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-      "dev": true
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -228,15 +132,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -247,33 +142,10 @@
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
-      }
-    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
-    },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
-    },
-    "buffer-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
       "dev": true
     },
     "buffer-from": {
@@ -331,44 +203,6 @@
         }
       }
     },
-    "clipboardy": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-      "requires": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
-      }
-    },
-    "clone": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-      "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-      "dev": true
-    },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-      "dev": true
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-      "dev": true
-    },
-    "cloneable-readable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -405,30 +239,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -448,24 +263,6 @@
         "ms": "2.0.0"
       }
     },
-    "deep-assign": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
-      "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-      "dev": true,
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -478,24 +275,6 @@
       "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
       "dev": true
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
-    },
-    "duplexify": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -506,13 +285,19 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-string-regexp": {
@@ -533,84 +318,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
-    "execa": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "^0.1.0"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "^2.1.0"
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
-    },
-    "extend-shallow": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-      "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^1.1.0"
-      }
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^1.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        }
-      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -630,65 +342,6 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
-    "fill-range": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-      "dev": true,
-      "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "first-chunk-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-      "dev": true
-    },
-    "flush-write-stream": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
-      }
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "^1.0.1"
-      }
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -706,50 +359,11 @@
         "mime-types": "^2.1.12"
       }
     },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
-    },
-    "fs-mkdirp-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "through2": "^2.0.3"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
@@ -774,427 +388,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
-    "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dev": true,
-      "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "glob-stream": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-      "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-      "dev": true,
-      "requires": {
-        "extend": "^3.0.0",
-        "glob": "^5.0.3",
-        "glob-parent": "^3.0.0",
-        "micromatch": "^2.3.7",
-        "ordered-read-streams": "^0.3.0",
-        "through2": "^0.6.0",
-        "to-absolute-glob": "^0.1.1",
-        "unique-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
-    },
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
-    },
-    "gulp-chmod": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
-      "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
-      "dev": true,
-      "requires": {
-        "deep-assign": "^1.0.0",
-        "stat-mode": "^0.2.0",
-        "through2": "^2.0.0"
-      }
-    },
-    "gulp-filter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
-      "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
-      "dev": true,
-      "requires": {
-        "multimatch": "^2.0.0",
-        "plugin-error": "^0.1.2",
-        "streamfilter": "^1.0.5"
-      }
-    },
-    "gulp-gunzip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
-      "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
-      "dev": true,
-      "requires": {
-        "through2": "~0.6.5",
-        "vinyl": "~0.4.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
-    "gulp-remote-src-vscode": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
-      "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
-      "dev": true,
-      "requires": {
-        "event-stream": "3.3.4",
-        "node.extend": "^1.1.2",
-        "request": "^2.79.0",
-        "through2": "^2.0.3",
-        "vinyl": "^2.0.1"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "dev": true,
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        }
-      }
-    },
-    "gulp-sourcemaps": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-      "dev": true,
-      "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "dev": true
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        }
-      }
-    },
-    "gulp-symdest": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.1.tgz",
-      "integrity": "sha512-UHd3MokfIN7SrFdsbV5uZTwzBpL0ZSTu7iq98fuDqBGZ0dlHxgbQBJwfd6qjCW83snkQ3Hz9IY4sMRMz2iTq7w==",
-      "dev": true,
-      "requires": {
-        "event-stream": "3.3.4",
-        "mkdirp": "^0.5.1",
-        "queue": "^3.1.0",
-        "vinyl-fs": "^2.4.3"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "dev": true
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        },
-        "vinyl-fs": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-          "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
-            "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
-          }
-        }
-      }
-    },
-    "gulp-untar": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
-      "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
-      "dev": true,
-      "requires": {
-        "event-stream": "~3.3.4",
-        "streamifier": "~0.1.1",
-        "tar": "^2.2.1",
-        "through2": "~2.0.3",
-        "vinyl": "^1.2.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "dev": true
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        }
-      }
-    },
-    "gulp-vinyl-zip": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
-      "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
-      "dev": true,
-      "requires": {
-        "event-stream": "3.3.4",
-        "queue": "^4.2.1",
-        "through2": "^2.0.3",
-        "vinyl": "^2.0.2",
-        "vinyl-fs": "^3.0.3",
-        "yauzl": "^2.2.1",
-        "yazl": "^2.2.1"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
-        },
-        "queue": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
-          "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
-          "dev": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "dev": true,
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        }
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -1212,15 +410,6 @@
         "har-schema": "^2.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1236,17 +425,21 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1257,6 +450,16 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       }
     },
     "inflight": {
@@ -1275,174 +478,11 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "is": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
-      "dev": true
-    },
-    "is-absolute": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-      "dev": true,
-      "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.0"
-      }
-    },
-    "is-negated-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-      "dev": true
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "is-relative": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-      "dev": true,
-      "requires": {
-        "is-unc-path": "^1.0.0"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
-    },
-    "is-unc-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-      "dev": true,
-      "requires": {
-        "unc-path-regex": "^0.1.2"
-      }
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "is-valid-glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-      "dev": true
-    },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -1484,25 +524,10 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
@@ -1517,135 +542,19 @@
         "verror": "1.10.0"
       }
     },
-    "kind-of": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-      "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
-      "dev": true
-    },
-    "lazystream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.5"
-      }
-    },
-    "lead": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
-      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-      "dev": true,
-      "requires": {
-        "flush-write-stream": "^1.0.2"
-      }
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
-    },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
-    },
-    "merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "~1.38.0"
       }
     },
     "minimatch": {
@@ -1659,13 +568,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1712,93 +621,11 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
-      }
-    },
-    "node.extend": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
-      "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "is": "^3.2.1"
-      }
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
-    },
-    "now-and-later": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
-      "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.2"
-      }
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      }
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -1809,86 +636,16 @@
         "wrappy": "1"
       }
     },
-    "ordered-read-streams": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-      "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-      "dev": true,
-      "requires": {
-        "is-stream": "^1.0.1",
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "~2.3"
-      }
-    },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
@@ -1897,62 +654,11 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "plugin-error": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-      "dev": true,
-      "requires": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
-      }
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
-    },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-      "dev": true,
-      "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -1967,112 +673,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
-      "dev": true
-    },
-    "queue": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
-      "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
-    },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
-      }
-    },
-    "remove-bom-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
-      "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5",
-        "is-utf8": "^0.2.1"
-      }
-    },
-    "remove-bom-stream": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
-      "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-      "dev": true,
-      "requires": {
-        "remove-bom-buffer": "^3.0.0",
-        "safe-buffer": "^5.1.0",
-        "through2": "^2.0.3"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-      "dev": true
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
     },
     "request": {
@@ -2118,24 +721,6 @@
         "path-parse": "^1.0.5"
       }
     },
-    "resolve-options": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
-      "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-      "dev": true,
-      "requires": {
-        "value-or-function": "^3.0.0"
-      }
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.5"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -2149,27 +734,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha1-ff3YgUvbfKvHvg+x1zTPtmyUBHc="
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -2178,22 +745,13 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2"
       }
     },
     "sprintf-js": {
@@ -2203,9 +761,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -2219,51 +777,6 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "stat-mode": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-      "dev": true
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
-    },
-    "streamfilter": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
-      "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "streamifier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-      "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -2273,30 +786,6 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
-    "strip-bom-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-      "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-      "dev": true,
-      "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
-      }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
@@ -2304,72 +793,6 @@
       "dev": true,
       "requires": {
         "has-flag": "^2.0.0"
-      }
-    },
-    "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
-      }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "through2-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-      "dev": true,
-      "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
-      }
-    },
-    "to-absolute-glob": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "^2.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
-    "to-through": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
-      "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.3"
       }
     },
     "tough-cookie": {
@@ -2454,22 +877,6 @@
       "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
       "dev": true
     },
-    "unc-path-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-      "dev": true
-    },
-    "unique-stream": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-      "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-      "dev": true,
-      "requires": {
-        "json-stable-stringify": "^1.0.0",
-        "through2-filter": "^2.0.0"
-      }
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -2489,28 +896,10 @@
         "requires-port": "^1.0.0"
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
-    },
-    "vali-date": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-      "dev": true
-    },
-    "value-or-function": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
       "dev": true
     },
     "verror": {
@@ -2524,192 +913,25 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vinyl": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-      "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-      "dev": true,
-      "requires": {
-        "clone": "^0.2.0",
-        "clone-stats": "^0.0.1"
-      }
-    },
-    "vinyl-fs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-      "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-      "dev": true,
-      "requires": {
-        "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
-        "graceful-fs": "^4.0.0",
-        "is-valid-glob": "^1.0.0",
-        "lazystream": "^1.0.0",
-        "lead": "^1.0.0",
-        "object.assign": "^4.0.4",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.3.3",
-        "remove-bom-buffer": "^3.0.0",
-        "remove-bom-stream": "^1.2.0",
-        "resolve-options": "^1.1.0",
-        "through2": "^2.0.0",
-        "to-through": "^2.0.0",
-        "value-or-function": "^3.0.0",
-        "vinyl": "^2.0.0",
-        "vinyl-sourcemap": "^1.1.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
-        },
-        "glob-stream": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-          "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-          "dev": true,
-          "requires": {
-            "extend": "^3.0.0",
-            "glob": "^7.1.1",
-            "glob-parent": "^3.1.0",
-            "is-negated-glob": "^1.0.0",
-            "ordered-read-streams": "^1.0.0",
-            "pumpify": "^1.3.5",
-            "readable-stream": "^2.1.5",
-            "remove-trailing-separator": "^1.0.1",
-            "to-absolute-glob": "^2.0.0",
-            "unique-stream": "^2.0.2"
-          }
-        },
-        "is-valid-glob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-          "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-          "dev": true
-        },
-        "ordered-read-streams": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-          "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.0.1"
-          }
-        },
-        "to-absolute-glob": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-          "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-          "dev": true,
-          "requires": {
-            "is-absolute": "^1.0.0",
-            "is-negated-glob": "^1.0.0"
-          }
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "dev": true,
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        }
-      }
-    },
-    "vinyl-source-stream": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
-      "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.3",
-        "vinyl": "^0.4.3"
-      }
-    },
-    "vinyl-sourcemap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-      "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-      "dev": true,
-      "requires": {
-        "append-buffer": "^1.0.2",
-        "convert-source-map": "^1.5.0",
-        "graceful-fs": "^4.1.6",
-        "normalize-path": "^2.1.1",
-        "now-and-later": "^2.0.0",
-        "remove-bom-buffer": "^3.0.0",
-        "vinyl": "^2.0.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "dev": true,
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        }
-      }
-    },
     "vscode": {
-      "version": "1.1.25",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.25.tgz",
-      "integrity": "sha512-I3iA3CxyFcI/UqCYQT4ieTTIaMrA4pE4seZMJvio4yfrM3BzedXazHlHGISABkNcnjHdxorUX/mlJNFAqMT+4w==",
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.33.tgz",
+      "integrity": "sha512-sXedp2oF6y4ZvqrrFiZpeMzaCLSWV+PpYkIxjG/iYquNZ9KrLL2LujltGxPLvzn49xu2sZkyC+avVNFgcJD1Iw==",
       "dev": true,
       "requires": {
         "glob": "^7.1.2",
-        "gulp-chmod": "^2.0.0",
-        "gulp-filter": "^5.0.1",
-        "gulp-gunzip": "1.0.0",
-        "gulp-remote-src-vscode": "^0.5.1",
-        "gulp-symdest": "^1.1.1",
-        "gulp-untar": "^0.0.7",
-        "gulp-vinyl-zip": "^2.1.2",
         "mocha": "^4.0.1",
         "request": "^2.88.0",
         "semver": "^5.4.1",
         "source-map-support": "^0.5.0",
-        "url-parse": "^1.4.3",
-        "vinyl-fs": "^3.0.3",
-        "vinyl-source-stream": "^1.1.0"
+        "url-parse": "^1.4.4",
+        "vscode-test": "^0.1.4"
       }
     },
     "vscode-html-languageservice": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-2.1.7.tgz",
-      "integrity": "sha1-AXfAHwlG6kKq4QaLwLfvCeOVnao=",
+      "integrity": "sha512-nJBfu3vYR8R2DFaXK6x8SCrJ23zDGGhI30/BfvUSTCi1Zrklhtw6BEPTMoDkalMGL3AaMQYF2JV52w6LO4KgAw==",
       "requires": {
         "vscode-languageserver-types": "^3.12.0",
         "vscode-nls": "^3.2.5",
@@ -2719,84 +941,56 @@
     "vscode-jsonrpc": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha1-p7907zJU0KDCcvqxXIISjjeLO+k="
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
     },
     "vscode-languageclient": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.0.tgz",
-      "integrity": "sha1-ZQqw3J/Q2qreBYqEcar/W8P5WA4=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
+      "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
       "requires": {
         "semver": "^5.5.0",
-        "vscode-languageserver-protocol": "3.13.0"
+        "vscode-languageserver-protocol": "3.14.1"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
-      "integrity": "sha1-cQ2OQhGbs6/7FBbh4QS9a01QNZU=",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
+      "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
       "requires": {
         "vscode-jsonrpc": "^4.0.0",
-        "vscode-languageserver-types": "3.13.0"
+        "vscode-languageserver-types": "3.14.0"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-      "integrity": "sha1-twSwJM7wWfezJmEcmbnIdTwKGLQ="
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
     },
     "vscode-nls": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
-      "integrity": "sha1-JVIMGVUQgDbexgfIXgClIvJH8aQ="
+      "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+    },
+    "vscode-test": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.1.5.tgz",
+      "integrity": "sha512-s+lbF1Dtasc0yXVB9iQTexBe2JK6HJAUJe3fWezHKIjq+xRw5ZwCMEMBaonFIPy7s95qg2HPTRDR5W4h4kbxGw==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1"
+      }
     },
     "vscode-uri": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
-      "integrity": "sha1-a48UGwu8RK17B+lPgvForHYIrU0="
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3"
-      }
     }
   }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/package.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/package.json
@@ -8,8 +8,9 @@
   "devDependencies": {
     "@types/node": "^10.9.4",
     "tslint": "^5.11.0",
-    "typescript": "^3.0.3",
-    "vscode": "1.1.33"
+    "typescript": "3.3.4000",
+    "vscode": "1.1.33",
+    "rimraf": "2.6.3"
   },
   "dependencies": {
     "vscode-html-languageservice": "2.1.7",

--- a/src/Microsoft.AspNetCore.Razor.VSCode/package.json
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/package.json
@@ -1,26 +1,24 @@
 {
   "name": "microsoft.aspnetcore.razor.vscode",
   "version": "0.0.1",
-  "defaults":{
+  "defaults": {
     "razor": "0.0.1"
   },
   "description": "Implements parts of a VS Code extension for Razor language support.",
   "devDependencies": {
     "@types/node": "^10.9.4",
-    "@types/clipboardy": "1.1.0",
     "tslint": "^5.11.0",
     "typescript": "^3.0.3",
-    "vscode": "^1.1.22"
+    "vscode": "1.1.33"
   },
   "dependencies": {
-    "vscode-html-languageservice": "^2.1.7",
-    "vscode-languageclient": "^5.1.0",
-    "clipboardy": "1.2.3"
+    "vscode-html-languageservice": "2.1.7",
+    "vscode-languageclient": "5.2.1"
   },
   "main": "./dist/extension.js",
   "types": "./dist/extension.d.ts",
   "engines": {
-    "vscode": "^1.25.0"
+    "vscode": "^1.31.0"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as clipboardy from 'clipboardy';
 import * as vscode from 'vscode';
 import { Trace } from 'vscode-jsonrpc';
 import { RazorLogger } from '../RazorLogger';
@@ -67,7 +66,7 @@ export class ReportIssuePanel {
                         this.dataCollector = undefined;
                     }
 
-                    await clipboardy.write(this.issueContent);
+                    await vscode.env.clipboard.writeText(this.issueContent);
                     vscode.window.showInformationMessage('Razor issue copied to clipboard');
                     return;
                 case 'startIssue':


### PR DESCRIPTION
- Updated and pinned VSCode, html-languageservice and languageclient packages.
- Updated the vscode engine to match that of OmniSharp vscode (this is the required VSCode to install the extension).
- Add a `version` to `package.json`so local debugging doesn't result in an error window.

#279