### PR TITLE
Update to preview9 Razor bits.

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -7,10 +7,10 @@
       "Microsoft.AspNetCore.Razor.OmniSharpPlugin": {
         "Exclusions": {
           "SIGN_STRONGNAME": {
-            "lib/net461/Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll": "Underlying omnisharp dependency is not strong-named."
+            "lib/net472/Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll": "Underlying omnisharp dependency is not strong-named."
           },
           "WRONG_PUBLICKEYTOKEN": {
-            "lib/net461/Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll": "Underlying omnisharp dependency is not strong-named."
+            "lib/net472/Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll": "Underlying omnisharp dependency is not strong-named."
           }
         }
       },

--- a/Razor.VSCode.sln
+++ b/Razor.VSCode.sln
@@ -47,6 +47,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed", "src\Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed\Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed.csproj", "{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Shared", "modules\omnisharp-roslyn\src\OmniSharp.Shared\OmniSharp.Shared.csproj", "{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -109,6 +111,10 @@ Global
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -130,6 +136,7 @@ Global
 		{68200076-1756-4E72-AD93-FD412D23086F} = {75400311-9729-4D9A-80D2-ADD5286DE405}
 		{C81B10BB-4272-49E8-BDF6-CB5615BC601D} = {75400311-9729-4D9A-80D2-ADD5286DE405}
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09} = {2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}
+		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69} = {05FA40C7-7899-4050-B9CC-9B9A20852C31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ED1782EB-ABE7-4615-80E2-442006DF2826}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,18 +1,19 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
+    <HumanizerPackageVersion>2.2.0</HumanizerPackageVersion>
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview8.19373.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview8.19370.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview8.19370.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview8.19370.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview9.19415.11</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>3.0.0-preview9.19415.11</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>3.0.0-preview9.19415.11</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10643</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftBuildPackageVersion>15.9.20</MicrosoftBuildPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview8.19370.2</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>3.3.0-beta2-19376-02</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.3.0-beta2-19376-02</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.3.0-beta2-19376-02</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>3.0.0-preview9.19415.11</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>3.3.0-beta2-19376-02</MicrosoftCodeAnalysisVisualBasicFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.3.0-beta2-19376-02</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>3.0.0-preview4.19155.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
@@ -20,6 +21,7 @@
     <MicrosoftNetCoreApp30PackageVersion>3.0.0-preview1-26907-05</MicrosoftNetCoreApp30PackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview-18577-0036</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETFrameworkReferenceAssembliesPackageVersion>1.0.0-preview.1</MicrosoftNETFrameworkReferenceAssembliesPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <OmniSharpExtensionsLanguageServerPackageVersion>0.10.0</OmniSharpExtensionsLanguageServerPackageVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -13,6 +13,7 @@
       https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
       https://vside.myget.org/F/vssdk/api/v3/index.json;
       https://www.myget.org/F/omnisharp/api/v3/index.json;
+      https://www.myget.org/F/vs-editor/api/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);

--- a/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -22,10 +22,10 @@
   <Target Name="PublishLanguageServerNativeExecutables" AfterTargets="Pack" DependsOnTargets="PublishAllRids" />
 
   <Target Name="IncludeOmniSharpPlugin" AfterTargets="Publish" Condition="Exists('$(PublishDir)')">
-    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj" Properties="PublishDir=$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish;RuntimeIdentifier=" Targets="Publish" />
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj" Properties="PublishDir=$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net472\publish;RuntimeIdentifier=" Targets="Publish" />
 
     <PropertyGroup>
-      <PluginReferenceOutputPath>$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net461\publish</PluginReferenceOutputPath>
+      <PluginReferenceOutputPath>$(MSBuildProjectDirectory)\..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\bin\$(Configuration)\net472\publish</PluginReferenceOutputPath>
       <TargetPluginOutputPath>$(PublishDir)\OmniSharpPlugin</TargetPluginOutputPath>
     </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
+
     <Description>Razor is a markup syntax for adding logic to pages. This package contains the Omnisharp Razor plugin that extracts Razor configuration information from projects.</Description>
     <EnableApiCheck>false</EnableApiCheck>
 
@@ -17,6 +18,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- 
+      This is here to workaround a Roslyn bug
+      https://github.com/OmniSharp/omnisharp-roslyn/commit/18cf2e415eb050de4e2e8a3520a25adbfc20aafa
+    -->
+    <PackageReference Include="Humanizer" Version="$(HumanizerPackageVersion)" />
+    
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="$(MicrosoftNETFrameworkReferenceAssembliesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.HashCodeCombiner.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimePackageVersion)" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,7 +5,7 @@
     <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
 
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
+    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net472</StandardTestTfms>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,7 +20,7 @@
     <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' OR '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' OR '$(TargetFramework)' == 'net472'">
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
@@ -212,8 +212,10 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             var args = new ProjectLoadedEventArgs(
                 ProjectId.CreateNewId(),
                 projectInstance,
-                Enumerable.Empty<MSBuildDiagnostic>().ToImmutableArray(),
-                false);
+                diagnostics: Enumerable.Empty<MSBuildDiagnostic>().ToImmutableArray(),
+                isReload: false,
+                projectIdIsDefinedInSolution: false,
+                sourceFiles: Enumerable.Empty<string>().ToImmutableArray());
 
             // Act
             await msbuildProjectManager.ProjectLoadedAsync(args);

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test.csproj
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="$(MicrosoftNETFrameworkReferenceAssembliesPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TagHelperRefreshTriggerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TagHelperRefreshTriggerTest.cs
@@ -75,7 +75,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
                 .Callback<Project, OmniSharpProjectSnapshot>((_, __) => mre.Set());
             var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object);
-            var args = new ProjectLoadedEventArgs(null, Project1Instance, EmptyDiagnostics, isReload: false);
+            var args = new ProjectLoadedEventArgs(
+                null,
+                Project1Instance,
+                EmptyDiagnostics,
+                isReload: false,
+                projectIdIsDefinedInSolution: false,
+                sourceFiles: Enumerable.Empty<string>().ToImmutableArray());
 
             // Act
             refreshTrigger.ProjectLoaded(args);
@@ -103,7 +109,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                     mre.Set();
                 });
             var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object, enqueueDelay: 10);
-            var args = new ProjectLoadedEventArgs(null, Project1Instance, EmptyDiagnostics, isReload: false);
+            var args = new ProjectLoadedEventArgs(
+                null,
+                Project1Instance,
+                EmptyDiagnostics,
+                isReload: false,
+                projectIdIsDefinedInSolution: false,
+                sourceFiles: Enumerable.Empty<string>().ToImmutableArray());
 
             // Act
             refreshTrigger.ProjectLoaded(args);


### PR DESCRIPTION
- Had to update the omnisharp-roslyn submodule to be the latest release. The version we were previously compiling against was pinned against an older Roslyn and would result in runtime typeload/methodmissing errors.
- Moved the O# plugn and the corresponding bits that interact with it to net472
- Updated Razor dependencies to latest preview9 bits.

aspnet/AspNetCore#12701