### PR TITLE
Batch component refresh output changes.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -3,10 +3,11 @@
 
 using System;
 using System.Net;
+using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
-    public sealed class FilePathNormalizer
+    public class FilePathNormalizer
     {
         public string Normalize(string filePath)
         {
@@ -38,6 +39,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
             var directory = normalizedPath.Substring(0, lastSeparatorIndex + 1);
             return directory;
+        }
+
+        public bool FilePathsEquivalent(string filePath1, string filePath2)
+        {
+            var normalizedFilePath1 = Normalize(filePath1);
+            var normalizedFilePath2 = Normalize(filePath2);
+
+            return FilePathComparer.Instance.Equals(normalizedFilePath1, normalizedFilePath2);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultUpdateBufferDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultUpdateBufferDispatcher.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp;
+using OmniSharp.Models;
+using OmniSharp.Roslyn;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    [Shared]
+    [Export(typeof(UpdateBufferDispatcher))]
+    internal class DefaultUpdateBufferDispatcher : UpdateBufferDispatcher
+    {
+        private readonly BufferManager _bufferManager;
+        private readonly SemaphoreSlim _updateLock;
+
+        [ImportingConstructor]
+        public DefaultUpdateBufferDispatcher(OmniSharpWorkspace omniSharpWorkspace)
+        {
+            if (omniSharpWorkspace == null)
+            {
+                throw new ArgumentNullException(nameof(omniSharpWorkspace));
+            }
+
+            _bufferManager = omniSharpWorkspace.BufferManager;
+            _updateLock = new SemaphoreSlim(1);
+        }
+
+        public override async Task UpdateBufferAsync(Request request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            await _updateLock.WaitAsync();
+
+            await _bufferManager.UpdateBufferAsync(request);
+
+            _updateLock.Release();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/OmniSharpStrongNamedExports.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/OmniSharpStrongNamedExports.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Composition;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed;
 using OmniSharp;
 
@@ -12,6 +13,12 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     // to make those services available via MEF. This isn't an issue for Roslyn based services because
     // we're able to hook into OmniSharp's Roslyn service aggregator to allow it to inspect the strong
     // named plugin assembly.
+
+    [Shared]
+    [Export(typeof(FilePathNormalizer))]
+    public class ExportedFilePathNormalizer : FilePathNormalizer
+    {
+    }
 
     [Shared]
     [Export(typeof(OmniSharpForegroundDispatcher))]

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/UpdateBufferDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/UpdateBufferDispatcher.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using OmniSharp.Models;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    public abstract class UpdateBufferDispatcher
+    {
+        public abstract Task UpdateBufferAsync(Request request);
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -8,6 +8,35 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     public class FilePathNormalizerTest
     {
         [Fact]
+        public void FilePathsEquivalent_NotEqualPaths_ReturnsFalse()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var filePath1 = "path/to/document.cshtml";
+            var filePath2 = "path\\to\\different\\document.cshtml";
+
+            // Act
+            var result = filePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
+
+            // Assert
+            Assert.False(result);
+        }
+        [Fact]
+        public void FilePathsEquivalent_NormalizesPathsBeforeComparison_ReturnsTrue()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var filePath1 = "path/to/document.cshtml";
+            var filePath2 = "path\\to\\document.cshtml";
+
+            // Act
+            var result = filePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
         public void GetDirectory_IncludesTrailingSlash()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ComponentRefreshTriggerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/ComponentRefreshTriggerTest.cs
@@ -1,20 +1,163 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
+using Microsoft.Extensions.Logging;
 using Moq;
+using OmniSharp.Models;
+using OmniSharp.Models.UpdateBuffer;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
     public class ComponentRefreshTriggerTest : OmniSharpTestBase
     {
-        private ProjectInstanceEvaluator ProjectInstanceEvaluator { get; } = Mock.Of<ProjectInstanceEvaluator>();
+        public ComponentRefreshTriggerTest()
+        {
+            var projectInstanceEvaluator = new Mock<ProjectInstanceEvaluator>();
+            projectInstanceEvaluator.Setup(instance => instance.Evaluate(It.IsAny<ProjectInstance>()))
+                .Returns<ProjectInstance>(pi => pi);
+            ProjectInstanceEvaluator = projectInstanceEvaluator.Object;
+        }
+
+        private ProjectInstanceEvaluator ProjectInstanceEvaluator { get; }
 
         private ProjectInstance ProjectInstance { get; } = new ProjectInstance(ProjectRootElement.Create());
+
+        [Fact]
+        public void RazorDocumentOutputChanged_ClearsWorkspaceBufferOnRemove()
+        {
+            // Arrange
+            var updateBufferRequests = new List<Request>();
+            var refreshTrigger = CreateTestComponentRefreshTrigger(onUpdateBuffer: (request) => updateBufferRequests.Add(request));
+            refreshTrigger.BlockRefreshWorkStarting = new ManualResetEventSlim(initialState: false);
+            var filePath = "file.razor.g.cs";
+            var projectRootElement = ProjectRootElement.Create("/path/to/project.csproj");
+            projectRootElement.AddItem("Compile", filePath);
+            var projectInstance = new ProjectInstance(projectRootElement);
+            var onAddArgs = new RazorFileChangeEventArgs(filePath, filePath, projectInstance, RazorFileChangeKind.Added);
+            var onRemoveArgs = new RazorFileChangeEventArgs(filePath, filePath, ProjectInstance, RazorFileChangeKind.Removed);
+            refreshTrigger.RazorDocumentOutputChanged(onAddArgs);
+            refreshTrigger.BlockRefreshWorkStarting.Set();
+
+            refreshTrigger.NotifyRefreshWorkCompleting.Wait(TimeSpan.FromSeconds(1));
+            refreshTrigger.NotifyRefreshWorkCompleting.Reset();
+
+            // Act
+            refreshTrigger.RazorDocumentOutputChanged(onRemoveArgs);
+
+            // Assert
+            refreshTrigger.BlockRefreshWorkStarting.Set();
+
+            refreshTrigger.NotifyRefreshWorkCompleting.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(refreshTrigger.NotifyRefreshWorkCompleting.IsSet);
+
+            Assert.Collection(updateBufferRequests,
+                request =>
+                {
+                    var updateBufferRequest = Assert.IsType<UpdateBufferRequest>(request);
+                    Assert.Equal(filePath, updateBufferRequest.FileName);
+                    Assert.True(updateBufferRequest.FromDisk);
+                },
+                request =>
+                {
+                    Assert.Equal(filePath, request.FileName);
+                    Assert.Equal(string.Empty, request.Buffer);
+                });
+        }
+
+        [Fact]
+        public void RazorDocumentOutputChanged_BatchesFileUpdates()
+        {
+            // Arrange
+            var updateBufferRequests = new List<Request>();
+            var refreshTrigger = CreateTestComponentRefreshTrigger(onUpdateBuffer: (request) => updateBufferRequests.Add(request));
+            refreshTrigger.BlockRefreshWorkStarting = new ManualResetEventSlim(initialState: false);
+            var file1Path = "file.razor.g.cs";
+            var file2Path = "anotherfile.razor.g.cs";
+            var file3Path = "file.razor.g.cs";
+            var projectRootElement = ProjectRootElement.Create("/path/to/project.csproj");
+            projectRootElement.AddItem("Compile", file1Path);
+            projectRootElement.AddItem("Compile", file2Path);
+            // Not adding file3 here to ensure it doesn't get updated.
+
+            var projectInstance = new ProjectInstance(projectRootElement);
+            var file1Args = new RazorFileChangeEventArgs(file1Path, file1Path, projectInstance, RazorFileChangeKind.Changed);
+            var file2Args = new RazorFileChangeEventArgs(file2Path, file2Path, projectInstance, RazorFileChangeKind.Changed);
+            var file3Args = new RazorFileChangeEventArgs(file3Path, file3Path, projectInstance, RazorFileChangeKind.Changed);
+
+            // Act
+            refreshTrigger.RazorDocumentOutputChanged(file1Args);
+            refreshTrigger.RazorDocumentOutputChanged(file2Args);
+            refreshTrigger.RazorDocumentOutputChanged(file3Args);
+
+            // Assert
+            refreshTrigger.BlockRefreshWorkStarting.Set();
+
+            refreshTrigger.NotifyRefreshWorkCompleting.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(refreshTrigger.NotifyRefreshWorkCompleting.IsSet);
+
+            Assert.Collection(updateBufferRequests,
+                request =>
+                {
+                    var updateBufferRequest = Assert.IsType<UpdateBufferRequest>(request);
+                    Assert.Equal(file1Path, updateBufferRequest.FileName);
+                    Assert.True(updateBufferRequest.FromDisk);
+                },
+                request =>
+                {
+                    var updateBufferRequest = Assert.IsType<UpdateBufferRequest>(request);
+                    Assert.Equal(file2Path, updateBufferRequest.FileName);
+                    Assert.True(updateBufferRequest.FromDisk);
+                });
+        }
+
+        [Fact]
+        public void RazorDocumentOutputChanged_MemoizesRefreshTasks()
+        {
+            // Arrange
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
+            refreshTrigger.BlockRefreshWorkStarting = new ManualResetEventSlim(initialState: false);
+            var args = new RazorFileChangeEventArgs("/path/to/file.razor.g.cs", "file.razor.g.cs", ProjectInstance, RazorFileChangeKind.Added);
+
+            // Act
+            refreshTrigger.RazorDocumentOutputChanged(args);
+            refreshTrigger.RazorDocumentOutputChanged(args);
+
+            // Assert
+            Assert.Single(refreshTrigger._deferredRefreshTasks);
+
+            refreshTrigger.BlockRefreshWorkStarting.Set();
+
+            refreshTrigger.NotifyRefreshWorkCompleting.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(refreshTrigger.NotifyRefreshWorkCompleting.IsSet);
+        }
+
+        [Fact]
+        public void RazorDocumentOutputChanged_EnqueuesRefresh()
+        {
+            // Arrange
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
+            var args = new RazorFileChangeEventArgs("/path/to/file.razor.g.cs", "file.razor.g.cs", ProjectInstance, RazorFileChangeKind.Added);
+
+            // Act
+            refreshTrigger.RazorDocumentOutputChanged(args);
+
+            // Assert
+            refreshTrigger.NotifyRefreshWorkStarting.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(refreshTrigger.NotifyRefreshWorkStarting.IsSet);
+
+            // Let refresh work complete
+            refreshTrigger.NotifyRefreshWorkCompleting.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(refreshTrigger.NotifyRefreshWorkCompleting.IsSet);
+        }
 
         [Fact]
         public void IsCompileItem_CompileItem_ReturnsTrue()
@@ -24,9 +167,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var projectRootElement = ProjectRootElement.Create("/path/to/project.csproj");
             projectRootElement.AddItem("Compile", relativeFilePath);
             var projectInstance = new ProjectInstance(projectRootElement);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
 
             // Act
-            var result = ComponentRefreshTrigger.IsCompileItem(relativeFilePath, projectInstance);
+            var result = refreshTrigger.IsCompileItem(relativeFilePath, projectInstance);
 
             // Assert
             Assert.True(result);
@@ -39,9 +183,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var relativeFilePath = "/path/to/obj/Debug/file.razor.g.cs";
             var projectRootElement = ProjectRootElement.Create("/path/to/project.csproj");
             var projectInstance = new ProjectInstance(projectRootElement);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
 
             // Act
-            var result = ComponentRefreshTrigger.IsCompileItem(relativeFilePath, projectInstance);
+            var result = refreshTrigger.IsCompileItem(relativeFilePath, projectInstance);
 
             // Assert
             Assert.False(result);
@@ -57,7 +202,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             projectInstanceEvaluator.Setup(evaluator => evaluator.Evaluate(It.IsAny<ProjectInstance>()))
                 .Verifiable();
             var projectManager = CreateProjectSnapshotManager();
-            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, projectInstanceEvaluator.Object, LoggerFactory);
+            var updateBufferDispatcher = Mock.Of<UpdateBufferDispatcher>(dispatcher => dispatcher.UpdateBufferAsync(It.IsAny<Request>()) == Task.CompletedTask);
+            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, new FilePathNormalizer(), projectInstanceEvaluator.Object, updateBufferDispatcher, LoggerFactory);
             refreshTrigger.Initialize(projectManager);
             await RunOnForegroundAsync(() =>
             {
@@ -81,7 +227,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public async Task RazorDocumentChangedAsync_AddedRemoved_Noops(RazorFileChangeKind changeKind)
         {
             // Arrange
-            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
             var args = new RazorFileChangeEventArgs("file.cshtml", "file.cshtml", ProjectInstance, changeKind);
 
             // Act & Assert
@@ -95,7 +241,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         {
             // Arrange
             var projectManager = CreateProjectSnapshotManager();
-            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
             refreshTrigger.Initialize(projectManager);
 
             await RunOnForegroundAsync(() =>
@@ -117,7 +263,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         {
             // Arrange
             var projectManager = CreateProjectSnapshotManager();
-            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
             refreshTrigger.Initialize(projectManager);
 
             // Act
@@ -132,7 +278,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         {
             // Arrange
             var projectManager = CreateProjectSnapshotManager();
-            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
             refreshTrigger.Initialize(projectManager);
             var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             await RunOnForegroundAsync(() => projectManager.ProjectAdded(hostProject));
@@ -149,7 +295,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         {
             // Arrange
             var projectManager = CreateProjectSnapshotManager();
-            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
             refreshTrigger.Initialize(projectManager);
             var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             var hostDocument = new OmniSharpHostDocument("file.cshtml", "file.cshtml", FileKinds.Legacy);
@@ -171,7 +317,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         {
             // Arrange
             var projectManager = CreateProjectSnapshotManager();
-            var refreshTrigger = new ComponentRefreshTrigger(Dispatcher, ProjectInstanceEvaluator, LoggerFactory);
+            var refreshTrigger = CreateTestComponentRefreshTrigger();
             refreshTrigger.Initialize(projectManager);
             var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             var hostDocument = new OmniSharpHostDocument("file.cshtml", "file.cshtml", FileKinds.Component);
@@ -186,6 +332,40 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
             // Assert
             Assert.True(result);
+        }
+
+        private ComponentRefreshTrigger CreateTestComponentRefreshTrigger(Action<Request> onUpdateBuffer = null)
+        {
+            onUpdateBuffer = onUpdateBuffer ?? ((_) => { });
+            var testUpdateBufferDispatcher = new TestUpdateBufferDispatcher(onUpdateBuffer);
+            return new ComponentRefreshTrigger(Dispatcher, new FilePathNormalizer(), ProjectInstanceEvaluator, testUpdateBufferDispatcher, LoggerFactory)
+            {
+                EnqueueDelay = 1,
+                NotifyRefreshWorkStarting = new ManualResetEventSlim(initialState: false),
+                NotifyRefreshWorkCompleting = new ManualResetEventSlim(initialState: false),
+            };
+        }
+
+        private class TestUpdateBufferDispatcher : UpdateBufferDispatcher
+        {
+            private readonly Action<Request> _onUpdateBuffer;
+
+            public TestUpdateBufferDispatcher(Action<Request> onUpdateBuffer)
+            {
+                if (onUpdateBuffer == null)
+                {
+                    throw new ArgumentNullException(nameof(onUpdateBuffer));
+                }
+
+                _onUpdateBuffer = onUpdateBuffer;
+            }
+
+            public override Task UpdateBufferAsync(Request request)
+            {
+                _onUpdateBuffer(request);
+
+                return Task.CompletedTask;
+            }
         }
     }
 }


### PR DESCRIPTION
- Prior to this when a component was saved in VSCode it would trigger a declaration refresh of every component file. This in turn would cause a design time build N number of times where N was the component count. To avoid this we now allow 250ms to collect all component declaration changes and then trigger a single design time build and update the world.
- Added tests to verify new scenarios.

#315