### PR TITLE
Update Razor to include _Imports.razor @using components and C# 8 changes.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,17 +3,17 @@
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBlazorExtensionsPackageVersion>0.7.0</MicrosoftAspNetCoreBlazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview4.19170.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview4.19202.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview4.19202.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview4.19202.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview4.19170.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview4.19202.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>3.0.0-preview4.19155.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -8,6 +8,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
     public sealed class FilePathNormalizer
     {
+        public string NormalizeDirectory(string directoryFilePath)
+        {
+            var normalized = Normalize(directoryFilePath);
+
+            if (!normalized.EndsWith("/"))
+            {
+                normalized += '/';
+            }
+
+            return normalized;
+        }
+
         public string Normalize(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_3_0.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_3_0.cs
@@ -30,7 +30,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 initializer.Initialize(b);
                 configure?.Invoke(b);
 
-                b.Features.OfType<ComponentDocumentClassifierPass>().Single().MangleClassNames = true;
+                var componentDocumentClassifier = b.Features.OfType<ComponentDocumentClassifierPass>().FirstOrDefault();
+                if (componentDocumentClassifier != null)
+                {
+                    componentDocumentClassifier.MangleClassNames = true;
+                }
             });
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_Blazor.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactory_Blazor.cs
@@ -20,8 +20,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 configure?.Invoke(b);
                 new BlazorExtensionInitializer().Initialize(b);
 
