### PR TITLE
Make project configuration parsing more resilient to alpha2 skews.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
@@ -160,6 +160,16 @@ export class RazorProjectManager {
             const projectJson = fs.readFileSync(fileSystemPath, 'utf8');
             const lastUpdated = fs.statSync(fileSystemPath).mtime;
             const projectHandle = JSON.parse(projectJson);
+            if (projectHandle.ProjectWorkspaceState === undefined) {
+                // ProjectWorkspaceState was added in the alpha3 release, if the parsed file doesn't contain this entry
+                // then it's an old-school project configuration file (unsupported). Wait for the OmniSharp side of the
+                // world to generate a new project configuration file.
+                //
+                // Eventually this work won't be needed. Once we 1.0 we'll add a protocol version to the configuration
+                // file and parse it correctly depending on its protocol.
+                return undefined;
+            }
+
             const projectUri = vscode.Uri.file(projectHandle.FilePath);
             const projectFilePath = getUriPath(projectUri);
             const configuration: IRazorProjectConfiguration = {


### PR DESCRIPTION
- When users update their OmniSharp extensions they'll run into cases where Razor will attempt to parse their project files and fail because of the different format. To combat this I added a simple check to differentiate between alpha2 and alpha3 project files. This is mostly temporary because once we 1.0 we'll do the work to maintain every future skew based on some protocol version. For now we don't want to do the work to support every skew, we'll just ignore the files that don't conform to what we know and wait for our plugin to generate a fresh up-to-date one.

#333