### PR TITLE
Add support for Razor 3.0.0-preview8

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,16 +1,16 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
-    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview8.19373.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview7.19325.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview7.19325.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview7.19325.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview8.19370.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview8.19370.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview8.19370.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview7.19325.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview8.19370.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>3.0.0-preview4.19155.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -7,6 +7,7 @@
       $(RestoreSources);
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json;
+      https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
       https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectSerializationFormat.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/ProjectSerializationFormat.cs
@@ -5,6 +5,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
     internal static class ProjectSerializationFormat
     {
-        public static string Version => "0.1";
+        public static string Version => "0.2";
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/TagHelperDescriptorJsonConverter.cs
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Serialization/TagHelperDescriptorJsonConverter.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
             var childTags = descriptor[nameof(TagHelperDescriptor.AllowedChildTags)].Value<JArray>();
             var documentation = descriptor[nameof(TagHelperDescriptor.Documentation)].Value<string>();
             var tagOutputHint = descriptor[nameof(TagHelperDescriptor.TagOutputHint)].Value<string>();
+            var caseSensitive = descriptor[nameof(TagHelperDescriptor.CaseSensitive)].Value<bool>();
             var diagnostics = descriptor[nameof(TagHelperDescriptor.Diagnostics)].Value<JArray>();
             var metadata = descriptor[nameof(TagHelperDescriptor.Metadata)].Value<JObject>();
 
@@ -43,6 +44,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
 
             builder.Documentation = documentation;
             builder.TagOutputHint = tagOutputHint;
+            builder.CaseSensitive = caseSensitive;
 
             foreach (var tagMatchingRule in tagMatchingRules)
             {
@@ -96,9 +98,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common.Serialization
 
             writer.WritePropertyName(nameof(TagHelperDescriptor.Documentation));
             writer.WriteValue(tagHelper.Documentation);
-
+            
             writer.WritePropertyName(nameof(TagHelperDescriptor.TagOutputHint));
             writer.WriteValue(tagHelper.TagOutputHint);
+
+            writer.WritePropertyName(nameof(TagHelperDescriptor.CaseSensitive));
+            writer.WriteValue(tagHelper.CaseSensitive);
 
             writer.WritePropertyName(nameof(TagHelperDescriptor.TagMatchingRules));
             writer.WriteStartArray();


### PR DESCRIPTION
- Updated project serialization format since the underlying structure changed.
- Updated the RazorDiagnosticJsonConverter: https://github.com/aspnet/Razor.VSCode/issues/378
- Updated the TagHelperDescriptorJsonConverter: https://github.com/aspnet/Razor.VSCode/issues/377

aspnet/AspNetCore#11663

/cc @mkArtakMSFT I imagine this doesn't fall under the same scope as needing to notify shiproom of tellmode?