### PR TITLE
Add support for 'Default' RazorConfiguration

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultProjectEngineFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultProjectEngineFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
+{
+
+    [ExportCustomProjectEngineFactory("Default", SupportsSerialization = true)]
+    internal class DefaultProjectEngineFactory : IProjectEngineFactory
+    {
+        public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            return RazorProjectEngine.Create(configuration, fileSystem, b =>
+            {
+                CompilerFeatures.Register(b);
+
+                configure?.Invoke(b);
+
+                // See comments on MangleClassNames
+                var componentDocumentClassifier = b.Features.OfType<ComponentDocumentClassifierPass>().FirstOrDefault();
+                if (componentDocumentClassifier != null)
+                {
+                    componentDocumentClassifier.MangleClassNames = true;
+                }
+            });
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactories.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectEngineFactories.cs
@@ -11,6 +11,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public static readonly Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>[] Factories =
             new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>[]
             {
+                // Razor based configurations
+                new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
+                    () => new DefaultProjectEngineFactory(),
+                    new ExportCustomProjectEngineFactoryAttribute("Default") { SupportsSerialization = true }),
                 new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                     () => new ProjectEngineFactory_1_0(),
                     new ExportCustomProjectEngineFactoryAttribute("MVC-1.0") { SupportsSerialization = true }),
@@ -26,12 +30,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                     () => new ProjectEngineFactory_3_0(),
                     new ExportCustomProjectEngineFactoryAttribute("MVC-3.0") { SupportsSerialization = true }),
-                new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
-                    () => new ProjectEngineFactory_Unsupported(),
-                    new ExportCustomProjectEngineFactoryAttribute(UnsupportedRazorConfiguration.Instance.ConfigurationName) { SupportsSerialization = true }),
+
+                // Blazor
                 new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
                     () => new ProjectEngineFactory_Blazor(),
                     new ExportCustomProjectEngineFactoryAttribute("Blazor-0.1") { SupportsSerialization = false }),
+
+                // Unsupported (Legacy/System.Web.Razor)
+                new Lazy<IProjectEngineFactory, ICustomProjectEngineFactoryMetadata>(
+                    () => new ProjectEngineFactory_Unsupported(),
+                    new ExportCustomProjectEngineFactoryAttribute(UnsupportedRazorConfiguration.Instance.ConfigurationName) { SupportsSerialization = true }),
             };
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
@@ -74,12 +74,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 return false;
             }
 
-            if (!TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames))
-            {
-                configuration = null;
-                return false;
-            }
-
+            var configuredExtensionNames = GetConfiguredExtensionNames(configurationItem);
             var rootNamespace = GetRootNamespace(projectInstance);
             var extensions = GetExtensions(configuredExtensionNames, projectInstance.Items);
             var razorConfiguration = new ProjectSystemRazorConfiguration(languageVersion, configurationItem.EvaluatedInclude, extensions);
@@ -180,18 +175,17 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         }
 
         // Internal for testing
-        internal static bool TryGetConfiguredExtensionNames(ProjectItemInstance configurationItem, out string[] configuredExtensionNames)
+        internal static string[] GetConfiguredExtensionNames(ProjectItemInstance configurationItem)
         {
             var extensionNamesValue = configurationItem.GetMetadataValue(RazorConfigurationItemTypeExtensionsProperty);
 
             if (string.IsNullOrEmpty(extensionNamesValue))
             {
-                configuredExtensionNames = null;
-                return false;
+                return Array.Empty<string>();
             }
 
-            configuredExtensionNames = extensionNamesValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            return true;
+            var configuredExtensionNames = extensionNamesValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            return configuredExtensionNames;
         }
 
         // Internal for testing

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/LatestProjectConfigurationProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/LatestProjectConfigurationProviderTest.cs
@@ -345,22 +345,21 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_FailsIfNoExtensions()
+        public void GetConfiguredExtensionNames_NoExtensions()
         {
             // Arrange
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
             var configurationItem = projectInstance.AddItem("RazorConfiguration", "Razor-10.0");
 
             // Act
-            var result = LatestProjectConfigurationProvider.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionnames);
+            var configuredExtensionNames = LatestProjectConfigurationProvider.GetConfiguredExtensionNames(configurationItem);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuredExtensionnames);
+            Assert.Empty(configuredExtensionNames);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_FailsIfEmptyExtensions()
+        public void GetConfiguredExtensionNames_EmptyExtensions()
         {
             // Arrange
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
@@ -373,15 +372,14 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 });
 
             // Act
-            var result = LatestProjectConfigurationProvider.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames);
+            var configuredExtensionNames = LatestProjectConfigurationProvider.GetConfiguredExtensionNames(configurationItem);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuredExtensionNames);
+            Assert.Empty(configuredExtensionNames);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsIfSingleExtension()
+        public void GetConfiguredExtensionNames_SingleExtension()
         {
             // Arrange
             var expectedExtensionName = "SomeExtensionName";
@@ -395,16 +393,15 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 });
 
             // Act
-            var result = LatestProjectConfigurationProvider.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames);
+            var configuredExtensionNames = LatestProjectConfigurationProvider.GetConfiguredExtensionNames(configurationItem);
 
             // Assert
-            Assert.True(result);
             var extensionName = Assert.Single(configuredExtensionNames);
             Assert.Equal(expectedExtensionName, extensionName);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsIfMultipleExtensions()
+        public void GetConfiguredExtensionNames_MultipleExtensions()
         {
             // Arrange
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
@@ -417,10 +414,9 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 });
 
             // Act
-            var result = LatestProjectConfigurationProvider.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames);
+            var configuredExtensionNames = LatestProjectConfigurationProvider.GetConfiguredExtensionNames(configurationItem);
 
             // Assert
-            Assert.True(result);
             Assert.Collection(
                 configuredExtensionNames,
                 name => Assert.Equal("SomeExtensionName", name),
@@ -522,7 +518,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         }
 
         [Fact]
-        public void TryGetConfiguration_FailsIfNoConfiguredExtensionNames()
+        public void TryGetConfiguration_SucceedsIfNoConfiguredExtensionNames()
         {
             // Arrange
             var projectInstance = new ProjectInstance(ProjectRootElement.Create());
@@ -534,8 +530,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var result = LatestProjectConfigurationProvider.TryGetConfiguration(projectInstance, out var configuration);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuration);
+            Assert.True(result);
+            Assert.Equal(RazorLanguageVersion.Version_1_0, configuration.Configuration.LanguageVersion);
+            Assert.Equal("Razor-13.37", configuration.Configuration.ConfigurationName);
+            Assert.Empty(configuration.Configuration.Extensions);
         }
 
         // This is more of an integration test but is here to test the overall flow/functionality


### PR DESCRIPTION
This is a configuration that will be used by the SDK for Components
projects without MVC support. In this case there are no extensions. I
also made the system more tolerant in general of missing extensions and
not fail quite so hard.