### PR TITLE
Fix unsupported project configuration detection.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/FallbackConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/FallbackConfigurationProvider.cs
@@ -29,13 +29,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             foreach (var compilationReference in compilationReferences)
             {
                 var assemblyFullPath = compilationReference.EvaluatedInclude;
-                if (assemblyFullPath.EndsWith(MvcAssemblyFileName, StringComparison.OrdinalIgnoreCase))
+                if (assemblyFullPath.EndsWith(MvcAssemblyFileName, FilePathComparison.Instance))
                 {
-                    if (assemblyFullPath.Length == MvcAssemblyFileName.Length)
-                    {
-                        continue;
-                    }
-
                     var potentialPathSeparator = assemblyFullPath[assemblyFullPath.Length - MvcAssemblyFileName.Length - 1];
                     if (potentialPathSeparator == '/' || potentialPathSeparator == '\\')
                     {

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/SystemWebConfigurationProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/SystemWebConfigurationProviderTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
@@ -37,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public void TryResolveConfiguration_NoSystemWebRazorReference_ReturnsFalse()
         {
             // Arrange
-            var context = BuildContext("/some/path/to/some.dll");
+            var context = BuildContext("/some/path/to/System.Foo.Razor.dll");
             var provider = new SystemWebConfigurationProvider();
 
             // Act


### PR DESCRIPTION
- Not quite sure what happened here. The configuration provider was mangled in such a way that tests passed but didn't properly detect a legacy project.
- Before this we'd get a lot of false positives for what was an "unsupported" razor project, after this PR all of those cases will default to Razor's default configuration (Razor config 2.1). In a lot of cases.
- Back tracked the root cause of this mangledness and found that it was due to the chaotic times of shipping alpha 2 and me reacting to [this comment](https://github.com/aspnet/Razor.VSCode/pull/199#discussion_r225711374). Half did it somehow "worked enough".