### PR TITLE
Add pre-compiled razor page suppression logic to workaround OmniSharp bug.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -8,6 +8,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
     public sealed class FilePathNormalizer
     {
+        public string NormalizeDirectory(string directoryFilePath)
+        {
+            var normalized = Normalize(directoryFilePath);
+
+            if (!normalized.EndsWith("/"))
+            {
+                normalized += '/';
+            }
+
+            return normalized;
+        }
+
         public string Normalize(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using OmniSharp;
+using OmniSharp.MSBuild.Notification;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    // This entire class is a temporary work around for https://github.com/OmniSharp/omnisharp-roslyn/issues/1443.
+    // We hack together a heuristic to detect when Razor documents that shouldn't be added to the workspace are and to then
+    // remove them from the workspace. In the primary case we're watching for pre-compiled Razor files that are generated
+    // from calling dotnet build and removing them from the workspace once they're added.
+
+    [Shared]
+    [Export(typeof(IMSBuildEventSink))]
+    public class PrecompiledRazorPageSuppressor : IMSBuildEventSink
+    {
+        private readonly OmniSharpWorkspace _workspace;
+
+        [ImportingConstructor]
+        public PrecompiledRazorPageSuppressor(OmniSharpWorkspace workspace)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _workspace = workspace;
+
+            _workspace.WorkspaceChanged += Workspace_WorkspaceChanged;
+        }
+
+        private void Workspace_WorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
+        {
+            switch (args.Kind)
+            {
+                case WorkspaceChangeKind.DocumentAdded:
+                case WorkspaceChangeKind.DocumentChanged:
+                    var project = args.NewSolution.GetProject(args.ProjectId);
+                    var document = project.GetDocument(args.DocumentId);
+
+                    if (document.FilePath == null)
+                    {
+                        break;
+                    }
+
+                    if (document.FilePath.EndsWith(".RazorTargetAssemblyInfo.cs", StringComparison.Ordinal))
+                    {
+                        // Razor declaration assembly info. This doesn't catch cases when users have customized their target assembly info but captures all of the
+                        // default cases for now. Once the omnisharp-roslyn bug has been fixed this entire class can go awy so we're hacking for now.
+                        _workspace.RemoveDocument(document.Id);
+                        break;
+                    }
+
+                    if (!document.FilePath.EndsWith(".cshtml.g.cs", StringComparison.Ordinal) && !document.FilePath.EndsWith(".razor.g.cs", StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+
+                    if (!document.FilePath.Contains("RazorDeclaration"))
+                    {
+                        // Razor output file that is not a declaration file.
+                        _workspace.RemoveDocument(document.Id);
+                        break;
+                    }
+
+                    break;
+            }
+        }
+
+        public void ProjectLoaded(ProjectLoadedEventArgs e)
+        {
+            // We don't do anything on project load we're just using the IMSBuildEventSink to ensure we're instantiated.
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -8,6 +8,34 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     public class FilePathNormalizerTest
     {
         [Fact]
+        public void NormalizeDirectory_EndsWithSlash()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var directory = "\\path\\to\\directory\\";
+
+            // Act
+            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+
+            // Assert
+            Assert.Equal("/path/to/directory/", normalized);
+        }
+
+        [Fact]
+        public void NormalizeDirectory_EndsWithoutSlash()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var directory = "\\path\\to\\directory";
+
+            // Act
+            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+
+            // Assert
+            Assert.Equal("/path/to/directory/", normalized);
+        }
+
+        [Fact]
         public void GetDirectory_IncludesTrailingSlash()
         {
             // Arrange


### PR DESCRIPTION
- OmniSharp has an issue where they unconditionally add content to the workspace when it's a added on the file system without checking if the file exists in the Compile item group.
- OmniSharp bug that's being worked around: https://github.com/OmniSharp/omnisharp-roslyn/issues/1443
- When we see that a Razor pre-compiled file is added to the workspace we remove it.
- When we see that the Razor declaration assembly info is added to the workspace we remove it.

#316