-                var classifier = b.Features.OfType<ComponentDocumentClassifierPass>().Single();
-                classifier.MangleClassNames = true;
+                var classifier = b.Features.OfType<ComponentDocumentClassifierPass>().FirstOrDefault();
+                if (classifier != null)
+                {
+                    classifier.MangleClassNames = true;
+                }
             });
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
             {
-                _logger.LogInformation($"Updating project '{filePath}' TagHelpers ({projectWorkspaceState.TagHelpers.Count}).");
+                _logger.LogInformation($"Updating project '{filePath}' TagHelpers ({projectWorkspaceState.TagHelpers.Count}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
             }
 
             _projectSnapshotManagerAccessor.Instance.ProjectWorkspaceStateChanged(project.FilePath, projectWorkspaceState);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectItem.cs
@@ -9,11 +9,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class RemoteProjectItem : RazorProjectItem
     {
-        public RemoteProjectItem(string filePath, string physicalPath)
+        public RemoteProjectItem(string filePath, string physicalPath, string fileKind)
         {
             FilePath = filePath;
             PhysicalPath = physicalPath;
-
+            FileKind = fileKind ?? FileKinds.GetFileKindFromFilePath(FilePath);
             if (FilePath.StartsWith('/'))
             {
                 RelativePhysicalPath = FilePath.Substring(1);
@@ -29,6 +29,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public override string FilePath { get; }
 
         public override string PhysicalPath { get; }
+
+        public override string FileKind { get; }
 
         public override string RelativePhysicalPath { get; }
 

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
@@ -38,7 +38,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             throw new NotImplementedException();
         }
 
+        [Obsolete]
         public override RazorProjectItem GetItem(string path)
+        {
+            return GetItem(path, fileKind: null);
+        }
+
+        public override RazorProjectItem GetItem(string path, string fileKind)
         {
             if (path == null)
             {
@@ -49,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (FilePathRootedBy(physicalPath, _root))
             {
                 var filePath = physicalPath.Substring(_root.Length + 1 /* / */);
-                return new RemoteProjectItem(filePath, physicalPath);
+                return new RemoteProjectItem(filePath, physicalPath, fileKind);
             }
             else
             {
@@ -57,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 // In practice this should never happen, the systems above this should have routed the
                 // file request to the appropriate file system. Return something reasonable so a higher
                 // layer falls over to provide a better error.
-                return new RemoteProjectItem(physicalPath, physicalPath);
+                return new RemoteProjectItem(physicalPath, physicalPath, fileKind);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
@@ -119,7 +119,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 {
                     var filePath = item.EvaluatedInclude;
                     var targetPath = item.GetMetadataValue(RazorTargetPathMetadataName);
-                    var hostDocument = new OmniSharpHostDocument(filePath, targetPath, FileKinds.Component);
+                    var fileKind = FileKinds.GetComponentFileKindFromFilePath(filePath);
+                    var hostDocument = new OmniSharpHostDocument(filePath, targetPath, fileKind);
                     hostDocuments.Add(hostDocument);
                 }
             }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using OmniSharp;
+using OmniSharp.MSBuild.Notification;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    // This entire class is a temporary work around for https://github.com/OmniSharp/omnisharp-roslyn/issues/1443.
+    // We hack together a heuristic to detect when Razor documents that shouldn't be added to the workspace are and to then
+    // remove them from the workspace. In the primary case we're watching for pre-compiled Razor files that are generated
+    // from calling dotnet build and removing them from the workspace once they're added.
+
+    [Shared]
+    [Export(typeof(IMSBuildEventSink))]
+    public class PrecompiledRazorPageSuppressor : IMSBuildEventSink
+    {
+        private readonly OmniSharpWorkspace _workspace;
+
+        [ImportingConstructor]
+        public PrecompiledRazorPageSuppressor(OmniSharpWorkspace workspace)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _workspace = workspace;
+
+            _workspace.WorkspaceChanged += Workspace_WorkspaceChanged;
+        }
+
+        private void Workspace_WorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
+        {
+            switch (args.Kind)
+            {
+                case WorkspaceChangeKind.DocumentAdded:
+                case WorkspaceChangeKind.DocumentChanged:
+                    var project = args.NewSolution.GetProject(args.ProjectId);
+                    var document = project.GetDocument(args.DocumentId);
+
+                    if (document.FilePath == null)
+                    {
+                        break;
+                    }
+
+                    if (document.FilePath.EndsWith(".RazorTargetAssemblyInfo.cs", StringComparison.Ordinal))
+                    {
+                        // Razor declaration assembly info. This doesn't catch cases when users have customized their target assembly info but captures all of the
+                        // default cases for now. Once the omnisharp-roslyn bug has been fixed this entire class can go awy so we're hacking for now.
+                        _workspace.RemoveDocument(document.Id);
+                        break;
+                    }
+
+                    if (!document.FilePath.EndsWith(".cshtml.g.cs", StringComparison.Ordinal) && !document.FilePath.EndsWith(".razor.g.cs", StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+
+                    if (!document.FilePath.Contains("RazorDeclaration"))
+                    {
+                        // Razor output file that is not a declaration file.
+                        _workspace.RemoveDocument(document.Id);
+                        break;
+                    }
+
+                    break;
+            }
+        }
+
+        public void ProjectLoaded(ProjectLoadedEventArgs e)
+        {
+            // We don't do anything on project load we're just using the IMSBuildEventSink to ensure we're instantiated.
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -189,7 +189,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         if (!projectedDocument.hostDocumentSyncVersion ||
             projectedDocument.hostDocumentSyncVersion <= updateBufferRequest.hostDocumentVersion) {
             // We allow re-setting of the updated content from the same doc sync version in the case
-            // of project or _ViewImports.cshtml changes.
+            // of project or file import changes.
             const csharpProjectedDocument = projectedDocument as CSharpProjectedDocument;
             csharpProjectedDocument.update(updateBufferRequest.changes, updateBufferRequest.hostDocumentVersion);
 

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -8,6 +8,34 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     public class FilePathNormalizerTest
     {
         [Fact]
+        public void NormalizeDirectory_EndsWithSlash()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var directory = "\\path\\to\\directory\\";
+
+            // Act
+            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+
+            // Assert
+            Assert.Equal("/path/to/directory/", normalized);
+        }
+
+        [Fact]
+        public void NormalizeDirectory_EndsWithoutSlash()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var directory = "\\path\\to\\directory";
+
+            // Act
+            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+
+            // Assert
+            Assert.Equal("/path/to/directory/", normalized);
+        }
+
+        [Fact]
         public void GetDirectory_IncludesTrailingSlash()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/SerializationTest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Newtonsoft.Json;
 using Xunit;
@@ -25,7 +25,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             ProjectWorkspaceState = new ProjectWorkspaceState(new[]
             {
                 TagHelperDescriptorBuilder.Create("Test", "TestAssembly").Build(),
-            });
+            },
+            LanguageVersion.LatestMajor);
             var converterCollection = new JsonConverterCollection();
             converterCollection.RegisterRazorConverters();
             Converters = converterCollection.ToArray();

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentFilePath = "file.cshtml";
 
             // Act
-            var item = fileSystem.GetItem(documentFilePath);
+            var item = fileSystem.GetItem(documentFilePath, fileKind: null);
 
             // Assert
             Assert.Equal(documentFilePath, item.FilePath);
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentFilePath = "/C:/path/to/file.cshtml";
 
             // Act
-            var item = fileSystem.GetItem(documentFilePath);
+            var item = fileSystem.GetItem(documentFilePath, fileKind: null);
 
             // Assert
             Assert.Equal("file.cshtml", item.FilePath);
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentFilePath = "/C:/otherpath/to/file.cshtml";
 
             // Act
-            var item = fileSystem.GetItem(documentFilePath);
+            var item = fileSystem.GetItem(documentFilePath, fileKind: null);
 
             // Assert
             Assert.Equal(documentFilePath, item.FilePath);


### PR DESCRIPTION
- Also included a bug fix to the project engines where improper configurations can result in Linq `Single` explosions when turning on `MangleClassNames = true`
- Update tests to include new `LanguageVersion` when using `ProjectWorkspaceState`.
- Updated OmniSharp plugin to properly detect `_Imports.razor` file kinds.

#326