### PR TITLE
Depend on OmniSHarp.MSBuild package.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "modules/omnisharp-roslyn"]
-	path = modules/omnisharp-roslyn
-	url = https://github.com/omnisharp/omnisharp-roslyn.git

--- a/Razor.VSCode.sln
+++ b/Razor.VSCode.sln
@@ -13,25 +13,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{9AD3190E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.LanguageServer", "src\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj", "{AF5FB0D8-BACD-45DE-B4A2-4CA172DCAEB6}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "modules", "modules", "{BEAA2EDB-B257-4B34-9FA3-2AD973914528}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{75400311-9729-4D9A-80D2-ADD5286DE405}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.LanguageServer.Test", "test\Microsoft.AspNetCore.Razor.LanguageServer.Test\Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj", "{367BD0CB-B226-4105-B741-77A225722078}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.VSCode", "src\Microsoft.AspNetCore.Razor.VSCode\Microsoft.AspNetCore.Razor.VSCode.csproj", "{F8485BC8-E9B6-48BA-8F85-42CED28D51D7}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "omnisharp-roslyn", "omnisharp-roslyn", "{56E75AE4-00F1-4D2F-AA29-B03CF8DF34E1}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{05FA40C7-7899-4050-B9CC-9B9A20852C31}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.MSBuild", "modules\omnisharp-roslyn\src\OmniSharp.MSBuild\OmniSharp.MSBuild.csproj", "{E3705276-7ACE-446A-81AA-11B8F15C7D96}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Abstractions", "modules\omnisharp-roslyn\src\OmniSharp.Abstractions\OmniSharp.Abstractions.csproj", "{641D2B52-E6F0-468C-8E71-E1222AD69D09}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Roslyn.CSharp", "modules\omnisharp-roslyn\src\OmniSharp.Roslyn.CSharp\OmniSharp.Roslyn.CSharp.csproj", "{2B1F1C70-965D-4469-A55C-5868E3740860}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Roslyn", "modules\omnisharp-roslyn\src\OmniSharp.Roslyn\OmniSharp.Roslyn.csproj", "{6D2F83F2-9E51-4143-8964-2D3E1D9B46A1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.OmniSharpPlugin", "src\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj", "{01150B4B-2CB3-44BF-AFFB-6686D5AF9DF3}"
 EndProject
@@ -46,8 +32,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.Test.Common", "test\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj", "{C81B10BB-4272-49E8-BDF6-CB5615BC601D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed", "src\Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed\Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed.csproj", "{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Shared", "modules\omnisharp-roslyn\src\OmniSharp.Shared\OmniSharp.Shared.csproj", "{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -67,22 +51,6 @@ Global
 		{F8485BC8-E9B6-48BA-8F85-42CED28D51D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8485BC8-E9B6-48BA-8F85-42CED28D51D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8485BC8-E9B6-48BA-8F85-42CED28D51D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E3705276-7ACE-446A-81AA-11B8F15C7D96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E3705276-7ACE-446A-81AA-11B8F15C7D96}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E3705276-7ACE-446A-81AA-11B8F15C7D96}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E3705276-7ACE-446A-81AA-11B8F15C7D96}.Release|Any CPU.Build.0 = Release|Any CPU
-		{641D2B52-E6F0-468C-8E71-E1222AD69D09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{641D2B52-E6F0-468C-8E71-E1222AD69D09}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{641D2B52-E6F0-468C-8E71-E1222AD69D09}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{641D2B52-E6F0-468C-8E71-E1222AD69D09}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2B1F1C70-965D-4469-A55C-5868E3740860}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2B1F1C70-965D-4469-A55C-5868E3740860}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2B1F1C70-965D-4469-A55C-5868E3740860}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2B1F1C70-965D-4469-A55C-5868E3740860}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6D2F83F2-9E51-4143-8964-2D3E1D9B46A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6D2F83F2-9E51-4143-8964-2D3E1D9B46A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6D2F83F2-9E51-4143-8964-2D3E1D9B46A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6D2F83F2-9E51-4143-8964-2D3E1D9B46A1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{01150B4B-2CB3-44BF-AFFB-6686D5AF9DF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{01150B4B-2CB3-44BF-AFFB-6686D5AF9DF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01150B4B-2CB3-44BF-AFFB-6686D5AF9DF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -111,10 +79,6 @@ Global
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -123,12 +87,6 @@ Global
 		{AF5FB0D8-BACD-45DE-B4A2-4CA172DCAEB6} = {2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}
 		{367BD0CB-B226-4105-B741-77A225722078} = {75400311-9729-4D9A-80D2-ADD5286DE405}
 		{F8485BC8-E9B6-48BA-8F85-42CED28D51D7} = {2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}
-		{56E75AE4-00F1-4D2F-AA29-B03CF8DF34E1} = {BEAA2EDB-B257-4B34-9FA3-2AD973914528}
-		{05FA40C7-7899-4050-B9CC-9B9A20852C31} = {56E75AE4-00F1-4D2F-AA29-B03CF8DF34E1}
-		{E3705276-7ACE-446A-81AA-11B8F15C7D96} = {05FA40C7-7899-4050-B9CC-9B9A20852C31}
-		{641D2B52-E6F0-468C-8E71-E1222AD69D09} = {05FA40C7-7899-4050-B9CC-9B9A20852C31}
-		{2B1F1C70-965D-4469-A55C-5868E3740860} = {05FA40C7-7899-4050-B9CC-9B9A20852C31}
-		{6D2F83F2-9E51-4143-8964-2D3E1D9B46A1} = {05FA40C7-7899-4050-B9CC-9B9A20852C31}
 		{01150B4B-2CB3-44BF-AFFB-6686D5AF9DF3} = {2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}
 		{35E074E5-D87F-43D8-9CAE-4F15536CED9C} = {75400311-9729-4D9A-80D2-ADD5286DE405}
 		{32E6733E-B8C0-4D60-9C90-890C52425726} = {2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}
@@ -136,7 +94,6 @@ Global
 		{68200076-1756-4E72-AD93-FD412D23086F} = {75400311-9729-4D9A-80D2-ADD5286DE405}
 		{C81B10BB-4272-49E8-BDF6-CB5615BC601D} = {75400311-9729-4D9A-80D2-ADD5286DE405}
 		{5E301FB7-D52E-412A-8EBE-B4B3FAFFBA09} = {2BBB2AB1-2AE4-4306-AA88-FD66A90AA101}
-		{4B3BEFE6-3D93-49B0-BA8C-87F81313FF69} = {05FA40C7-7899-4050-B9CC-9B9A20852C31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ED1782EB-ABE7-4615-80E2-442006DF2826}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,5 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
-    <HumanizerPackageVersion>2.2.0</HumanizerPackageVersion>
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview8.19373.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>3.0.0-preview9.19415.11</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
@@ -25,6 +24,7 @@
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <OmniSharpExtensionsLanguageServerPackageVersion>0.10.0</OmniSharpExtensionsLanguageServerPackageVersion>
+    <OmniSharpMSBuildPackageVersion>1.33.0</OmniSharpMSBuildPackageVersion>
     <SystemRuntimePackageVersion>4.3.0</SystemRuntimePackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>

--- a/modules/Directory.Build.props
+++ b/modules/Directory.Build.props
@@ -1,2 +1,0 @@
-<Project>
-</Project>

--- a/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
+++ b/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
@@ -13,17 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\modules\omnisharp-roslyn\src\OmniSharp.MSBuild\OmniSharp.MSBuild.csproj" ExcludeAssets="Runtime" Private="True" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed\Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- 
-      This is here to workaround a Roslyn bug
-      https://github.com/OmniSharp/omnisharp-roslyn/commit/18cf2e415eb050de4e2e8a3520a25adbfc20aafa
-    -->
-    <PackageReference Include="Humanizer" Version="$(HumanizerPackageVersion)" />
-    
+    <PackageReference Include="OmniSharp.MSBuild" Version="$(OmniSharpMSBuildPackageVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="$(MicrosoftNETFrameworkReferenceAssembliesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.HashCodeCombiner.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />

--- a/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test.csproj
+++ b/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\modules\omnisharp-roslyn\src\OmniSharp.MSBuild\OmniSharp.MSBuild.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- As part of this can also remove the Roslyn package hack we added.
 - Removed OmniSharp-Roslyn submodule.

https://github.com/aspnet/Razor.VSCode/issues/379