### PR TITLE
Update vside NuGet feed to be the blob feed.

### DIFF
--- a/build/sources.props
+++ b/build/sources.props
@@ -11,7 +11,7 @@
       https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-      https://vside.myget.org/F/vssdk/api/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
       https://www.myget.org/F/omnisharp/api/v3/index.json;
       https://www.myget.org/F/vs-editor/api/v3/index.json;
     </RestoreSources>


### PR DESCRIPTION
- The old myget variant was discontinued.