### PR TITLE
Add ability to refresh TagHelpers on build.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpProjectWorkspaceStateGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpProjectWorkspaceStateGenerator.cs
@@ -9,6 +9,11 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
 {
     public class OmniSharpProjectWorkspaceStateGenerator : IOmniSharpProjectSnapshotManagerChangeTrigger
     {
+        // Internal for testing
+        internal OmniSharpProjectWorkspaceStateGenerator()
+        {
+        }
+
         public OmniSharpProjectWorkspaceStateGenerator(OmniSharpForegroundDispatcher foregroundDispatcher)
         {
             if (foregroundDispatcher == null)
@@ -23,6 +28,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
 
         public void Initialize(OmniSharpProjectSnapshotManagerBase projectManager) => InternalWorkspaceStateGenerator.Initialize(projectManager.InternalProjectSnapshotManager);
 
-        public void Update(Project workspaceProject, OmniSharpProjectSnapshot projectSnapshot) => InternalWorkspaceStateGenerator.Update(workspaceProject, projectSnapshot.InternalProjectSnapshot);
+        public virtual void Update(Project workspaceProject, OmniSharpProjectSnapshot projectSnapshot) => InternalWorkspaceStateGenerator.Update(workspaceProject, projectSnapshot.InternalProjectSnapshot);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/TagHelperRefreshTrigger.cs
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/TagHelperRefreshTrigger.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed;
+using Microsoft.CodeAnalysis;
+using OmniSharp;
+using OmniSharp.MSBuild.Notification;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    [Shared]
+    [Export(typeof(IMSBuildEventSink))]
+    [Export(typeof(IRazorDocumentOutputChangeListener))]
+    [Export(typeof(IOmniSharpProjectSnapshotManagerChangeTrigger))]
+    internal class TagHelperRefreshTrigger : IMSBuildEventSink, IRazorDocumentOutputChangeListener, IOmniSharpProjectSnapshotManagerChangeTrigger
+    {
+        private readonly OmniSharpForegroundDispatcher _foregroundDispatcher;
+        private readonly Workspace _omniSharpWorkspace;
+        private readonly OmniSharpProjectWorkspaceStateGenerator _workspaceStateGenerator;
+        private readonly Dictionary<string, Task> _deferredUpdates;
+        private OmniSharpProjectSnapshotManager _projectManager;
+
+        [ImportingConstructor]
+        public TagHelperRefreshTrigger(
+            OmniSharpForegroundDispatcher foregroundDispatcher,
+            OmniSharpWorkspace omniSharpWorkspace,
+            OmniSharpProjectWorkspaceStateGenerator workspaceStateGenerator) :
+                this(foregroundDispatcher, (Workspace)omniSharpWorkspace, workspaceStateGenerator)
+        {
+        }
+
+        // Internal for testing
+        internal TagHelperRefreshTrigger(
+            OmniSharpForegroundDispatcher foregroundDispatcher,
+            Workspace omniSharpWorkspace,
+            OmniSharpProjectWorkspaceStateGenerator workspaceStateGenerator)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (omniSharpWorkspace == null)
+            {
+                throw new ArgumentNullException(nameof(omniSharpWorkspace));
+            }
+
+            if (workspaceStateGenerator == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceStateGenerator));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _omniSharpWorkspace = omniSharpWorkspace;
+            _workspaceStateGenerator = workspaceStateGenerator;
+            _deferredUpdates = new Dictionary<string, Task>();
+        }
+
+        public int EnqueueDelay { get; set; } = 3 * 1000;
+
+        public void Initialize(OmniSharpProjectSnapshotManagerBase projectManager)
+        {
+            if (projectManager == null)
+            {
+                throw new ArgumentNullException(nameof(projectManager));
+            }
+
+            _projectManager = projectManager;
+        }
+
+        public void ProjectLoaded(ProjectLoadedEventArgs args)
+        {
+            if (args == null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            // Project file was modified or impacted in a significant way.
+
+            Task.Factory.StartNew(
+                () => EnqueueUpdate(args.ProjectInstance.ProjectFileLocation.File),
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                _foregroundDispatcher.ForegroundScheduler);
+        }
+
+        public void RazorDocumentOutputChanged(RazorFileChangeEventArgs args)
+        {
+            if (args == null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            // Razor build occurred
+
+            Task.Factory.StartNew(
+                () => EnqueueUpdate(args.UnevaluatedProjectInstance.ProjectFileLocation.File),
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                _foregroundDispatcher.ForegroundScheduler);
+        }
+
+        // Internal for testing
+        internal async Task UpdateAfterDelayAsync(string projectFilePath)
+        {
+            if (string.IsNullOrEmpty(projectFilePath))
+            {
+                return;
+            }
+
+            await Task.Delay(EnqueueDelay);
+
+            var solution = _omniSharpWorkspace.CurrentSolution;
+            var workspaceProject = solution.Projects.FirstOrDefault(project => FilePathComparer.Instance.Equals(project.FilePath, projectFilePath));
+            if (workspaceProject != null && TryGetProjectSnapshot(workspaceProject.FilePath, out var projectSnapshot))
+            {
+                _workspaceStateGenerator.Update(workspaceProject, projectSnapshot);
+            }
+        }
+
+        private void EnqueueUpdate(string projectFilePath)
+        {
+            _foregroundDispatcher.AssertForegroundThread();
+
+            // A race is not possible here because we use the main thread to synchronize the updates
+            // by capturing the sync context.
+            if (!_deferredUpdates.TryGetValue(projectFilePath, out var update) || update.IsCompleted)
+            {
+                _deferredUpdates[projectFilePath] = UpdateAfterDelayAsync(projectFilePath);
+            }
+        }
+
+        private bool TryGetProjectSnapshot(string projectFilePath, out OmniSharpProjectSnapshot projectSnapshot)
+        {
+            if (projectFilePath == null)
+            {
+                projectSnapshot = null;
+                return false;
+            }
+
+            projectSnapshot = _projectManager.GetLoadedProject(projectFilePath);
+            return projectSnapshot != null;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
@@ -84,5 +84,14 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 TaskCreationOptions.None,
                 Dispatcher.ForegroundScheduler);
         }
+
+        protected Task RunOnForegroundAsync(Func<Task> action)
+        {
+            return Task.Factory.StartNew(
+                async () => await action(),
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                Dispatcher.ForegroundScheduler);
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TagHelperRefreshTriggerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TagHelperRefreshTriggerTest.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.CodeAnalysis;
+using Moq;
+using OmniSharp.MSBuild.Logging;
+using OmniSharp.MSBuild.Notification;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    public class TagHelperRefreshTriggerTest : OmniSharpTestBase
+    {
+        public TagHelperRefreshTriggerTest()
+        {
+            Workspace = TestWorkspace.Create();
+            var projectRoot1 = ProjectRootElement.Create("/path/to/project.csproj");
+            Project1Instance = new ProjectInstance(projectRoot1);
+            ProjectManager = CreateProjectSnapshotManager();
+            Project1 = new OmniSharpHostProject(projectRoot1.ProjectFileLocation.File, RazorConfiguration.Default, "TestRootNamespace");
+
+            var solution = Workspace.CurrentSolution.AddProject(
+                ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Default,
+                    "Project1",
+                    "Project1",
+                    LanguageNames.CSharp,
+                    filePath: Project1.FilePath));
+            Workspace.TryApplyChanges(solution);
+        }
+
+        public TimeSpan WaitDelay
+        {
+            get
+            {
+                if (Debugger.IsAttached)
+                {
+                    return TimeSpan.MaxValue;
+                }
+
+                return TimeSpan.FromMilliseconds(250);
+            }
+        }
+
+        public Workspace Workspace { get; }
+
+        public OmniSharpProjectSnapshotManagerBase ProjectManager { get; }
+
+        public OmniSharpHostProject Project1 { get; }
+
+        public ProjectInstance Project1Instance { get; }
+
+        public ImmutableArray<MSBuildDiagnostic> EmptyDiagnostics => Enumerable.Empty<MSBuildDiagnostic>().ToImmutableArray();
+
+        [Fact]
+        public async Task ProjectLoaded_TriggersUpdate()
+        {
+            // Arrange
+            await RunOnForegroundAsync(() => ProjectManager.ProjectAdded(Project1));
+            var mre = new ManualResetEventSlim(initialState: false);
+            var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>();
+            workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
+                .Callback<Project, OmniSharpProjectSnapshot>((_, __) => mre.Set());
+            var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object);
+            var args = new ProjectLoadedEventArgs(null, Project1Instance, EmptyDiagnostics, isReload: false);
+
+            // Act
+            refreshTrigger.ProjectLoaded(args);
+
+            // Assert
+            var result = mre.Wait(WaitDelay);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task ProjectLoaded_BatchesUpdates()
+        {
+            // Arrange
+            await RunOnForegroundAsync(() => ProjectManager.ProjectAdded(Project1));
+            var mre = new ManualResetEventSlim(initialState: false);
+            var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>();
+            workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
+                .Callback<Project, OmniSharpProjectSnapshot>((_, __) =>
+                {
+                    if (mre.IsSet)
+                    {
+                        throw new XunitException("Should not have been called twice.");
+                    }
+
+                    mre.Set();
+                });
+            var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object, enqueueDelay: 10);
+            var args = new ProjectLoadedEventArgs(null, Project1Instance, EmptyDiagnostics, isReload: false);
+
+            // Act
+            refreshTrigger.ProjectLoaded(args);
+            refreshTrigger.ProjectLoaded(args);
+            refreshTrigger.ProjectLoaded(args);
+            refreshTrigger.ProjectLoaded(args);
+
+            // Assert
+            var result = mre.Wait(WaitDelay);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task RazorDocumentOutputChanged_TriggersUpdate()
+        {
+            // Arrange
+            await RunOnForegroundAsync(() => ProjectManager.ProjectAdded(Project1));
+            var mre = new ManualResetEventSlim(initialState: false);
+            var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>();
+            workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
+                .Callback<Project, OmniSharpProjectSnapshot>((_, __) => mre.Set());
+            var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object);
+            var args = new RazorFileChangeEventArgs("/path/to/obj/file.cshtml.g.cs", "obj/file.cshtml.g.cs", Project1Instance, RazorFileChangeKind.Added);
+
+            // Act
+            refreshTrigger.RazorDocumentOutputChanged(args);
+
+            // Assert
+            var result = mre.Wait(WaitDelay);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task RazorDocumentOutputChanged_BatchesUpdates()
+        {
+            // Arrange
+            await RunOnForegroundAsync(() => ProjectManager.ProjectAdded(Project1));
+            var mre = new ManualResetEventSlim(initialState: false);
+            var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>();
+            workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
+                .Callback<Project, OmniSharpProjectSnapshot>((_, __) =>
+                {
+                    if (mre.IsSet)
+                    {
+                        throw new XunitException("Should not have been called twice.");
+                    }
+
+                    mre.Set();
+                });
+            var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object, enqueueDelay: 10);
+            var args = new RazorFileChangeEventArgs("/path/to/obj/file.cshtml.g.cs", "obj/file.cshtml.g.cs", Project1Instance, RazorFileChangeKind.Added);
+
+            // Act
+            refreshTrigger.RazorDocumentOutputChanged(args);
+            refreshTrigger.RazorDocumentOutputChanged(args);
+            refreshTrigger.RazorDocumentOutputChanged(args);
+            refreshTrigger.RazorDocumentOutputChanged(args);
+
+            // Assert
+            var result = mre.Wait(WaitDelay);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task UpdateAfterDelayAsync_NoWorkspaceProject_Noops()
+        {
+            // Arrange
+            var workspace = TestWorkspace.Create();
+            var projectManager = CreateProjectSnapshotManager();
+            await RunOnForegroundAsync(() => ProjectManager.ProjectAdded(Project1));
+            var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>();
+            workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
+                .Throws<XunitException>();
+            var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object, workspace);
+
+            // Act & Assert
+            await RunOnForegroundAsync(() => refreshTrigger.UpdateAfterDelayAsync(Project1.FilePath));
+        }
+
+        [Fact]
+        public async Task UpdateAfterDelayAsync_NoProjectSnapshot_Noops()
+        {
+            // Arrange
+            var projectManager = CreateProjectSnapshotManager();
+            var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>();
+            workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
+                .Throws<XunitException>();
+            var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object);
+
+            // Act & Assert
+            await RunOnForegroundAsync(() => refreshTrigger.UpdateAfterDelayAsync(Project1Instance.ProjectFileLocation.File));
+        }
+
+        private TagHelperRefreshTrigger CreateRefreshTrigger(OmniSharpProjectWorkspaceStateGenerator workspaceStateGenerator, Workspace workspace = null, int enqueueDelay = 1)
+        {
+            workspace = workspace ?? Workspace;
+            var refreshTrigger = new TagHelperRefreshTrigger(Dispatcher, workspace, workspaceStateGenerator)
+            {
+                EnqueueDelay = enqueueDelay,
+            };
+
+            refreshTrigger.Initialize(ProjectManager);
+
+            return refreshTrigger;
+        }
+    }
+}


### PR DESCRIPTION
- Added a `TagHelperRefreshTrigger` to understand when project changes or output file changes occur and trigger TagHelper refreshes.
- Added tests to cover the various ways TagHelpers can refresh.
- Updated test infrastructure to make the tests easier to write.

Mostly FYI, going to merge this once build completes.