### PR TITLE
Fix F5 task hang.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "outFiles": [
                 "${workspaceFolder}/client/out/**/*.js"
             ],
-            "preLaunchTask": "client-npm-watch"
+            "preLaunchTask": "WatchPackageAndCompileClient"
         },
         {
             "name": "Extension Tests",
@@ -32,7 +32,7 @@
             "outFiles": [
                 "${workspaceFolder}/client/out/test/**/*.js"
             ],
-            "preLaunchTask": "client-npm-compile"
+            "preLaunchTask": "CompilePackageAndClient"
         },
         {
             "type": "node",
@@ -49,7 +49,7 @@
             ],
             "sourceMaps": true,
             "internalConsoleOptions": "openOnSessionStart",
-            "preLaunchTask": "client-npm-compile"
+            "preLaunchTask": "CompilePackageAndClient"
         },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,71 +4,40 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "client-npm-compile",
-            "dependsOn": [
-                "client-npm-compile:package",
-                "client-npm-compile:shell"
-            ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "isBackground": true,
-            "problemMatcher": []
-        },
-        {
-            "label": "client-npm-compile:shell",
-            "type": "npm",
-            "script": "compile",
-            "path": "client/",
-            "problemMatcher": "$tsc-watch",
-            "isBackground": true,
-            "presentation": {
-                "reveal": "never"
-            }
-        },
-        {
-            "label": "client-npm-compile:package",
-            "type": "npm",
-            "script": "compile",
-            "path": "src/Microsoft.AspNetCore.Razor.VSCode/",
-            "problemMatcher": "$tsc-watch",
-            "isBackground": true,
-            "presentation": {
-                "reveal": "never"
-            }
-        },
-        {
-            "label": "client-npm-watch",
-            "dependsOn": [
-                "client-npm-watch:shell",
-                "client-npm-watch:package"
-            ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "isBackground": true,
-            "problemMatcher": []
-        },
-        {
-            "label": "client-npm-watch:shell",
-            "type": "npm",
-            "script": "watch",
-            "path": "client/",
-            "problemMatcher": "$tsc-watch",
-            "isBackground": true,
-            "presentation": {
-                "reveal": "never"
-            }
-        },
-        {
-            "label": "client-npm-watch:package",
+            // There's a bug in OmniSharp which prevents us from watching both the client and package simultaneously
+            // If we attempt to watch in a dependent task it hangs on launch.
+            "label": "WatchPackageAndCompileClient",
             "type": "npm",
             "script": "watch",
             "path": "src/Microsoft.AspNetCore.Razor.VSCode/",
             "problemMatcher": "$tsc-watch",
             "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "dependsOn": [
+                "CompileClient"
+            ]
+        },
+        {
+            "label": "CompilePackageAndClient",
+            "type": "npm",
+            "script": "compile",
+            "path": "src/Microsoft.AspNetCore.Razor.VSCode/",
+            "problemMatcher": "$tsc-watch",
+            "presentation": {
+                "reveal": "never"
+            },
+            "dependsOn": [
+                "CompileClient"
+            ]
+        },
+        {
+            "label": "CompileClient",
+            "type": "npm",
+            "script": "compile",
+            "path": "client/",
+            "problemMatcher": "$tsc-watch",
             "presentation": {
                 "reveal": "never"
             }

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -4,5 +4,11 @@
      },
      "cake": {
          "enabled": false
+     },
+     "dotnet": {
+         "enabled": false
+     },
+     "msbuild": {
+         "enabled": false
      }
 }


### PR DESCRIPTION
- There's an active issue in VSCode where you can't have purely background tasks (npm watch) as dependent tasks. That's what we were doing and was working for some time. Now it does not. Therefore, changed the F5 experience to compile the client app and then npm watch the VSCode package.
- Also updated the omnisharp.json to not attempt to provide C# completion for Razor.VSCode since KoreBuild doesn't work well in an O# world.

#327