### PR TITLE
Add language server understanding of Razor file kinds.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,17 +3,17 @@
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.7.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview4.19202.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview4.19202.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview4.19202.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview4.19170.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview4.19202.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>3.0.0-preview4.19155.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -9,6 +9,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
     public class FilePathNormalizer
     {
+        public string NormalizeDirectory(string directoryFilePath)
+        {
+            var normalized = Normalize(directoryFilePath);
+
+            if (!normalized.EndsWith("/"))
+            {
+                normalized += '/';
+            }
+
+            return normalized;
+        }
+
         public string Normalize(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/HostDocumentComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/HostDocumentComparer.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
+{
+    internal class HostDocumentComparer : IEqualityComparer<HostDocument>
+    {
+        public static readonly HostDocumentComparer Instance = new HostDocumentComparer();
+
+        private HostDocumentComparer()
+        {
+        }
+
+        public bool Equals(HostDocument x, HostDocument y)
+        {
+            if (x.FileKind != y.FileKind)
+            {
+                return false;
+            }
+
+            if (!FilePathComparer.Instance.Equals(x.FilePath, y.FilePath))
+            {
+                return false;
+            }
+
+            if (!FilePathComparer.Instance.Equals(x.TargetPath, y.TargetPath))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(HostDocument hostDocument)
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(hostDocument.FilePath, FilePathComparer.Instance);
+            combiner.Add(hostDocument.TargetPath, FilePathComparer.Instance);
+            combiner.Add(hostDocument.FileKind);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_3_0.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_3_0.cs
@@ -30,7 +30,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 initializer.Initialize(b);
                 configure?.Invoke(b);
 
-                b.Features.OfType<ComponentDocumentClassifierPass>().Single().MangleClassNames = true;
+                var componentDocumentClassifier = b.Features.OfType<ComponentDocumentClassifierPass>().FirstOrDefault();
+                if (componentDocumentClassifier != null)
+                {
+                    componentDocumentClassifier.MangleClassNames = true;
+                }
             });
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_Blazor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_Blazor.cs
@@ -20,8 +20,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 configure?.Invoke(b);
                 new BlazorExtensionInitializer().Initialize(b);
 
-                var classifier = b.Features.OfType<ComponentDocumentClassifierPass>().Single();
-                classifier.MangleClassNames = true;
+                var classifier = b.Features.OfType<ComponentDocumentClassifierPass>().FirstOrDefault();
+                if (classifier != null)
+                {
+                    classifier.MangleClassNames = true;
+                }
             });
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/DocumentSnapshotHandle.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/DocumentSnapshotHandle.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
+{
+    internal sealed class DocumentSnapshotHandle
+    {
+        public DocumentSnapshotHandle(
+            string filePath,
+            string targetPath,
+            string fileKind)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (targetPath == null)
+            {
+                throw new ArgumentNullException(nameof(targetPath));
+            }
+
+            if (fileKind == null)
+            {
+                throw new ArgumentNullException(nameof(fileKind));
+            }
+
+            FilePath = filePath;
+            TargetPath = targetPath;
+            FileKind = fileKind;
+        }
+
+        public string FilePath { get; }
+
+        public string TargetPath { get; }
+
+        public string FileKind { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandle.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandle.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -16,17 +17,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
             string filePath,
             RazorConfiguration configuration,
             string rootNamespace,
-            ProjectWorkspaceState projectWorkspaceState)
+            ProjectWorkspaceState projectWorkspaceState,
+            IReadOnlyList<DocumentSnapshotHandle> documents)
         {
             if (filePath == null)
             {
                 throw new ArgumentNullException(nameof(filePath));
             }
 
+            if (documents == null)
+            {
+                throw new ArgumentNullException(nameof(documents));
+            }
+
             FilePath = filePath;
             Configuration = configuration;
             RootNamespace = rootNamespace;
             ProjectWorkspaceState = projectWorkspaceState;
+            Documents = documents;
         }
 
         public string FilePath { get; }
@@ -36,5 +44,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
         public string RootNamespace { get; }
 
         public ProjectWorkspaceState ProjectWorkspaceState { get; }
+
+        public IReadOnlyList<DocumentSnapshotHandle> Documents { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandleJsonConverter.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/FullProjectSnapshotHandleJsonConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Newtonsoft.Json;
@@ -30,8 +31,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
             var configuration = obj[nameof(FullProjectSnapshotHandle.Configuration)].ToObject<RazorConfiguration>(serializer);
             var rootNamespace = obj[nameof(FullProjectSnapshotHandle.RootNamespace)].ToObject<string>(serializer);
             var projectWorkspaceState = obj[nameof(FullProjectSnapshotHandle.ProjectWorkspaceState)].ToObject<ProjectWorkspaceState>(serializer);
+            var documents = obj[nameof(FullProjectSnapshotHandle.Documents)].ToObject<DocumentSnapshotHandle[]>(serializer);
 
-            return new FullProjectSnapshotHandle(filePath, configuration, rootNamespace, projectWorkspaceState);
+            return new FullProjectSnapshotHandle(filePath, configuration, rootNamespace, projectWorkspaceState, documents);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -67,6 +69,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
 
             writer.WritePropertyName(nameof(FullProjectSnapshotHandle.RootNamespace));
             writer.WriteValue(handle.RootNamespace);
+
+            writer.WritePropertyName(nameof(FullProjectSnapshotHandle.Documents));
+            serializer.Serialize(writer, handle.Documents);
 
             writer.WriteEndObject();
         }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/ProjectSnapshotJsonConverter.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/ProjectSnapshotJsonConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Newtonsoft.Json;
 
@@ -28,7 +29,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var project = (ProjectSnapshot)value;
-            var handle = new FullProjectSnapshotHandle(project.FilePath, project.Configuration, project.RootNamespace, project.ProjectWorkspaceState);
+
+            var documents = new List<DocumentSnapshotHandle>();
+            foreach (var documentFilePath in project.DocumentFilePaths)
+            {
+                var document = project.GetDocument(documentFilePath);
+                var documentHandle = new DocumentSnapshotHandle(document.FilePath, document.TargetPath, document.FileKind);
+                documents.Add(documentHandle);
+            }
+
+            var handle = new FullProjectSnapshotHandle(project.FilePath, project.Configuration, project.RootNamespace, project.ProjectWorkspaceState, documents);
 
             FullProjectSnapshotHandleJsonConverter.Instance.WriteJson(writer, handle, serializer);
         }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/HostDocumentFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/HostDocumentFactory.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal abstract class HostDocumentFactory
     {
-        public abstract HostDocument Create(string documentFilePath, ProjectSnapshot projectSnapshot);
+        public abstract HostDocument Create(string filePath, string targetFilePath);
+
+        public abstract HostDocument Create(string filePath, string targetFilePath, string fileKind);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
             {
-                _logger.LogInformation($"Updating project '{filePath}' TagHelpers ({projectWorkspaceState.TagHelpers.Count}).");
+                _logger.LogInformation($"Updating project '{filePath}' TagHelpers ({projectWorkspaceState.TagHelpers.Count}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
             }
 
             _projectSnapshotManagerAccessor.Instance.ProjectWorkspaceStateChanged(project.FilePath, projectWorkspaceState);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
@@ -11,11 +12,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 {
     internal abstract class RazorProjectService
     {
-        public abstract void AddDocument(string filePath, TextLoader textLoader);
+        public abstract void AddDocument(string filePath);
 
         public abstract void OpenDocument(string filePath, SourceText sourceText, long version);
 
-        public abstract void CloseDocument(string filePath, TextLoader textLoader);
+        public abstract void CloseDocument(string filePath);
 
         public abstract void RemoveDocument(string filePath);
 
@@ -25,6 +26,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
         public abstract void RemoveProject(string filePath);
 
-        public abstract void UpdateProject(string filePath, RazorConfiguration configuration, string rootNamespace, ProjectWorkspaceState projectWorkspaceState);
+        public abstract void UpdateProject(
+            string filePath,
+            RazorConfiguration configuration,
+            string rootNamespace,
+            ProjectWorkspaceState projectWorkspaceState,
+            IReadOnlyList<DocumentSnapshotHandle> documents);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorUpdateProjectParams.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorUpdateProjectParams.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using OmniSharp.Extensions.Embedded.MediatR;
 
@@ -17,5 +18,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
         public string RootNamespace { get; set; }
 
         public ProjectWorkspaceState ProjectWorkspaceState { get; set; }
+
+        public DocumentSnapshotHandle[] Documents { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -24,13 +24,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly ILogger _logger;
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
-        private readonly RemoteTextLoaderFactory _remoteTextLoaderFactory;
         private readonly RazorProjectService _projectService;
 
         public RazorDocumentSynchronizationEndpoint(
             ForegroundDispatcher foregroundDispatcher,
             DocumentResolver documentResolver,
-            RemoteTextLoaderFactory remoteTextLoaderFactory,
             RazorProjectService projectService,
             ILoggerFactory loggerFactory)
         {
@@ -42,11 +40,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (documentResolver == null)
             {
                 throw new ArgumentNullException(nameof(documentResolver));
-            }
-
-            if (remoteTextLoaderFactory == null)
-            {
-                throw new ArgumentNullException(nameof(remoteTextLoaderFactory));
             }
 
             if (projectService == null)
@@ -61,7 +54,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _foregroundDispatcher = foregroundDispatcher;
             _documentResolver = documentResolver;
-            _remoteTextLoaderFactory = remoteTextLoaderFactory;
             _projectService = projectService;
             _logger = loggerFactory.CreateLogger<RazorDocumentSynchronizationEndpoint>();
         }
@@ -115,9 +107,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             _foregroundDispatcher.AssertBackgroundThread();
 
-            var textLoader = _remoteTextLoaderFactory.Create(notification.TextDocument.Uri.AbsolutePath);
             await Task.Factory.StartNew(
-                () => _projectService.CloseDocument(notification.TextDocument.Uri.AbsolutePath, textLoader),
+                () => _projectService.CloseDocument(notification.TextDocument.Uri.AbsolutePath),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 _foregroundDispatcher.ForegroundScheduler);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
@@ -9,11 +9,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class RemoteProjectItem : RazorProjectItem
     {
-        public RemoteProjectItem(string filePath, string physicalPath)
+        public RemoteProjectItem(string filePath, string physicalPath, string fileKind)
         {
             FilePath = filePath;
             PhysicalPath = physicalPath;
-
+            FileKind = fileKind ?? FileKinds.GetFileKindFromFilePath(FilePath);
             if (FilePath.StartsWith('/'))
             {
                 RelativePhysicalPath = FilePath.Substring(1);
@@ -29,6 +29,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public override string FilePath { get; }
 
         public override string PhysicalPath { get; }
+
+        public override string FileKind { get; }
 
         public override string RelativePhysicalPath { get; }
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
@@ -38,7 +38,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             throw new NotImplementedException();
         }
 
+        [Obsolete]
         public override RazorProjectItem GetItem(string path)
+        {
+            return GetItem(path, fileKind: null);
+        }
+
+        public override RazorProjectItem GetItem(string path, string fileKind)
         {
             if (path == null)
             {
@@ -49,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (FilePathRootedBy(physicalPath, _root))
             {
                 var filePath = physicalPath.Substring(_root.Length + 1 /* / */);
-                return new RemoteProjectItem(filePath, physicalPath);
+                return new RemoteProjectItem(filePath, physicalPath, fileKind);
             }
             else
             {
@@ -57,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 // In practice this should never happen, the systems above this should have routed the
                 // file request to the appropriate file system. Return something reasonable so a higher
                 // layer falls over to provide a better error.
-                return new RemoteProjectItem(physicalPath, physicalPath);
+                return new RemoteProjectItem(physicalPath, physicalPath, fileKind);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     public sealed class OmniSharpDocumentSnapshot
     {
         private readonly DocumentSnapshot _documentSnapshot;
+        private OmniSharpHostDocument _hostDocument;
 
         internal OmniSharpDocumentSnapshot(DocumentSnapshot documentSnapshot)
         {
@@ -18,6 +19,21 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             }
 
             _documentSnapshot = documentSnapshot;
+        }
+
+        public OmniSharpHostDocument HostDocument
+        {
+            get
+            {
+                if (_hostDocument == null)
+                {
+                    var defaultDocumentSnapshot = (DefaultDocumentSnapshot)_documentSnapshot;
+                    var hostDocument = defaultDocumentSnapshot.State.HostDocument;
+                    _hostDocument = new OmniSharpHostDocument(hostDocument.FilePath, hostDocument.TargetPath, hostDocument.FileKind);
+                }
+
+                return _hostDocument;
+            }
         }
 
         public string FileKind => _documentSnapshot.FileKind;

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocument.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocument.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
-    public sealed class OmniSharpHostDocument : IEquatable<OmniSharpHostDocument>
+    public sealed class OmniSharpHostDocument
     {
         public OmniSharpHostDocument(string filePath, string targetPath, string kind)
         {
@@ -20,30 +19,5 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public string FileKind => InternalHostDocument.FileKind;
 
         internal HostDocument InternalHostDocument { get; }
-
-        public bool Equals(OmniSharpHostDocument other)
-        {
-            if (FilePath != other.FilePath)
-            {
-                return false;
-            }
-
-            if (TargetPath != other.TargetPath)
-            {
-                return false;
-            }
-
-            if (FileKind != other.FileKind)
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        public override int GetHashCode()
-        {
-            return FilePath.GetHashCode();
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocumentComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocumentComparer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    public sealed class OmniSharpHostDocumentComparer : IEqualityComparer<OmniSharpHostDocument>
+    {
+        public static readonly OmniSharpHostDocumentComparer Instance = new OmniSharpHostDocumentComparer();
+
+        private OmniSharpHostDocumentComparer()
+        {
+        }
+
+        public bool Equals(OmniSharpHostDocument x, OmniSharpHostDocument y) => 
+            HostDocumentComparer.Instance.Equals(x.InternalHostDocument, y.InternalHostDocument);
+
+        public int GetHashCode(OmniSharpHostDocument hostDocument) => 
+            HostDocumentComparer.Instance.GetHashCode(hostDocument.InternalHostDocument);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpProjectChangeEventArgs.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpProjectChangeEventArgs.cs
@@ -41,5 +41,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public string DocumentFilePath { get; }
 
         public OmniSharpProjectChangeKind Kind { get; }
+
+        public static OmniSharpProjectChangeEventArgs CreateTestInstance(OmniSharpProjectSnapshot older, OmniSharpProjectSnapshot newer, OmniSharpProjectChangeKind kind) =>
+            new OmniSharpProjectChangeEventArgs(older, newer, kind);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed.Serialization;
@@ -185,7 +184,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             if (!_pendingProjectPublishes.TryGetValue(projectFilePath, out var projectSnapshot))
             {
                 // Project was removed while waiting for the publish delay.
-                Debug.Assert(!_pendingProjectPublishes.ContainsKey(projectFilePath));
                 return;
             }
 

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectInstanceEvaluator.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectInstanceEvaluator.cs
@@ -37,7 +37,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         private static readonly IEnumerable<ILogger> EmptyMSBuildLoggers = Enumerable.Empty<ILogger>();
         private readonly OmniSharpForegroundDispatcher _foregroundDispatcher;
         private readonly object _evaluationLock = new object();
-        private ProjectCollection _projectCollection;
 
         [ImportingConstructor]
         public DefaultProjectInstanceEvaluator(OmniSharpForegroundDispatcher foregroundDispatcher)
@@ -80,13 +79,9 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
                 if (refreshTargets.Count > 2)
                 {
-                    EnsureProjectCollection(projectInstance.GlobalProperties);
-
+                    var _projectCollection = new ProjectCollection(projectInstance.GlobalProperties);
                     var project = _projectCollection.LoadProject(projectInstance.ProjectFileLocation.File, projectInstance.ToolsVersion);
                     SetTargetFrameworkIfNeeded(project);
-
-                    // Force re-evaluation of project inputs so the Razor re-compile below doesn't no-op.
-                    project.MarkDirty();
 
                     var refreshedProjectInstance = project.CreateProjectInstance();
 
@@ -97,14 +92,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 }
 
                 return projectInstance;
-            }
-        }
-
-        private void EnsureProjectCollection(IDictionary<string, string> globalProperties)
-        {
-            if (_projectCollection == null)
-            {
-                _projectCollection = new ProjectCollection(globalProperties);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
@@ -119,7 +119,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 {
                     var filePath = item.EvaluatedInclude;
                     var targetPath = item.GetMetadataValue(RazorTargetPathMetadataName);
-                    var hostDocument = new OmniSharpHostDocument(filePath, targetPath, FileKinds.Component);
+                    var fileKind = FileKinds.GetComponentFileKindFromFilePath(filePath);
+                    var hostDocument = new OmniSharpHostDocument(filePath, targetPath, fileKind);
                     hostDocuments.Add(hostDocument);
                 }
             }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectDocumentChangeDetector.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectDocumentChangeDetector.cs
@@ -85,6 +85,12 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 documentWatcher.Created += (sender, args) => FileSystemWatcher_RazorDocumentEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Added);
                 documentWatcher.Deleted += (sender, args) => FileSystemWatcher_RazorDocumentEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Removed);
                 documentWatcher.Changed += (sender, args) => FileSystemWatcher_RazorDocumentEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Changed);
+                documentWatcher.Renamed += (sender, args) =>
+                {
+                    // Translate file renames into remove->add
+                    FileSystemWatcher_RazorDocumentEvent(args.OldFullPath, projectDirectory, projectInstance, RazorFileChangeKind.Removed);
+                    FileSystemWatcher_RazorDocumentEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Added);
+                };
                 watchers.Add(documentWatcher);
 
 
@@ -97,6 +103,12 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 documentOutputWatcher.Created += (sender, args) => FileSystemWatcher_RazorDocumentOutputEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Added);
                 documentOutputWatcher.Deleted += (sender, args) => FileSystemWatcher_RazorDocumentOutputEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Removed);
                 documentOutputWatcher.Changed += (sender, args) => FileSystemWatcher_RazorDocumentOutputEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Changed);
+                documentOutputWatcher.Renamed += (sender, args) =>
+                {
+                    // Translate file renames into remove->add
+                    FileSystemWatcher_RazorDocumentOutputEvent(args.OldFullPath, projectDirectory, projectInstance, RazorFileChangeKind.Removed);
+                    FileSystemWatcher_RazorDocumentOutputEvent(args.FullPath, projectDirectory, projectInstance, RazorFileChangeKind.Added);
+                };
                 watchers.Add(documentOutputWatcher);
 
                 documentWatcher.EnableRaisingEvents = true;

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
@@ -199,22 +199,22 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             foreach (var documentFilePath in projectSnapshot.DocumentFilePaths)
             {
                 OmniSharpHostDocument associatedHostDocument = null;
+                var currentHostDocument = projectSnapshot.GetDocument(documentFilePath).HostDocument;
 
                 for (var i = 0; i < configuredHostDocuments.Count; i++)
                 {
-                    var hostDocument = configuredHostDocuments[i];
-                    if (FilePathComparer.Instance.Equals(hostDocument.FilePath, documentFilePath))
+                    var configuredHostDocument = configuredHostDocuments[i];
+                    if (OmniSharpHostDocumentComparer.Instance.Equals(configuredHostDocument, currentHostDocument))
                     {
-                        associatedHostDocument = hostDocument;
+                        associatedHostDocument = configuredHostDocument;
+                        break;
                     }
                 }
 
                 if (associatedHostDocument == null)
                 {
                     // Document was removed
-                    var removedDocumentSnapshot = projectSnapshot.GetDocument(documentFilePath);
-                    var removedHostDocument = new OmniSharpHostDocument(removedDocumentSnapshot.FilePath, removedDocumentSnapshot.TargetPath, removedDocumentSnapshot.FileKind);
-                    _projectManager.DocumentRemoved(hostProject, removedHostDocument);
+                    _projectManager.DocumentRemoved(hostProject, currentHostDocument);
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using OmniSharp;
+using OmniSharp.MSBuild.Notification;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    // This entire class is a temporary work around for https://github.com/OmniSharp/omnisharp-roslyn/issues/1443.
+    // We hack together a heuristic to detect when Razor documents that shouldn't be added to the workspace are and to then
+    // remove them from the workspace. In the primary case we're watching for pre-compiled Razor files that are generated
+    // from calling dotnet build and removing them from the workspace once they're added.
+
+    [Shared]
+    [Export(typeof(IMSBuildEventSink))]
+    public class PrecompiledRazorPageSuppressor : IMSBuildEventSink
+    {
+        private readonly OmniSharpWorkspace _workspace;
+
+        [ImportingConstructor]
+        public PrecompiledRazorPageSuppressor(OmniSharpWorkspace workspace)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _workspace = workspace;
+
+            _workspace.WorkspaceChanged += Workspace_WorkspaceChanged;
+        }
+
+        private void Workspace_WorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
+        {
+            switch (args.Kind)
+            {
+                case WorkspaceChangeKind.DocumentAdded:
+                case WorkspaceChangeKind.DocumentChanged:
+                    var project = args.NewSolution.GetProject(args.ProjectId);
+                    var document = project.GetDocument(args.DocumentId);
+
+                    if (document.FilePath == null)
+                    {
+                        break;
+                    }
+
+                    if (document.FilePath.EndsWith(".RazorTargetAssemblyInfo.cs", StringComparison.Ordinal))
+                    {
+                        // Razor declaration assembly info. This doesn't catch cases when users have customized their target assembly info but captures all of the
+                        // default cases for now. Once the omnisharp-roslyn bug has been fixed this entire class can go awy so we're hacking for now.
+                        _workspace.RemoveDocument(document.Id);
+                        break;
+                    }
+
+                    if (!document.FilePath.EndsWith(".cshtml.g.cs", StringComparison.Ordinal) && !document.FilePath.EndsWith(".razor.g.cs", StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+
+                    if (!document.FilePath.Contains("RazorDeclaration"))
+                    {
+                        // Razor output file that is not a declaration file.
+                        _workspace.RemoveDocument(document.Id);
+                        break;
+                    }
+
+                    break;
+            }
+        }
+
+        public void ProjectLoaded(ProjectLoadedEventArgs e)
+        {
+            // We don't do anything on project load we're just using the IMSBuildEventSink to ensure we're instantiated.
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorProjectConfiguration.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorProjectConfiguration.ts
@@ -14,4 +14,5 @@ export interface IRazorProjectConfiguration {
     readonly rootNamespace: string;
     readonly projectWorkspaceState: any;
     readonly lastUpdated: Date;
+    readonly documents: any;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
@@ -8,4 +8,5 @@ export interface UpdateProjectRequest {
     readonly configuration?: any;
     readonly rootNamespace?: string;
     readonly projectWorkspaceState?: any;
+    readonly documents?: any;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -189,7 +189,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         if (!projectedDocument.hostDocumentSyncVersion ||
             projectedDocument.hostDocumentSyncVersion <= updateBufferRequest.hostDocumentVersion) {
             // We allow re-setting of the updated content from the same doc sync version in the case
-            // of project or _ViewImports.cshtml changes.
+            // of project or file import changes.
             const csharpProjectedDocument = projectedDocument as CSharpProjectedDocument;
             csharpProjectedDocument.update(updateBufferRequest.changes, updateBufferRequest.hostDocumentVersion);
 

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -64,6 +64,7 @@ export class RazorLanguageServiceClient {
             projectWorkspaceState: project.configuration ? project.configuration.projectWorkspaceState : null,
             configuration: project.configuration ? project.configuration.configuration : undefined,
             rootNamespace: project.configuration ? project.configuration.rootNamespace : undefined,
+            documents: project.configuration ? project.configuration.documents : undefined,
         };
         await this.serverClient.sendRequest<UpdateProjectRequest>('projects/updateProject', request);
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
@@ -180,6 +180,7 @@ export class RazorProjectManager {
                 configuration: projectHandle.Configuration,
                 rootNamespace: projectHandle.RootNamespace,
                 projectWorkspaceState: projectHandle.ProjectWorkspaceState,
+                documents: projectHandle.Documents,
                 lastUpdated,
             };
             return configuration;

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -8,6 +8,34 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     public class FilePathNormalizerTest
     {
         [Fact]
+        public void NormalizeDirectory_EndsWithSlash()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var directory = "\\path\\to\\directory\\";
+
+            // Act
+            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+
+            // Assert
+            Assert.Equal("/path/to/directory/", normalized);
+        }
+
+        [Fact]
+        public void NormalizeDirectory_EndsWithoutSlash()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var directory = "\\path\\to\\directory";
+
+            // Act
+            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+
+            // Assert
+            Assert.Equal("/path/to/directory/", normalized);
+        }
+
+        [Fact]
         public void FilePathsEquivalent_NotEqualPaths_ReturnsFalse()
         {
             // Arrange
@@ -21,6 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             // Assert
             Assert.False(result);
         }
+
         [Fact]
         public void FilePathsEquivalent_NormalizesPathsBeforeComparison_ReturnsTrue()
         {

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Newtonsoft.Json;
 using Xunit;
@@ -25,7 +25,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             ProjectWorkspaceState = new ProjectWorkspaceState(new[]
             {
                 TagHelperDescriptorBuilder.Create("Test", "TestAssembly").Build(),
-            });
+            },
+            LanguageVersion.LatestMajor);
             var converterCollection = new JsonConverterCollection();
             converterCollection.RegisterRazorConverters();
             Converters = converterCollection.ToArray();

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             Assert.Equal(handle.Configuration, deserializedHandle.Configuration);
             Assert.Equal(handle.RootNamespace, deserializedHandle.RootNamespace);
             Assert.Equal(handle.ProjectWorkspaceState, deserializedHandle.ProjectWorkspaceState);
-            Assert.Collection(handle.Documents,
+            Assert.Collection(handle.Documents.OrderBy(doc => doc.FilePath),
                 document =>
                 {
                     Assert.Equal(legacyDocument.FilePath, document.FilePath);
@@ -82,8 +82,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 "/path/to/project.csproj",
                 new[]
                 {
-                    "/path/to/file.cshtml",
                     "/path/to/component.razor",
+                    "/path/to/file.cshtml",
                 },
                 Configuration,
                 ProjectWorkspaceState);
@@ -96,9 +96,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             Assert.Equal(projectSnapshot.FilePath, deserializedHandle.FilePath);
             Assert.Equal(projectSnapshot.Configuration, deserializedHandle.Configuration);
             Assert.Equal(projectSnapshot.ProjectWorkspaceState, deserializedHandle.ProjectWorkspaceState);
-            Assert.Collection(deserializedHandle.Documents,
-                document => Assert.Equal("/path/to/file.cshtml", document.FilePath),
-                document => Assert.Equal("/path/to/component.razor", document.FilePath));
+            Assert.Collection(deserializedHandle.Documents.OrderBy(doc => doc.FilePath),
+                document => Assert.Equal("/path/to/component.razor", document.FilePath),
+                document => Assert.Equal("/path/to/file.cshtml", document.FilePath));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
@@ -25,27 +25,36 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private DefaultHostDocumentFactory Factory { get; }
 
         [Fact]
-        public void Create_GeneratesProjectRelativeHostDocument()
+        public void Create_NoFileKind_CreatesHostDocumentProperly()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/file.cshtml";
-            var relativeDocumentFilePath = "file.cshtml";
-            var projectItem = Mock.Of<RazorProjectItem>(
-                pi => pi.PhysicalPath == documentFilePath && pi.FilePath == relativeDocumentFilePath);
-            var fileSystem = new Mock<RazorProjectFileSystem>();
-            fileSystem.Setup(fs => fs.GetItem(documentFilePath))
-                .Returns(projectItem);
-            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem.Object);
-            var projectSnapshot = new Mock<ProjectSnapshot>();
-            projectSnapshot.Setup(project => project.GetProjectEngine())
-                .Returns(projectEngine);
+            var filePath = "/path/to/file.razor";
+            var targetPath = "file.razor";
 
             // Act
-            var hostDocument = Factory.Create(documentFilePath, projectSnapshot.Object);
+            var hostDocument = Factory.Create(filePath, targetPath);
 
             // Assert
-            Assert.Equal(documentFilePath, hostDocument.FilePath);
-            Assert.Equal(relativeDocumentFilePath, hostDocument.TargetPath);
+            Assert.Equal(filePath, hostDocument.FilePath);
+            Assert.Equal(targetPath, hostDocument.TargetPath);
+            Assert.Equal(FileKinds.Component, hostDocument.FileKind);
+        }
+
+        [Fact]
+        public void Create_WithFileKind_CreatesHostDocumentProperly()
+        {
+            // Arrange
+            var filePath = "/path/to/file.cshtml";
+            var targetPath = "file.cshtml";
+            var fileKind = FileKinds.Component;
+
+            // Act
+            var hostDocument = Factory.Create(filePath, targetPath, fileKind);
+
+            // Assert
+            Assert.Equal(filePath, hostDocument.FilePath);
+            Assert.Equal(targetPath, hostDocument.TargetPath);
+            Assert.Equal(fileKind, hostDocument.FileKind);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentSynchronizationEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentSynchronizationEndpointTest.cs
@@ -21,13 +21,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         private RazorProjectService ProjectService => Mock.Of<RazorProjectService>();
 
-        private RemoteTextLoaderFactory TextLoaderFactory => Mock.Of<RemoteTextLoaderFactory>(factory => factory.Create(It.IsAny<string>()) == Mock.Of<TextLoader>());
-
         [Fact]
         public void ApplyContentChanges_SingleChange()
         {
             // Arrange
-            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, TextLoaderFactory, ProjectService, LoggerFactory);
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, ProjectService, LoggerFactory);
             var sourceText = SourceText.From("Hello World");
             var change = new TextDocumentContentChangeEvent()
             {
@@ -48,7 +46,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ApplyContentChanges_MultipleChanges()
         {
             // Arrange
-            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, TextLoaderFactory, ProjectService, LoggerFactory);
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, ProjectService, LoggerFactory);
             var sourceText = SourceText.From("Hello World");
             var changes = new[] {
                 new TextDocumentContentChangeEvent()
@@ -107,7 +105,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Assert.Equal(documentPath, path);
                     Assert.Equal(1337, version);
                 });
-            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, documentResolver, TextLoaderFactory, projectService.Object, LoggerFactory);
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, documentResolver, projectService.Object, LoggerFactory);
             var change = new TextDocumentContentChangeEvent()
             {
                 Range = new Range(new Position(0, 3), new Position(0, 3)),
@@ -146,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Assert.Equal(documentPath, path);
                     Assert.Equal(1337, version);
                 });
-            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, TextLoaderFactory, projectService.Object, LoggerFactory);
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, projectService.Object, LoggerFactory);
             var request = new DidOpenTextDocumentParams()
             {
                 TextDocument = new TextDocumentItem()
@@ -171,13 +169,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = "C:/path/to/document.cshtml";
             var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
-            projectService.Setup(service => service.CloseDocument(It.IsAny<string>(), It.IsAny<TextLoader>()))
-                .Callback<string, TextLoader>((path, loader) =>
+            projectService.Setup(service => service.CloseDocument(It.IsAny<string>()))
+                .Callback<string>((path) =>
                 {
                     Assert.Equal(documentPath, path);
-                    Assert.NotNull(loader);
                 });
-            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, TextLoaderFactory, projectService.Object, LoggerFactory);
+            var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, projectService.Object, LoggerFactory);
             var request = new DidCloseTextDocumentParams()
             {
                 TextDocument = new TextDocumentIdentifier()

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentFilePath = "file.cshtml";
 
             // Act
-            var item = fileSystem.GetItem(documentFilePath);
+            var item = fileSystem.GetItem(documentFilePath, fileKind: null);
 
             // Assert
             Assert.Equal(documentFilePath, item.FilePath);
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentFilePath = "/C:/path/to/file.cshtml";
 
             // Act
-            var item = fileSystem.GetItem(documentFilePath);
+            var item = fileSystem.GetItem(documentFilePath, fileKind: null);
 
             // Assert
             Assert.Equal("file.cshtml", item.FilePath);
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentFilePath = "/C:/otherpath/to/file.cshtml";
 
             // Act
-            var item = fileSystem.GetItem(documentFilePath);
+            var item = fileSystem.GetItem(documentFilePath, fileKind: null);
 
             // Assert
             Assert.Equal(documentFilePath, item.FilePath);

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     public class OmniSharpTestBase : TestBase
     {
         private readonly MethodInfo _createTestProjectSnapshotMethod;
+        private readonly MethodInfo _createWithDocumentsTestProjectSnapshotMethod;
         private readonly MethodInfo _createProjectSnapshotManagerMethod;
         private readonly PropertyInfo _allowNotifyListenersProperty;
         private readonly PropertyInfo _dispatcherProperty;
@@ -28,6 +29,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var defaultSnapshotManagerType = strongNamedAssembly.GetType("Microsoft.AspNetCore.Razor.OmniSharpPlugin.DefaultOmniSharpProjectSnapshotManager");
 
             _createTestProjectSnapshotMethod = testProjectSnapshotType.GetMethod("Create", new[] { typeof(string) });
+            _createWithDocumentsTestProjectSnapshotMethod = testProjectSnapshotType.GetMethod("Create", new[] { typeof(string), typeof(string[]) });
             _createProjectSnapshotManagerMethod = testProjectSnapshotManagerType.GetMethod("Create");
             _allowNotifyListenersProperty = testProjectSnapshotManagerType.GetProperty("AllowNotifyListeners");
             _dispatcherProperty = typeof(OmniSharpForegroundDispatcher).GetProperty("InternalDispatcher", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -42,6 +44,14 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         protected OmniSharpProjectSnapshot CreateProjectSnapshot(string projectFilePath)
         {
             var projectSnapshot = _createTestProjectSnapshotMethod.Invoke(null, new[] { projectFilePath });
+            var omniSharpProjectSnapshot = (OmniSharpProjectSnapshot)_omniSharpSnapshotConstructor.Invoke(new[] { projectSnapshot });
+
+            return omniSharpProjectSnapshot;
+        }
+
+        protected OmniSharpProjectSnapshot CreateProjectSnapshot(string projectFilePath, string[] documentFilePaths)
+        {
+            var projectSnapshot = _createWithDocumentsTestProjectSnapshotMethod.Invoke(null, new object[] { projectFilePath, documentFilePaths });
             var omniSharpProjectSnapshot = (OmniSharpProjectSnapshot)_omniSharpSnapshotConstructor.Invoke(new[] { projectSnapshot });
 
             return omniSharpProjectSnapshot;


### PR DESCRIPTION
- Added a `HostDocumentComparer` that is used in the language server and on the plugin side of the world. It enables us to look at two host documents who have identical paths and then tell them apart (usually because of FileKind differences).
- Added a `DocumentSnapshotHandle` to represent the serialized form of a `DocumentSnapshot`. During `ProjectSnapshot` serialization we translate all of the snapshots documents into handles now.
- Updated the host document factory to take in target path and file kinds. This way we generate proper `HostDocument`s to be used in the project system. Part of this work was to remove the hack that we were doing in the host document factory of creating a project engine and then asking its file system for relative paths. We now compute this in a cross-platform friendly way inside of the `DefaultRazorProjectService`.
- Updated the `RazorProjectService` APIs to no longer take `TextLoader`s. This was important because now that the project service is responsible for updating documents when a project updates it needs to be able to create TextLoaders as well. In the end it was a positive change because we could take all of the `TextLoader` factory usages from other classes and group them into the project service. This ended up revealing a bug in `AddDocument` where we wouldn't properly create a document with a valid `TextLoader`.
- Updated the OmniSharp plugin to lift document kinds into the serialization layer. This involved making the plugin smarter to understand when documents change, prior to this it only knew when they were added or removed. Because we now listen more intently to documents and can indirectly cause project file updates we need ed to batch our project file publishing so we didn't result in a new .json file publish for every .cshtml/.razor file in a project.
- Found that renames weren't being properly listened to on the plugin side of the world. Updated the `MSBuildProjectDocumentChangeDetector` to properly listen to renames and translate them into remove->adds.
- Found a bug in how we evaluated project files where if you were to add `<_RazorComponentInclude>Components\**\*.cshtml</_RazorComponentInclude>` to your project file it wouldn't properly be picked up because the primary project file would change and our way of representing that via ProjectCollection transitively cached the project output. We now more closely follow what OmniSharp does and every time we want to evaluate a project we create a new project collection.
- Updated the extension to pass along document information for a project.
- Updated existing tests to respect new APIs
- Added new tests to cover new APIs.

#312