### PR TITLE
Add support for serialization formats to protect against new releases.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,15 +2,15 @@
   <PropertyGroup Label="Package Versions">
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview7.19306.3</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview7.19306.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview7.19306.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview7.19325.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview7.19325.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview7.19325.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview7.19306.3</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview7.19325.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>3.0.0-preview4.19155.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectSerializationFormat.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectSerializationFormat.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
+{
+    internal static class ProjectSerializationFormat
+    {
+        public static string Version => "0.1";
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorUpdateProjectParams.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorUpdateProjectParams.cs
@@ -1,24 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using OmniSharp.Extensions.Embedded.MediatR;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 {
     internal class RazorUpdateProjectParams : IRequest
     {
-        public string FilePath { get; set; }
-
-        public RazorConfiguration Configuration { get; set; }
-
-        public string RootNamespace { get; set; }
-
-        public ProjectWorkspaceState ProjectWorkspaceState { get; set; }
-
-        public DocumentSnapshotHandle[] Documents { get; set; }
+        public FullProjectSnapshotHandle ProjectSnapshotHandle { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorProjectConfiguration.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/IRazorProjectConfiguration.ts
@@ -15,4 +15,5 @@ export interface IRazorProjectConfiguration {
     readonly projectWorkspaceState: any;
     readonly lastUpdated: Date;
     readonly documents: any;
+    readonly serializationFormat: string;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateProjectRequest.ts
@@ -3,10 +3,16 @@
 * Licensed under the MIT License. See License.txt in the project root for license information.
 * ------------------------------------------------------------------------------------------ */
 
+// Everything here is pascal cased in order to correspond with the language server invocation we're performing.
 export interface UpdateProjectRequest {
-    readonly filePath: string;
-    readonly configuration?: any;
-    readonly rootNamespace?: string;
-    readonly projectWorkspaceState?: any;
-    readonly documents?: any;
+    readonly ProjectSnapshotHandle: SerializedProjectSnapshotHandle;
+}
+
+interface SerializedProjectSnapshotHandle {
+    readonly FilePath: string;
+    readonly Configuration?: any;
+    readonly RootNamespace?: string;
+    readonly ProjectWorkspaceState?: any;
+    readonly Documents?: any;
+    readonly SerializationFormat: string | null;
 }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -60,11 +60,14 @@ export class RazorLanguageServiceClient {
         await this.ensureStarted();
 
         const request: UpdateProjectRequest = {
-            filePath: project.uri.fsPath,
-            projectWorkspaceState: project.configuration ? project.configuration.projectWorkspaceState : null,
-            configuration: project.configuration ? project.configuration.configuration : undefined,
-            rootNamespace: project.configuration ? project.configuration.rootNamespace : undefined,
-            documents: project.configuration ? project.configuration.documents : undefined,
+            ProjectSnapshotHandle: {
+                FilePath: project.uri.fsPath,
+                ProjectWorkspaceState: project.configuration ? project.configuration.projectWorkspaceState : null,
+                Configuration: project.configuration ? project.configuration.configuration : undefined,
+                RootNamespace: project.configuration ? project.configuration.rootNamespace : undefined,
+                Documents: project.configuration ? project.configuration.documents : undefined,
+                SerializationFormat: project.configuration ? project.configuration.serializationFormat : null,
+            },
         };
         await this.serverClient.sendRequest<UpdateProjectRequest>('projects/updateProject', request);
     }

--- a/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
+++ b/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorProjectManager.ts
@@ -160,16 +160,6 @@ export class RazorProjectManager {
             const projectJson = fs.readFileSync(fileSystemPath, 'utf8');
             const lastUpdated = fs.statSync(fileSystemPath).mtime;
             const projectHandle = JSON.parse(projectJson);
-            if (projectHandle.ProjectWorkspaceState === undefined) {
-                // ProjectWorkspaceState was added in the alpha3 release, if the parsed file doesn't contain this entry
-                // then it's an old-school project configuration file (unsupported). Wait for the OmniSharp side of the
-                // world to generate a new project configuration file.
-                //
-                // Eventually this work won't be needed. Once we 1.0 we'll add a protocol version to the configuration
-                // file and parse it correctly depending on its protocol.
-                return undefined;
-            }
-
             const projectUri = vscode.Uri.file(projectHandle.FilePath);
             const projectFilePath = getUriPath(projectUri);
             const configuration: IRazorProjectConfiguration = {
@@ -182,6 +172,7 @@ export class RazorProjectManager {
                 projectWorkspaceState: projectHandle.ProjectWorkspaceState,
                 documents: projectHandle.Documents,
                 lastUpdated,
+                serializationFormat: projectHandle.SerializationFormat,
             };
             return configuration;
         } catch (error) {

--- a/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectEndpointTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectEndpointTest.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorProjectEndpointTest : TestBase
+    {
+        [Fact]
+        public async Task Handle_UpdateProject_NoProjectSnapshotHandle_Noops()
+        {
+            // Arrange
+            var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
+            var endpoint = new RazorProjectEndpoint(Dispatcher, projectService.Object, LoggerFactory);
+            var request = new RazorUpdateProjectParams()
+            {
+                ProjectSnapshotHandle = null,
+            };
+
+            // Act & Assert
+            await endpoint.Handle(request, CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
- Prior to this I was finding that with latest Razor bits we were exploding on preview6 Blazor components whose metadata wasn't able to be deserialized properly.
- Added serialization and project endpoint tests to account for this.
- Updated to preview7 Razor